### PR TITLE
feat: guild join/leave from guild posts view

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -51,12 +51,12 @@ Guilds are member groups with their own forum of threads. A user can belong to o
 | Endpoint | Method | Description | Status |
 |---|---|---|---|
 | `/v1/guilds` | GET | List guilds (paginated, most-populated first) | **Done** — feature 29 |
-| `/v1/guilds/:slug` | GET | Get guild detail + caller's `isMember` / `role` | Not called — server `isMember` bug; membership delegated to server on post |
+| `/v1/guilds/:slug` | GET | Get guild detail + caller's `isMember` / `role` | **Done** — fetched alongside thread list; used for membership hint bar |
 | `/v1/guilds/:slug/members` | GET | List guild members (paginated, oldest-joined first) | **Done** — feature 29 |
 | `/v1/guilds/:slug/posts` | GET | List guild threads (most recently active first) | **Done** — feature 29 |
 | `/v1/guilds/:slug/posts` | POST | Create guild thread (title + topics supported) | **Done** — feature 29 |
-| `/v1/guilds/:slug/join` | POST | Join a guild (one per user; 409 if already in one) | Deferred — newly documented as an official API endpoint in v0.4.1 (was previously considered web-only). Implementation not yet planned. |
-| `/v1/guilds/:slug/leave` | POST | Leave a guild (founders blocked via API; 403) | Deferred — newly documented as an official API endpoint in v0.4.1. Implementation not yet planned. |
+| `/v1/guilds/:slug/join` | POST | Join a guild (one per user; 409 if already in one) | **Done** — `J` key in guild threads view |
+| `/v1/guilds/:slug/leave` | POST | Leave a guild (founders blocked via API; 403) | **Done** — `l` key in guild threads view; founders see no action key |
 
 Notes:
 - Guild threads are ordinary posts with `guildId`, `guildSlug`, `isGuildThread: true`; replying uses `POST /v1/replies` as normal.
@@ -70,8 +70,8 @@ Notes:
 | Area | Description | Priority |
 |---|---|---|
 | `profilePictureUrl` on Guild / GuildMember | v0.4.1 adds this field to the guild list response and the member list response. Not in model types or wire layer. Low value for a TUI but keeps model in sync. | Low |
-| Guild join (`POST /v1/guilds/:slug/join`) | Now an official API endpoint. One guild per user; 409 if already in one. | Deferred |
-| Guild leave (`POST /v1/guilds/:slug/leave`) | Now an official API endpoint. Founders get 403 — must use web. | Deferred |
+| Guild join (`POST /v1/guilds/:slug/join`) | Now an official API endpoint. One guild per user; 409 if already in one. | **Done** |
+| Guild leave (`POST /v1/guilds/:slug/leave`) | Now an official API endpoint. Founders get 403 — must use web. | **Done** |
 
 ### Notifications (new in v0.4.1)
 
@@ -132,4 +132,7 @@ Notes:
 | `PATCH /v1/notes/:id` | Server-side 500 bug resolved in API v0.4. Note editing and revision history fully operational. | 2026-05-29 |
 | `POST /v1/posts` (extended) | `CreatePost` now accepts `title`, `isPublic`, `isNSFW`. `Post` model gained `Title`, `Slug`, `GuildID`, `GuildSlug`, `IsGuildThread`. Title rendered in feed/detail/profile/bookmarks. Feature 28. | 2026-05-29 |
 | `GET /v1/guilds/:slug/members` | Guild member list — paginated, oldest-joined first; `m` from guild posts view; `enter` navigates to profile. Feature 29. | 2026-05-30 |
+| `GET /v1/guilds/:slug` (join/leave flow) | Guild detail (`isMember`, `role`) fetched alongside thread list. `J` to join, `l` to leave with y/n confirmation and membership hint bar. Feature 29. | 2026-06-01 |
+| `POST /v1/guilds/:slug/join` | Join guild — `J` key in guild thread feed with confirmation prompt; success banner "✓ Joined #name". Feature 29. | 2026-06-01 |
+| `POST /v1/guilds/:slug/leave` | Leave guild — `l` key in guild thread feed with confirmation prompt; success banner "✓ Left #name"; navigates back to guild list. Feature 29. | 2026-06-01 |
 | Attachments (image/audio) | Attachment URLs surfaced via `GetFocusedURLs` and opened with `o`. Best-effort handling for a TUI — no further work needed. | 2026-05-30 |

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -483,11 +483,12 @@ Browse the guild directory, drill into threads, and view guild members.
 - Three-mode screen: guild list → guild thread feed → member list
 - Guild list sorted by member count, cursor-paginated; `enter` opens the thread feed
 - Thread feed is a standard paginated post list; `m` opens the member list, `esc` returns to the guild list
+- Thread feed shows a membership hint bar (`J` to join, `l` to leave) with y/n confirmation; `GetGuild` is fetched alongside the thread list to populate membership state
 - Member list is cursor-paginated oldest-joined first; `enter` navigates to the member's profile, `esc` returns to the thread feed
 
-Key types: `GuildsModel`, `LoadMoreGuildsMsg`, `LoadGuildPostsMsg`, `LoadMoreGuildPostsMsg`, `LoadGuildMembersMsg`, `LoadMoreGuildMembersMsg`  
-Key methods: `SetGuilds`, `AppendGuilds`, `SetGuildPosts`, `AppendGuildPosts`, `SetGuildMembers`, `AppendGuildMembers`  
-Key accessors: `IsBrowsingGuild()`, `IsBrowsingMembers()`
+Key types: `GuildsModel`, `LoadMoreGuildsMsg`, `LoadGuildPostsMsg`, `LoadMoreGuildPostsMsg`, `LoadGuildMembersMsg`, `LoadMoreGuildMembersMsg`, `JoinGuildMsg`, `LeaveGuildMsg`  
+Key methods: `SetGuilds`, `AppendGuilds`, `SetGuildPosts`, `AppendGuildPosts`, `SetGuildMembers`, `AppendGuildMembers`, `SetGuildDetail`, `BackToGuildList`  
+Key accessors: `IsBrowsingGuild()`, `IsBrowsingMembers()`, `IsDetailLoaded()`, `GuildDetail()`, `IsConfirmingJoin()`, `IsConfirmingLeave()`
 
 #### `topics.go`
 

--- a/docs/29-guilds.md
+++ b/docs/29-guilds.md
@@ -4,7 +4,7 @@
 
 Guilds are member communities on cyberspace.online, each with their own thread forum. The guilds screen lets users browse the guild directory, read guild threads, and view the member list.
 
-A user can belong to one guild at a time. Joining and leaving guilds is done on the web; the TUI is read-only for guild membership.
+A user can belong to one guild at a time. Joining and leaving guilds can be done from the guild threads view using `J` and `l`.
 
 ## Menu placement
 
@@ -44,7 +44,15 @@ Navigation:
 - `enter` — open thread in PostDetail; ESC from PostDetail returns here
 - `m` — open the member list for this guild
 - `n` — open compose panel
-- `esc` — cancel compose if open, otherwise return to the guild list
+- `J` (shift+j) — join this guild (available when not a member)
+- `L` (shift+l) — leave this guild (available when a member; blocked for founders)
+- `esc` — cancel compose or confirm prompt if open, otherwise return to the guild list
+
+The status bar shows contextual hints: `J join` when the user is not a member (once detail loads), `l leave` when a member and not the founder. Pressing `J` or `l` opens a confirmation prompt at the bottom of the screen. Confirm with `y` or cancel with `n` / `esc`.
+
+**API constraints:**
+- A user can only be in one guild at a time. Attempting to join while already a member of another guild returns a 409 error from the server.
+- Founders cannot leave via the API (403). The `l` key is hidden for founders.
 
 ### Guild members (members view)
 
@@ -76,20 +84,22 @@ After a successful post the thread list reloads.
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | `/v1/guilds?limit=20&cursor=<id>` | Paginated guild list |
+| GET | `/v1/guilds/:slug` | Guild detail including `isMember` and `role` |
 | GET | `/v1/guilds/:slug/posts?limit=20&cursor=<id>` | Paginated thread list for a guild |
 | GET | `/v1/guilds/:slug/members?limit=20&cursor=<membershipId>` | Paginated member list for a guild |
 | POST | `/v1/guilds/:slug/posts` | Create a guild thread (server enforces membership) |
+| POST | `/v1/guilds/:slug/join` | Join this guild |
+| POST | `/v1/guilds/:slug/leave` | Leave this guild (founders get 403) |
 
 ## Implementation
 
 - `internal/model/types.go` — `Guild` struct (includes `IsMember`, `Role`); `GuildMember` struct
-- `internal/api/interface.go` — `GetGuilds`, `GetGuild`, `GetGuildPosts`, `CreateGuildPost`, `GetGuildMembers`
+- `internal/api/interface.go` — `GetGuilds`, `GetGuild`, `GetGuildPosts`, `CreateGuildPost`, `GetGuildMembers`, `JoinGuild`, `LeaveGuild`
 - `internal/api/client.go` — wire types and HTTP implementations
 - `internal/ui/screens/guilds.go` — `GuildsModel` (three-view screen + embedded `PostComposePanel`)
 - `internal/ui/app.go` — `screenGuilds` enum, `handleGuilds`, load/create commands, menu wiring
 
 ## Known limitations / out of scope
 
-- Join and leave guild (`POST /v1/guilds/:slug/join`, `/leave`) are not implemented; use the web interface
 - Public/NSFW toggles are shown in the compose panel but have no effect on guild posts
 - The API may not surface title or topics in the thread list on the website

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1143,6 +1143,16 @@ func (c *HTTPClient) GetGuildMembers(slug, cursor string) ([]model.GuildMember, 
 	return fetchPage(c, path, wireGuildMemberToModel)
 }
 
+func (c *HTTPClient) JoinGuild(slug string) error {
+	_, err := c.doRequest("POST", "/v1/guilds/"+url.PathEscape(slug)+"/join", nil)
+	return err
+}
+
+func (c *HTTPClient) LeaveGuild(slug string) error {
+	_, err := c.doRequest("POST", "/v1/guilds/"+url.PathEscape(slug)+"/leave", nil)
+	return err
+}
+
 func (c *HTTPClient) CreateGuildPost(slug, content, title string, topics []string) (model.Post, error) {
 	if topics == nil {
 		topics = []string{}

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -97,6 +97,12 @@ type Client interface {
 	// GetGuildMembers returns paginated members for a guild, oldest-joined first.
 	// Pass empty cursor for first page; use returned cursor for next page.
 	GetGuildMembers(slug, cursor string) ([]model.GuildMember, string, error)
+	// JoinGuild joins the guild identified by slug. Returns an error if the user is
+	// already a member of another guild (409) or if the slug does not exist (404).
+	JoinGuild(slug string) error
+	// LeaveGuild leaves the guild identified by slug. Returns an error if the user
+	// is the founder (403) or is not a member.
+	LeaveGuild(slug string) error
 
 	// Posts — deletion.
 	// DeletePost soft-deletes a post owned by the authenticated user.

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -322,6 +322,9 @@ func (m *MockClient) GetGuildMembers(slug, cursor string) ([]model.GuildMember, 
 	return nil, "", nil
 }
 
+func (m *MockClient) JoinGuild(slug string) error  { return nil }
+func (m *MockClient) LeaveGuild(slug string) error { return nil }
+
 func (m *MockClient) GetNotifications(cursor string, unreadOnly bool) ([]model.Notification, string, error) {
 	if !unreadOnly {
 		return mockNotifications, "", nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1016,7 +1016,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, nil, true
 
 	case screens.LoadGuildPostsMsg:
-		return a, a.loadGuildPostsCmd(msg.Slug), true
+		return a, tea.Batch(a.loadGuildPostsCmd(msg.Slug), a.loadGuildDetailCmd(msg.Slug)), true
 
 	case guildPostsLoadedMsg:
 		if msg.slug != a.guilds.ActiveGuild() {
@@ -1067,6 +1067,33 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 	case guildMembersPageMsg:
 		a.guilds = a.guilds.AppendGuildMembers(msg.members, msg.cursor)
 		return a, nil, true
+
+	case guildDetailLoadedMsg:
+		a.guilds = a.guilds.SetGuildDetail(msg.guild)
+		return a, nil, true
+
+	case screens.JoinGuildMsg:
+		return a, a.joinGuildCmd(msg.Slug, a.guilds.GuildDetail().Name), true
+
+	case screens.LeaveGuildMsg:
+		return a, a.leaveGuildCmd(msg.Slug, a.guilds.GuildDetail().Name), true
+
+	case guildJoinedMsg:
+		detail := a.guilds.GuildDetail()
+		detail.IsMember = true
+		detail.Role = "member"
+		a.guilds = a.guilds.SetGuildDetail(detail)
+		a.currentUser.GuildSlug = msg.slug
+		var notifyCmd tea.Cmd
+		a, notifyCmd = a.notify(notifyInfo, "✓ Joined #"+msg.name)
+		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
+
+	case guildLeftMsg:
+		a.guilds = a.guilds.BackToGuildList()
+		a.currentUser.GuildSlug = ""
+		var notifyCmd tea.Cmd
+		a, notifyCmd = a.notify(notifyInfo, "✓ Left #"+msg.name)
+		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
 	}
 	return a, nil, false
 }
@@ -1454,7 +1481,17 @@ func (a App) screenHints() []hint {
 			return []hint{{"↑↓", "navigate"}, {"enter", "view profile"}, {"esc", "back"}, more}
 		}
 		if a.guilds.IsBrowsingGuild() {
-			return []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"m", "members"}, {"n", "new thread"}, {"esc", "back"}, more}
+			if a.guilds.IsConfirmingJoin() || a.guilds.IsConfirmingLeave() {
+				return []hint{{"y", "confirm"}, {"n/esc", "cancel"}}
+			}
+			hints := []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"m", "members"}, {"n", "new thread"}, {"esc", "back"}}
+			d := a.guilds.GuildDetail()
+			if a.guilds.IsDetailLoaded() && !d.IsMember && a.currentUser.GuildSlug == "" {
+				hints = append(hints, hint{"J", "join"})
+			} else if a.guilds.IsDetailLoaded() && d.IsMember && d.Role != "founder" {
+				hints = append(hints, hint{"L", "leave"})
+			}
+			return append(hints, more)
 		}
 		return []hint{{"↑↓", "navigate"}, {"enter", "browse"}, more}
 	case screenTopics:
@@ -2252,6 +2289,9 @@ type guildMembersPageMsg struct {
 	members []model.GuildMember
 	cursor  string
 }
+type guildDetailLoadedMsg struct{ guild model.Guild }
+type guildJoinedMsg       struct{ slug, name string }
+type guildLeftMsg         struct{ slug, name string }
 
 type notifsLoadedMsg struct {
 	notifs []model.Notification
@@ -2802,6 +2842,34 @@ func (a *App) createGuildPostCmd(slug, content, title string, topics []string) t
 			return actionErrMsg{err}
 		}
 		return guildPostCreatedMsg{slug: slug}
+	}
+}
+
+func (a *App) loadGuildDetailCmd(slug string) tea.Cmd {
+	return func() tea.Msg {
+		g, err := a.client.GetGuild(slug)
+		if err != nil {
+			return actionErrMsg{err}
+		}
+		return guildDetailLoadedMsg{guild: g}
+	}
+}
+
+func (a *App) joinGuildCmd(slug, name string) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.client.JoinGuild(slug); err != nil {
+			return actionErrMsg{err}
+		}
+		return guildJoinedMsg{slug: slug, name: name}
+	}
+}
+
+func (a *App) leaveGuildCmd(slug, name string) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.client.LeaveGuild(slug); err != nil {
+			return actionErrMsg{err}
+		}
+		return guildLeftMsg{slug: slug, name: name}
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -340,7 +340,7 @@ func (a App) updateAll(msg tea.Msg) App {
 // Call this whenever loc, relaxed, or dimensions change outside of a
 // WindowSizeMsg (e.g. after login, timezone change, or density toggle).
 func (a *App) broadcastConfig() {
-	msg := screens.SharedConfigMsg{Width: a.width, Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone}
+	msg := screens.SharedConfigMsg{Width: a.width, Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, OwnGuildSlug: a.currentUser.GuildSlug}
 	*a = a.updateAll(msg)
 }
 
@@ -1084,6 +1084,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		detail.Role = "member"
 		a.guilds = a.guilds.SetGuildDetail(detail)
 		a.currentUser.GuildSlug = msg.slug
+		a.guilds = a.guilds.SetOwnGuildSlug(msg.slug)
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "✓ Joined #"+msg.name)
 		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
@@ -1091,6 +1092,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 	case guildLeftMsg:
 		a.guilds = a.guilds.BackToGuildList()
 		a.currentUser.GuildSlug = ""
+		a.guilds = a.guilds.SetOwnGuildSlug("")
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "✓ Left #"+msg.name)
 		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -45,6 +45,21 @@ type LoadMoreGuildMembersMsg struct {
 	Cursor string
 }
 
+// JoinGuildMsg is emitted when the user confirms joining the active guild.
+type JoinGuildMsg struct{ Slug string }
+
+// LeaveGuildMsg is emitted when the user confirms leaving the active guild.
+type LeaveGuildMsg struct{ Slug string }
+
+// guildsConfirm tracks whether a join/leave confirmation prompt is active.
+type guildsConfirm int
+
+const (
+	confirmNoneG  guildsConfirm = iota
+	confirmJoinG
+	confirmLeaveG
+)
+
 // Internal view state for the Guilds screen.
 type guildsView int
 
@@ -65,15 +80,18 @@ type GuildsModel struct {
 	guildsExhausted  bool
 
 	// Guild posts state
-	activeGuild string
-	posts       []model.Post
-	postIndex   int
-	nextCursor  string
-	exhausted   bool
-	loading     bool
-	fetching    bool
-	refreshing  bool
-	loaded      bool
+	activeGuild       string
+	activeGuildDetail model.Guild
+	guildDetailLoaded bool
+	confirming        guildsConfirm
+	posts             []model.Post
+	postIndex         int
+	nextCursor        string
+	exhausted         bool
+	loading           bool
+	fetching          bool
+	refreshing        bool
+	loaded            bool
 
 	// Guild members state
 	members           []model.GuildMember
@@ -234,6 +252,29 @@ func (m GuildsModel) AppendGuildMembers(members []model.GuildMember, cursor stri
 	return m
 }
 
+// SetGuildDetail stores the guild detail (including IsMember and Role) fetched from
+// the single-guild endpoint and marks the detail as loaded.
+func (m GuildsModel) SetGuildDetail(g model.Guild) GuildsModel {
+	m.activeGuildDetail = g
+	m.guildDetailLoaded = true
+	if m.ready {
+		m = m.refreshContent()
+	}
+	return m
+}
+
+// GuildDetail returns the most recently fetched guild detail.
+func (m GuildsModel) GuildDetail() model.Guild { return m.activeGuildDetail }
+
+// IsDetailLoaded reports whether guild detail has been fetched for the active guild.
+func (m GuildsModel) IsDetailLoaded() bool { return m.guildDetailLoaded }
+
+// IsConfirmingJoin reports whether the join confirmation prompt is active.
+func (m GuildsModel) IsConfirmingJoin() bool { return m.confirming == confirmJoinG }
+
+// IsConfirmingLeave reports whether the leave confirmation prompt is active.
+func (m GuildsModel) IsConfirmingLeave() bool { return m.confirming == confirmLeaveG }
+
 // SetError stores an error and clears the loading state.
 func (m GuildsModel) SetError(err error) GuildsModel {
 	m.err = err
@@ -311,6 +352,10 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 			var cmd tea.Cmd
 			m.panel, cmd = m.panel.Update(msg)
 			return m, cmd
+		}
+		// Route to confirm handler when a join/leave prompt is active.
+		if m.confirming != confirmNoneG {
+			return m.handleConfirmKey(msg)
 		}
 		switch msg.String() {
 		case "up", "k":
@@ -409,6 +454,20 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 			}
 			return m, nil
 
+		case "J":
+			if m.view == viewGuildPosts && m.guildDetailLoaded && !m.activeGuildDetail.IsMember {
+				m.confirming = confirmJoinG
+				m = m.refreshContent()
+			}
+			return m, nil
+
+		case "L":
+			if m.view == viewGuildPosts && m.guildDetailLoaded && m.activeGuildDetail.IsMember && m.activeGuildDetail.Role != "founder" {
+				m.confirming = confirmLeaveG
+				m = m.refreshContent()
+			}
+			return m, nil
+
 		case "n":
 			if m.view == viewGuildPosts {
 				var cmd tea.Cmd
@@ -429,6 +488,9 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 			if m.view == viewGuildPosts {
 				m.view = viewGuildList
 				m.activeGuild = ""
+				m.activeGuildDetail = model.Guild{}
+				m.guildDetailLoaded = false
+				m.confirming = confirmNoneG
 				m.loading = false
 				m.fetching = false
 				m.panel = m.panel.Close()
@@ -479,7 +541,67 @@ func (m GuildsModel) View() string {
 			m.panel.View(),
 		)
 	}
+	if m.confirming != confirmNoneG {
+		return lipgloss.JoinVertical(lipgloss.Left,
+			m.viewport.View(),
+			m.renderConfirmBar(),
+		)
+	}
 	return m.viewport.View()
+}
+
+// BackToGuildList resets state and returns to the guild list view. Used by app.go
+// after a successful leave so the screen navigates back without a keypress.
+func (m GuildsModel) BackToGuildList() GuildsModel {
+	m.view = viewGuildList
+	m.activeGuild = ""
+	m.activeGuildDetail = model.Guild{}
+	m.guildDetailLoaded = false
+	m.confirming = confirmNoneG
+	m.loading = false
+	m.fetching = false
+	m.panel = m.panel.Close()
+	if m.ready {
+		m = m.refreshContent()
+		m.viewport.GotoTop()
+	}
+	return m
+}
+
+func (m GuildsModel) renderConfirmBar() string {
+	var content string
+	if m.confirming == confirmJoinG {
+		content = theme.Highlight.Render("Join "+m.activeGuildDetail.Name+"?") + "  " +
+			theme.Base.Render("[y]es") + "  " +
+			theme.Subtle.Render("[n]o / esc")
+	} else {
+		content = theme.Error.Render("Leave "+m.activeGuildDetail.Name+"?") + "  " +
+			theme.Base.Render("[y]es") + "  " +
+			theme.Subtle.Render("[n]o / esc")
+	}
+	style := theme.ActiveBorder
+	if m.width > 2 {
+		style = style.Width(m.width - 2)
+	}
+	return style.Render(content)
+}
+
+func (m GuildsModel) handleConfirmKey(msg tea.KeyMsg) (GuildsModel, tea.Cmd) {
+	switch msg.String() {
+	case "y":
+		kind := m.confirming
+		m.confirming = confirmNoneG
+		m = m.refreshContent()
+		slug := m.activeGuild
+		if kind == confirmJoinG {
+			return m, func() tea.Msg { return JoinGuildMsg{Slug: slug} }
+		}
+		return m, func() tea.Msg { return LeaveGuildMsg{Slug: slug} }
+	case "n", "esc":
+		m.confirming = confirmNoneG
+		m = m.refreshContent()
+	}
+	return m, nil
 }
 
 func (m GuildsModel) buildContent() (string, []int) {
@@ -727,6 +849,8 @@ func (m GuildsModel) viewportHeight() int {
 	h := m.height - theme.ChromeHeight
 	if m.panel.IsActive() {
 		h -= m.panel.PanelHeight()
+	} else if m.confirming != confirmNoneG {
+		h -= 3 // confirm prompt: border-top + content + border-bottom
 	}
 	if h < 1 {
 		h = 1

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -84,6 +84,7 @@ type GuildsModel struct {
 	activeGuildDetail model.Guild
 	guildDetailLoaded bool
 	confirming        guildsConfirm
+	ownGuildSlug      string // logged-in user's current guild membership (empty = no guild)
 	posts             []model.Post
 	postIndex         int
 	nextCursor        string
@@ -269,6 +270,14 @@ func (m GuildsModel) GuildDetail() model.Guild { return m.activeGuildDetail }
 // IsDetailLoaded reports whether guild detail has been fetched for the active guild.
 func (m GuildsModel) IsDetailLoaded() bool { return m.guildDetailLoaded }
 
+// SetOwnGuildSlug updates the logged-in user's guild membership slug. Called by
+// app.go after a successful join or leave so the J key guard stays current without
+// requiring a full SharedConfigMsg broadcast.
+func (m GuildsModel) SetOwnGuildSlug(slug string) GuildsModel {
+	m.ownGuildSlug = slug
+	return m
+}
+
 // IsConfirmingJoin reports whether the join confirmation prompt is active.
 func (m GuildsModel) IsConfirmingJoin() bool { return m.confirming == confirmJoinG }
 
@@ -300,6 +309,7 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 			m.filterNSFW = msg.Settings.FilterNSFW
 			m.postIndex = 0
 		}
+		m.ownGuildSlug = msg.OwnGuildSlug
 		if m.ready {
 			m = m.refreshContent()
 		}
@@ -455,7 +465,7 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 			return m, nil
 
 		case "J":
-			if m.view == viewGuildPosts && m.guildDetailLoaded && !m.activeGuildDetail.IsMember {
+			if m.view == viewGuildPosts && m.guildDetailLoaded && !m.activeGuildDetail.IsMember && m.ownGuildSlug == "" {
 				m.confirming = confirmJoinG
 				m = m.refreshContent()
 			}

--- a/internal/ui/screens/guilds_test.go
+++ b/internal/ui/screens/guilds_test.go
@@ -432,3 +432,171 @@ func TestGuildsModel_FilterNSFW_Off_ShowsAll(t *testing.T) {
 		t.Errorf("expected g2 (nsfw), got %s", sp.Post.ID)
 	}
 }
+
+// --- Guild join / leave ---
+
+func inPostsView(t *testing.T) screens.GuildsModel {
+	t.Helper()
+	m := screens.NewGuildsModel()
+	m = m.SetGuilds(sampleGuilds(), "")
+	m, _ = m.Update(specialKey(tea.KeyEnter))
+	m = m.SetGuildPosts(sampleGuildPosts(), "")
+	return m
+}
+
+func TestGuildsModel_SetGuildDetail_StoresDetailAndMarksLoaded(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	if m.IsDetailLoaded() {
+		t.Error("detail should not be loaded before SetGuildDetail")
+	}
+	m = m.SetGuildDetail(model.Guild{ID: "g1", Name: "Alpha", Slug: "alpha", IsMember: false})
+	if !m.IsDetailLoaded() {
+		t.Error("IsDetailLoaded should return true after SetGuildDetail")
+	}
+	if m.GuildDetail().Name != "Alpha" {
+		t.Errorf("expected Name 'Alpha', got %q", m.GuildDetail().Name)
+	}
+}
+
+func TestGuildsModel_JKey_WhenNotMember_SetsConfirmJoin(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: false})
+	m, _ = m.Update(keyMsg_g("J"))
+	if !m.IsConfirmingJoin() {
+		t.Error("J key when not a member should set confirming to join")
+	}
+}
+
+func TestGuildsModel_JKey_WhenAlreadyMember_DoesNothing(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: true, Role: "member"})
+	m, _ = m.Update(keyMsg_g("J"))
+	if m.IsConfirmingJoin() {
+		t.Error("J key when already a member should not set confirming")
+	}
+}
+
+func TestGuildsModel_JKey_WhenDetailNotLoaded_DoesNothing(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	// detail not loaded
+	m, _ = m.Update(keyMsg_g("J"))
+	if m.IsConfirmingJoin() {
+		t.Error("J key when detail not loaded should not set confirming")
+	}
+}
+
+func TestGuildsModel_LKey_WhenMember_SetsConfirmLeave(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: true, Role: "member"})
+	m, _ = m.Update(keyMsg_g("L"))
+	if !m.IsConfirmingLeave() {
+		t.Error("l key when a member should set confirming to leave")
+	}
+}
+
+func TestGuildsModel_LKey_WhenFounder_DoesNothing(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: true, Role: "founder"})
+	m, _ = m.Update(keyMsg_g("L"))
+	if m.IsConfirmingLeave() {
+		t.Error("l key when founder should not set confirming")
+	}
+}
+
+func TestGuildsModel_ConfirmY_Join_EmitsJoinGuildMsg(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: false})
+	m, _ = m.Update(keyMsg_g("J"))
+	m2, cmd := m.Update(keyMsg_g("y"))
+	if cmd == nil {
+		t.Fatal("expected a cmd after y confirmation")
+	}
+	msg := cmd()
+	jm, ok := msg.(screens.JoinGuildMsg)
+	if !ok {
+		t.Fatalf("expected JoinGuildMsg, got %T", msg)
+	}
+	if jm.Slug != "alpha" {
+		t.Errorf("expected slug 'alpha', got %q", jm.Slug)
+	}
+	if m2.IsConfirmingJoin() {
+		t.Error("confirming should be cleared after y")
+	}
+}
+
+func TestGuildsModel_ConfirmY_Leave_EmitsLeaveGuildMsg(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: true, Role: "member"})
+	m, _ = m.Update(keyMsg_g("L"))
+	m2, cmd := m.Update(keyMsg_g("y"))
+	if cmd == nil {
+		t.Fatal("expected a cmd after y confirmation")
+	}
+	msg := cmd()
+	lm, ok := msg.(screens.LeaveGuildMsg)
+	if !ok {
+		t.Fatalf("expected LeaveGuildMsg, got %T", msg)
+	}
+	if lm.Slug != "alpha" {
+		t.Errorf("expected slug 'alpha', got %q", lm.Slug)
+	}
+	if m2.IsConfirmingLeave() {
+		t.Error("confirming should be cleared after y")
+	}
+}
+
+func TestGuildsModel_ConfirmN_ClearsConfirming(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: false})
+	m, _ = m.Update(keyMsg_g("J"))
+	m2, cmd := m.Update(keyMsg_g("n"))
+	if cmd != nil {
+		t.Error("n should not emit a cmd")
+	}
+	if m2.IsConfirmingJoin() {
+		t.Error("n should clear confirming")
+	}
+}
+
+func TestGuildsModel_ConfirmEsc_ClearsConfirming_StaysInPostsView(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: false})
+	m, _ = m.Update(keyMsg_g("J"))
+	m2, _ := m.Update(specialKey(tea.KeyEsc))
+	if m2.IsConfirmingJoin() {
+		t.Error("esc should clear confirming")
+	}
+	if !m2.IsBrowsingGuild() {
+		t.Error("esc while confirming should stay in posts view, not navigate back")
+	}
+}
+
+func TestGuildsModel_Esc_WithoutConfirm_NavigatesBack(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	// No confirming active — esc should navigate back to guild list
+	m2, _ := m.Update(specialKey(tea.KeyEsc))
+	if m2.IsBrowsingGuild() {
+		t.Error("esc without confirming should navigate back to guild list")
+	}
+}
+
+func TestGuildsModel_EscBack_ClearsDetailState(t *testing.T) {
+	t.Helper()
+	m := inPostsView(t)
+	m = m.SetGuildDetail(model.Guild{Slug: "alpha", Name: "Alpha", IsMember: true, Role: "member"})
+	m2, _ := m.Update(specialKey(tea.KeyEsc))
+	if m2.IsDetailLoaded() {
+		t.Error("navigating back should clear guildDetailLoaded")
+	}
+}

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -29,6 +29,7 @@ type SharedConfigMsg struct {
 	WanderLust     bool
 	MaxThreadDepth int
 	Timezone       string
+	OwnGuildSlug   string
 }
 
 // URLProvider is implemented by screens that can expose URLs from their


### PR DESCRIPTION
## Summary

- Adds `J` / `L` keybindings to join or leave a guild from the guild threads view
- Fetches guild detail (`GET /v1/guilds/:slug`) alongside posts on entry so `isMember` / `role` are available immediately
- Confirmation prompt appears inline at the bottom of the viewport; `y` confirms, `n`/`esc` cancels
- Status bar shows `J join` hint only when the user has no guild, `L leave` only when a member and not the founder
- `J` key is fully suppressed (no prompt, no hint) when the user already belongs to any guild
- `OwnGuildSlug` added to `SharedConfigMsg` so every screen broadcast keeps guilds in sync; dedicated `SetOwnGuildSlug` setter avoids partial-struct zeroing

## Test plan

- [ ] Browse a guild forum while not in any guild → `J join` hint visible in status bar
- [ ] Press `J` → confirm prompt appears; `n`/`esc` cancels; `y` joins, banner shows, hint switches to `L leave`
- [ ] Browse a different guild while already in a guild → no `J` hint, `J` key does nothing
- [ ] Press `L` in own guild → confirm prompt; `y` leaves, returns to list, `J join` re-appears on next forum visit
- [ ] As founder: no `L` hint, `L` key does nothing
- [ ] All unit tests pass, vet and staticcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)