### PR TITLE
fix: errors never block a screen; deleted-post & guild notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (e.g. v0.3.6.1)"
+        description: "Tag to release (e.g. v0.4.1.1)"
         required: true
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file defines workflow guardrails for Claude. It is not project documentatio
 - **Stack:** Go + Bubble Tea (TUI), Lip Gloss (styling), Wish (SSH hosting)
 - **Code map:** `docs/00-project-reference.md` — comprehensive architecture, package structure, and file listing; **read this first to understand the codebase before targeting specific files for changes**
 - **Project docs:** `docs/` folder — numbered per feature (e.g. `docs/01-auth.md`)
-- **API status:** v0.3.6 — docs at https://api.cyberspace.online/docs.md — **always fetch before any API work** to catch changes
+- **API status:** v0.4.1 — docs at https://api.cyberspace.online/docs.md — **always fetch before any API work** to catch changes
 - **API snapshot:** `docs/00-latest-api-reference.md` — current baseline we're building against (check for drift against live URL)
 - **Key API facts:** login uses email (not username) · chat/DMs use Firebase RTDB (SSE), not REST · cursor-based pagination
 - **API backlog:** `docs/00-api-backlog.md` — unimplemented features and known server-side bugs; update whenever issues are found or features land
@@ -55,11 +55,11 @@ This file defines workflow guardrails for Claude. It is not project documentatio
 - `dev` → `main` only when a full milestone is complete and user approves
 
 ### Releases — API-aligned versioning
-- Release tags mirror the cyberspace.online API version they target: `v0.3.6`, `v0.4.0`, etc.
-- Current target: **v0.3.6** (see `docs/00-latest-api-reference.md`)
+- Release tags mirror the cyberspace.online API version they target: `v0.4.0`, `v0.4.1`, etc.
+- Current target: **v0.4.1** (see `docs/00-latest-api-reference.md`)
 - When the API ships a new version, open a new milestone on `dev` targeting that version
 - When the milestone is complete and the user approves, merge `dev` → `main` and tag with the API version
-- Incremental TUI releases within an API version use a fourth segment: `v0.3.6.1`, `v0.3.6.2`, etc.
+- Incremental TUI releases within an API version use a fourth segment: `v0.4.1.1`, `v0.4.1.2`, etc.
 - A milestone is a named set of features forming a coherent releasable version; the user defines scope and approves each release
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Pre-built binaries for Linux (amd64/arm64) and Windows (amd64) are attached to e
 
 ## Versioning
 
-Release tags mirror the cyberspace.online API version they target (e.g. `v0.3.6`). Patch releases (`v0.3.7`) are used for TUI-only fixes between API updates. The current target API version is always recorded in `docs/00-latest-api-reference.md`.
+Release tags mirror the cyberspace.online API version they target (e.g. `v0.4.1`). Patch releases (`v0.4.2`) are used for TUI-only fixes between API updates. The current target API version is always recorded in `docs/00-latest-api-reference.md`.
 
 ## Questions
 

--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -12,6 +12,7 @@ These bugs exist in the server — no client-side fix is possible. Report to the
 | Endpoint | Method | Status | Description | Discovered |
 |---|---|---|---|---|
 | `/v1/follows` | GET | **Open** | Response does not include `followerUsername` or `followedUsername`. Confirmed still missing in v0.4 (re-tested 2026-05-29). The profile Following/Followers tabs fall back to showing a truncated user ID; profile navigation from those tabs is disabled until the API returns usernames. | 2026-04-17 |
+| `/v1/notifications` | GET | **Open (by design?)** | Notifications can point to posts that have since been deleted, and the notification object exposes no "target deleted/unavailable" flag — opening one is the only way to discover the target is gone (`GET /v1/posts/:id` → 404). The client now handles this gracefully (friendly "This post has been deleted" banner, non-blocking). A `targetDeleted` field (or server-side filtering of dead-target notifications) would let the client mark/skip them up front. | 2026-06-03 |
 | Rate limits (spec) | — | **Open** | Inline per-endpoint docs and the consolidated Rate Limits table still contradict each other in v0.4.1. Entries: 15/day inline vs 10/day in table. Replies: 15/day vs 10/day. Notes: 30/day vs 20/day. Bookmarks: 75/day vs 50/day. Profile updates: 15/day vs 10/day. Guild threads/join/leave are now consistent. Unknown which is authoritative — report to API maintainer. | 2026-05-29 |
 
 ---

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -317,10 +317,11 @@ Root Bubble Tea model. Acts as the message hub and screen lifecycle manager.
 - Surfaces transient errors via a **global notification banner** that replaces the status-bar row, colored by severity, and auto-dismisses after 4 s or on the next keypress (which still performs its normal action)
 - Runs background tick jobs: `schedulePollCmd` (60 s unread count), `scheduleWanderCmd` (1 h wander check)
 
-**Error handling — two paths:**
+**Error handling — errors never block a screen:**
 
-- **Load failures** (a fetch that populates a screen returns an error) wrap the error in `errMsg`; `handleErr` routes it to the active screen's `SetError`, which renders a full-screen message explaining the empty screen. Screen success setters (`SetGuilds`, `SetPosts`, `SetTopics`, …) clear `err` so a stale load error never persists.
-- **Action failures** (create/reply/delete/follow/save/submit) wrap the error in `actionErrMsg`; `handleNotify` shows it as the transient global banner without blanking the screen, so the tab stays usable. The banner is driven by `notifyText`/`notifyLevel`/`notifyGen` on `App`; `notifyExpireMsg` carries a generation id so a stale auto-dismiss tick cannot clear a newer notification. `notifyMsg` and the `notify(level, text)` helper allow surfacing info/warning messages directly.
+- **Load failures** (a fetch that populates a screen returns an error) wrap the error in `errMsg`; `handleErr` fires the transient global banner (text via `friendlyErr`) **and** sets the active screen's `err`. That `err` only feeds a subtle inline "couldn't load …" empty-state — no `View()` collapses to a full-screen error. Every screen clears `err` on the next fetch (`SetFetching`) and on each success setter, so a load error can never trap the user.
+- **Post-open from Notifications** uses `notifPostLoadErrMsg` instead of `errMsg`, so a deleted target (404) shows a friendly "This post has been deleted" banner; 401 still redirects to login. The notification payload has no deleted-target field, so the 404 on open is the only signal (API v0.4.1).
+- **Action failures** (create/reply/delete/follow/save/submit) wrap the error in `actionErrMsg`; `handleNotify` shows it as the transient global banner without blanking the screen, so the tab stays usable. The banner is driven by `notifyText`/`notifyLevel`/`notifyGen` on `App`; `notifyExpireMsg` carries a generation id so a stale auto-dismiss tick cannot clear a newer notification. `notifyMsg` and the `notify(level, text)` helper allow surfacing info/warning messages directly. See `docs/31-global-notifications.md`.
 
 #### `app_test.go`
 

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -8,7 +8,7 @@ Comprehensive map of every module, file, and artifact in this repository. Use th
 
 **cyber-tui** is a terminal user interface (TUI) client for [cyberspace.online](https://cyberspace.online) — a retro text-only social network. It is written in Go, using [Bubble Tea](https://github.com/charmbracelet/bubbletea) for the TUI event loop, [Lip Gloss](https://github.com/charmbracelet/lipgloss) for styling, and [Wish](https://github.com/charmbracelet/wish) to optionally host the client over SSH.
 
-The client talks to the cyberspace.online REST API (current target v0.3.6; see CLAUDE.md) and to Firebase Realtime Database (RTDB) for live direct messages. See `docs/00-latest-api-reference.md` for the current API spec snapshot.
+The client talks to the cyberspace.online REST API (current target v0.4.1; see CLAUDE.md) and to Firebase Realtime Database (RTDB) for live direct messages. See `docs/00-latest-api-reference.md` for the current API spec snapshot.
 
 ---
 

--- a/docs/15-notifications.md
+++ b/docs/15-notifications.md
@@ -97,8 +97,12 @@ Pressing `enter` on `poke` or `new_follower` notifications (or any with an empty
 | `reply` | replied to your post. |
 | `reply_mention` | mentioned you in a reply. |
 | `thread_reply` | replied in @username's thread. (falls back to "a thread you're following" if author unknown) |
-| `guild_new_thread` | posted a new thread in \<guildName\>. (falls back to "posted a new thread." if guild name absent) |
+| `guild_new_thread` | posted a new thread in #\<guildName\>. (falls back to "posted a new thread." if guild name absent) |
 | `poke` | poked you. ¯\_(ツ)_/¯ |
+
+### Guild context
+
+When a post or reply notification happens inside a guild, the summary appends an `in #<guildName>` clause — e.g. `replied to your post in #technica.` or `published something in #CHOOMS.` This applies to `new_post_friend`, `new_post_following`, `reply`, and `thread_reply` whenever the notification carries `metadata.guildName`; `guild_new_thread` always shows it. The guild name is rendered **verbatim** (guilds choose their own casing); the leading `#` marks it as a guild, matching the app's existing convention (join/leave banners, the `guild_new_thread` icon). `*_mention` types are excluded to avoid awkward phrasing. The handling lives in `notifSummary` / `withGuild` in `internal/ui/screens/notifications.go`.
 
 ---
 

--- a/docs/15-notifications.md
+++ b/docs/15-notifications.md
@@ -131,6 +131,10 @@ The notifications screen opens in unread-only mode by default. Press `u` to togg
 
 Pressing `enter` on a navigable notification opens PostDetail. Pressing `esc` in PostDetail returns to the notifications screen with the previously selected notification visible. This uses a shared `postDetailReturn` field in the App to track which screen to return to (same mechanism used by Feed → PostDetail → Feed).
 
+### Deleted-post notifications
+
+A notification can point to a post that has since been deleted; the notification list carries no "deleted target" field, so this only surfaces when the post is opened and `GET /v1/posts/:id` returns `404 NOT_FOUND`. Rather than blocking the screen, the post-open fetch returns `notifPostLoadErrMsg`; `handleNotifications` shows a transient banner **"This post has been deleted"** and leaves the notifications list intact and usable. (A 401 here still redirects to login; other errors show their message in the banner.) See [31-global-notifications.md](31-global-notifications.md) for the banner mechanism and the broader "errors never block a screen" model.
+
 ---
 
 ## API Endpoints

--- a/docs/31-global-notifications.md
+++ b/docs/31-global-notifications.md
@@ -1,8 +1,8 @@
 # 31 · Global Notifications
 
-A single transient banner surfaces non-fatal action errors (and info/warning messages) without blocking the screen they occurred on.
+A single transient banner surfaces non-fatal errors (and info/warning messages) without blocking the screen they occurred on.
 
-Previously, any API error — including a failed action like posting to a guild the user isn't a member of — was rendered as permanent full-screen red text that replaced the whole tab until the app restarted.
+**Errors never block a screen.** Previously, any *load* error was rendered as permanent full-screen red text that replaced the whole tab until the app restarted — and several screens never cleared it, trapping the user (the canonical case: a notification pointing to a deleted post, which 404s on open). Now every failure surfaces in the transient banner, and a screen with no content shows a subtle inline "couldn't load …" line instead of a blocking error.
 
 ---
 
@@ -10,10 +10,14 @@ Previously, any API error — including a failed action like posting to a guild 
 
 | Failure kind | Message | Routed by | Display |
 |---|---|---|---|
-| **Load failure** — a fetch that populates a screen returns an error (screen would be empty) | `errMsg` | `handleErr` → active screen's `SetError` | Full-screen message explaining the empty screen |
+| **Load failure** — a fetch that populates a screen returns an error | `errMsg` | `handleErr` → global banner **and** active screen's `SetError` | Transient banner (via `friendlyErr`); the screen stays usable. If it has no content, its empty-state reads "couldn't load …" instead of the normal "nothing here yet" |
 | **Action failure** — create / reply / delete / follow / save / submit / send is rejected (screen still has content) | `actionErrMsg` | `handleNotify` → global banner | Transient banner; screen content stays visible and usable |
 
-The distinguishing question for a command: *if this fails, does the screen still have valid content to show?* If yes, it uses `actionErrMsg`.
+`handleErr` still calls each screen's `SetError`, but that error now only feeds the inline empty-state — `View()` never collapses to a bare error string. The error is always cleared on the next load (see *Self-healing* below), so no screen can stay stuck.
+
+### Deleted-post notifications
+
+Opening a notification whose target post was deleted is special-cased so the banner reads a friendly **"This post has been deleted"** rather than the raw 404. The post-open fetch returns `notifPostLoadErrMsg`, handled in `handleNotifications`: a `*api.APIError` with `Status == 404` → friendly warning banner; `ErrUnauthorized` falls through to the login redirect; anything else → error banner. The notification API exposes no "deleted target" field, so the 404 on open is the only signal (confirmed against API v0.4.1).
 
 ---
 
@@ -41,6 +45,8 @@ Each notification bumps `notifyGen` and captures that value in its auto-dismiss 
 |---|---|
 | `App.notifyText` / `notifyLevel` / `notifyGen` | Current banner text, severity, and generation counter (empty text = hidden) |
 | `actionErrMsg{err}` | Non-fatal action failure; surfaces as a banner |
+| `notifPostLoadErrMsg{err}` | Failure opening a post from Notifications; friendly-handled in `handleNotifications` (404 → "This post has been deleted") |
+| `friendlyErr(err)` | Softens raw API errors for the banner (404 → "Not found — it may have been deleted.") |
 | `notifyMsg{text, level}` | Set the banner directly (e.g. info/success surfacing) |
 | `notifyExpireMsg{gen}` | Auto-dismiss tick; clears the banner iff `gen == App.notifyGen` |
 | `notify(level, text)` | Helper: sets banner state and returns the timed-expire command |
@@ -53,17 +59,18 @@ Each notification bumps `notifyGen` and captures that value in its auto-dismiss 
 
 All mutation commands return `actionErrMsg` on failure: guild post, post, reply, post/reply delete, follow/unfollow, profile save, settings save, note create/update/delete, note publish, send room message, send C-Mail. A failed bookmark create (which rolls back its optimistic add) also raises a banner.
 
-All `load*` commands keep `errMsg` (full-screen `SetError`).
+All `load*` commands return `errMsg`, which `handleErr` now routes to the banner (plus the inline empty-state). The post-open path from Notifications uses `notifPostLoadErrMsg` instead, for friendly deleted-post handling.
 
 ---
 
 ## Self-healing load errors
 
-Screen success setters clear their stored `err` so a stale full-screen load error can no longer persist:
+No screen blocks on a load error, and every screen clears its stored `err` on the next fetch (`SetFetching`) and on each successful setter, so a stale error can never persist:
 
-- `guilds.go`: `SetGuilds`, `AppendGuilds`, `SetGuildPosts`, `AppendGuildPosts`, `SetGuildMembers`, `AppendGuildMembers`
-- `feed.go`: `SetPosts`
-- `topics.go`: `SetTopics`, `AppendTopics`, `SetTopicPosts`
+- Every list/detail screen's `SetFetching` clears `err` before re-fetching.
+- Success setters clear `err`: `feed.SetPosts`; `notifications.SetNotifs`; `bookmarks.SetBookmarks`; `guilds.SetGuilds`/`SetGuildPosts`/`SetGuildMembers`; `topics.SetTopics`/`SetTopicPosts`; `journal.SetNotes`; `profile.SetUser` + the four sub-tab setters; `postdetail.SetPost`/`SetReplies`; `cmail.SetConversations`.
+
+When a screen has no content and an `err` is set, its `View()`/empty-state renders a subtle "couldn't load …" line. `chatrooms` carried a dead, never-set `err` field and blocking branch — both removed.
 
 ---
 
@@ -79,3 +86,20 @@ Screen success setters clear their stored `err` so a stale full-screen load erro
 | `TestNotify_KeypressDismissesButKeyStillActs` | A keypress clears the banner and still performs its action (`?` opens help) |
 | `TestNotify_ExpireAfterKeypressIsNoOp` | A stale tick after keypress-dismiss is a no-op |
 | `TestActionErrMsg_DoesNotBlankScreen` | An action error keeps guild content visible while showing the banner |
+
+`internal/ui/app_test.go`
+
+| Test | Verifies |
+|---|---|
+| `TestNotifPostLoadErr_DeletedPostShowsBanner` | A 404 on post-open → "This post has been deleted" warning banner; stays on Notifications |
+| `TestNotifPostLoadErr_OtherErrorShowsBanner` | Any other post-open failure → error banner |
+| `TestNotifPostLoadErr_UnauthorizedRedirectsToLogin` | A 401 on post-open still redirects to login |
+| `TestHandleErr_FiresBannerWithoutBlocking` | A load error fires the banner and keeps the user on their screen |
+| `TestFriendlyErr_404IsSoftened` | `friendlyErr` softens a 404 and passes other errors through |
+
+`internal/ui/screens/notifications_test.go`
+
+| Test | Verifies |
+|---|---|
+| `TestNotifs_SetError_ShowsInlineEmptyState` | An errored empty screen shows "couldn't load …" inline, not the raw error |
+| `TestNotifs_SetFetchingClearsError` | `SetFetching` and `SetNotifs` clear a prior error (no permanent trap) |

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1235,6 +1235,8 @@ func (a App) handleUnauthorized(msg tea.Msg) (App, tea.Cmd, bool) {
 		err = m.err
 	case actionErrMsg:
 		err = m.err
+	case notifPostLoadErrMsg:
+		err = m.err
 	default:
 		return a, nil, false
 	}
@@ -1281,7 +1283,21 @@ func (a App) handleErr(msg tea.Msg) (App, tea.Cmd, bool) {
 	case screenJournal:
 		a.journal = a.journal.SetError(m.err)
 	}
-	return a, nil, true
+	// Errors never block a screen: the per-screen SetError above only feeds an
+	// inline "couldn't load" empty-state, while the failure is announced in the
+	// transient global banner so it is visible even when content is already shown.
+	a, cmd := a.notify(notifyError, friendlyErr(m.err))
+	return a, cmd, true
+}
+
+// friendlyErr converts an API error into human-facing banner text, softening the
+// raw "API error NOT_FOUND (404): …" wording for the common deleted-resource case.
+func friendlyErr(err error) string {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) && apiErr.Status == 404 {
+		return "Not found — it may have been deleted."
+	}
+	return err.Error()
 }
 
 // activeScreenHasFocusedInput returns true when the current screen has a
@@ -2175,6 +2191,12 @@ type wanderTickMsg struct{}
 type wanderDoneMsg struct{ at time.Time } // zero At means no update was made
 type errMsg struct{ err error }
 
+// notifPostLoadErrMsg is the failure of opening a post from the Notifications
+// screen. It is handled in handleNotifications so a deleted target surfaces as a
+// friendly transient banner ("This post has been deleted") instead of routing
+// through handleErr and blanking the list.
+type notifPostLoadErrMsg struct{ err error }
+
 // notifyLevel selects the color of a global notification banner.
 type notifyLevel int
 
@@ -2185,8 +2207,9 @@ const (
 )
 
 // actionErrMsg is a non-fatal failure from a user-initiated action (post, reply,
-// delete, follow, …). Unlike errMsg — which blanks a screen via SetError —
-// it surfaces as a transient global banner and never blocks a tab.
+// delete, follow, …). Like errMsg it surfaces as a transient global banner and
+// never blocks a tab; unlike errMsg it does not set any screen's inline
+// "couldn't load" empty-state, since there is no load in flight.
 type actionErrMsg struct{ err error }
 
 // notifyMsg sets the global banner directly; used for success/info surfacing.
@@ -2632,6 +2655,21 @@ func (a App) handleNotifications(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.active = screenPostDetail
 		a.postDetail = a.postDetail.SetPost(msg.post)
 		return a, a.loadRepliesCmd(msg.post.ID), true
+	case notifPostLoadErrMsg:
+		// A dead session must still redirect to login — let handleUnauthorized
+		// (which runs later in the dispatch chain) claim it.
+		if errors.Is(msg.err, api.ErrUnauthorized) {
+			return a, nil, false
+		}
+		// The target post is gone (or otherwise unfetchable): announce it in the
+		// transient banner and leave the notifications list untouched.
+		var apiErr *api.APIError
+		if errors.As(msg.err, &apiErr) && apiErr.Status == 404 {
+			a, cmd := a.notify(notifyWarn, "This post has been deleted")
+			return a, cmd, true
+		}
+		a, cmd := a.notify(notifyError, msg.err.Error())
+		return a, cmd, true
 	case screens.ShowUserProfileMsg:
 		if a.active != screenNotifications {
 			return a, nil, false
@@ -3076,7 +3114,7 @@ func (a *App) loadPostAndShowCmd(postID string) tea.Cmd {
 	return func() tea.Msg {
 		post, err := a.client.GetPost(postID)
 		if err != nil {
-			return errMsg{err}
+			return notifPostLoadErrMsg{err}
 		}
 		return notifPostLoadedMsg{post: post}
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -330,3 +330,81 @@ func TestHandleUnauthorized_OtherErrorDoesNotRedirect(t *testing.T) {
 		t.Errorf("active = %v, want screenFeed (non-401 must not redirect)", got.active)
 	}
 }
+
+// --- errors never block: notifPostLoadErrMsg & handleErr → banner ---
+
+// A notification pointing to a deleted post must surface as a friendly,
+// non-blocking warning banner rather than blanking the notifications list.
+func TestNotifPostLoadErr_DeletedPostShowsBanner(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenNotifications
+	deleted := &api.APIError{Code: "NOT_FOUND", Status: 404, Message: "Post not found"}
+
+	m, _ := a.Update(notifPostLoadErrMsg{err: deleted})
+	got := m.(App)
+	if got.notifyText != "This post has been deleted" {
+		t.Errorf("notifyText = %q, want deleted-post banner", got.notifyText)
+	}
+	if got.notifyLevel != notifyWarn {
+		t.Errorf("notifyLevel = %v, want notifyWarn", got.notifyLevel)
+	}
+	if got.active != screenNotifications {
+		t.Errorf("active = %v, want screenNotifications (must not navigate away)", got.active)
+	}
+}
+
+// Any other post-open failure still surfaces in the banner (with its raw text),
+// never blocking the screen.
+func TestNotifPostLoadErr_OtherErrorShowsBanner(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenNotifications
+
+	m, _ := a.Update(notifPostLoadErrMsg{err: errors.New("network down")})
+	got := m.(App)
+	if got.notifyText != "network down" {
+		t.Errorf("notifyText = %q, want raw error text", got.notifyText)
+	}
+	if got.notifyLevel != notifyError {
+		t.Errorf("notifyLevel = %v, want notifyError", got.notifyLevel)
+	}
+}
+
+// A dead session on the post-open path must still redirect to login rather than
+// being swallowed by the banner.
+func TestNotifPostLoadErr_UnauthorizedRedirectsToLogin(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenNotifications
+	a.ephemeral = true
+
+	m, _ := a.Update(notifPostLoadErrMsg{err: api.ErrUnauthorized})
+	if got := m.(App); got.active != screenLogin {
+		t.Errorf("active = %v, want screenLogin", got.active)
+	}
+}
+
+// handleErr must fire the global banner (non-blocking) for load failures while
+// keeping the user on their current screen.
+func TestHandleErr_FiresBannerWithoutBlocking(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenFeed
+
+	m, _ := a.Update(errMsg{errors.New("network down")})
+	got := m.(App)
+	if got.notifyText != "network down" {
+		t.Errorf("notifyText = %q, want banner with error text", got.notifyText)
+	}
+	if got.active != screenFeed {
+		t.Errorf("active = %v, want screenFeed (error must not navigate)", got.active)
+	}
+}
+
+// friendlyErr softens the raw API 404 wording for the banner.
+func TestFriendlyErr_404IsSoftened(t *testing.T) {
+	got := friendlyErr(&api.APIError{Code: "NOT_FOUND", Status: 404, Message: "Post not found"})
+	if got != "Not found — it may have been deleted." {
+		t.Errorf("friendlyErr(404) = %q, want softened message", got)
+	}
+	if got := friendlyErr(errors.New("boom")); got != "boom" {
+		t.Errorf("friendlyErr(non-api) = %q, want raw text", got)
+	}
+}

--- a/internal/ui/screens/bookmarks.go
+++ b/internal/ui/screens/bookmarks.go
@@ -1,7 +1,6 @@
 package screens
 
 import (
-	"fmt"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -82,6 +81,7 @@ func (m BookmarksModel) IsLoaded() bool { return m.loaded }
 
 func (m BookmarksModel) SetFetching() BookmarksModel {
 	m.fetching = true
+	m.err = nil
 	if m.ready {
 		m = m.refreshContent()
 	}
@@ -95,6 +95,7 @@ func (m BookmarksModel) SetBookmarks(items []model.Bookmark, cursor string) Book
 	m.loading = false
 	m.fetching = false
 	m.loaded = true
+	m.err = nil
 	m.selectedIndex = 0
 	if m.ready {
 		m = m.refreshContent()
@@ -138,6 +139,9 @@ func (m BookmarksModel) SetError(err error) BookmarksModel {
 	m.err = err
 	m.loading = false
 	m.fetching = false
+	if m.ready {
+		m = m.refreshContent()
+	}
 	return m
 }
 
@@ -290,6 +294,9 @@ func (m BookmarksModel) buildContent() (string, []int) {
 	}
 	visible := m.visibleItems()
 	if len(visible) == 0 {
+		if m.err != nil {
+			return theme.Subtle.Render("  couldn't load bookmarks"), nil
+		}
 		return theme.Subtle.Render("  no bookmarks yet — press b on a post to save it"), nil
 	}
 
@@ -434,9 +441,6 @@ func (m BookmarksModel) renderItem(b model.Bookmark, selected bool) string {
 }
 
 func (m BookmarksModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("bookmarks error: %s", m.err))
-	}
 	if !m.ready {
 		return theme.Subtle.Render("  Loading bookmarks…")
 	}

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -26,7 +26,6 @@ type ChatroomsModel struct {
 	input             textinput.Model
 	width             int
 	ready             bool
-	err               error
 	loc               *time.Location // timezone for timestamp display; nil = UTC
 	timeDisplayFormat string         // API setting: "datetime", "relative", "unix", "swatch"
 }
@@ -155,10 +154,6 @@ func (m ChatroomsModel) renderMessages() string {
 }
 
 func (m ChatroomsModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("chatroom error: %s", m.err))
-	}
-
 	roomList := theme.Border.Width(chatroomSidebarWidth).Render(m.renderRoomList())
 
 	var chatArea string

--- a/internal/ui/screens/cmail.go
+++ b/internal/ui/screens/cmail.go
@@ -2,7 +2,6 @@ package screens
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -153,6 +152,7 @@ func (m CMailModel) SetError(err error) CMailModel {
 // SetConversations replaces the conversation list, clamping the selection cursor if needed.
 func (m CMailModel) SetConversations(convs []model.Conversation) CMailModel {
 	m.conversations = convs
+	m.err = nil
 	if len(convs) > 0 && m.selectedConv >= len(convs) {
 		m.selectedConv = len(convs) - 1
 	}
@@ -341,6 +341,12 @@ func (m CMailModel) otherParticipant(conv model.Conversation) string {
 
 func (m CMailModel) renderConvList() string {
 	out := theme.Title.Render("c-mail") + "\n\n"
+	if len(m.conversations) == 0 {
+		if m.err != nil {
+			return out + theme.Subtle.Render("couldn't load conversations")
+		}
+		return out + theme.Subtle.Render("no conversations yet")
+	}
 	maxPreview := m.sidebarWidth - 4
 	if maxPreview < 4 {
 		maxPreview = 4
@@ -419,10 +425,6 @@ func (m CMailModel) AppendMessage(msg model.Message) CMailModel {
 }
 
 func (m CMailModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("c-mail error: %s", m.err))
-	}
-
 	listBorder := theme.Border
 	if m.focusPane == FocusCMailLeft {
 		listBorder = theme.ActiveBorder

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -1,7 +1,6 @@
 package screens
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -87,6 +86,7 @@ func ParseTopics(s string) []string {
 
 func (m FeedModel) SetFetching() FeedModel {
 	m.fetching = true
+	m.err = nil
 	if m.ready {
 		m = m.refreshContent()
 	}
@@ -142,6 +142,10 @@ func (m FeedModel) SetError(err error) FeedModel {
 	m.err = err
 	m.loading = false
 	m.fetching = false
+	m.refreshing = false
+	if m.ready {
+		m = m.refreshContent()
+	}
 	return m
 }
 
@@ -462,6 +466,9 @@ func (m FeedModel) buildContent() (string, []int) {
 		startLine = 1
 	}
 	if len(m.posts) == 0 {
+		if m.err != nil {
+			return prefix + theme.Subtle.Render("  couldn't load feed"), nil
+		}
 		return prefix + theme.Subtle.Render("  no posts yet"), nil
 	}
 	sep := "\n"
@@ -494,9 +501,6 @@ func (m FeedModel) renderPost(p model.Post, selected bool) string {
 }
 
 func (m FeedModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("feed error: %s", m.err))
-	}
 	if !m.ready {
 		return theme.Subtle.Render("loading feed...")
 	}

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -149,6 +149,7 @@ func (m GuildsModel) IsLoaded() bool { return m.loaded }
 // SetFetching marks the model as loading and refreshes the loading indicator.
 func (m GuildsModel) SetFetching() GuildsModel {
 	m.fetching = true
+	m.err = nil
 	if m.ready {
 		m = m.refreshContent()
 	}
@@ -290,6 +291,9 @@ func (m GuildsModel) SetError(err error) GuildsModel {
 	m.loading = false
 	m.fetching = false
 	m.refreshing = false
+	if m.ready {
+		m = m.refreshContent()
+	}
 	return m
 }
 
@@ -539,9 +543,6 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 
 // View renders the guilds screen.
 func (m GuildsModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("guilds error: %s", m.err))
-	}
 	if !m.ready {
 		return theme.Subtle.Render("loading guilds...")
 	}
@@ -634,6 +635,9 @@ func (m GuildsModel) buildContent() (string, []int) {
 
 	if m.view == viewGuildList {
 		if len(m.guilds) == 0 {
+			if m.err != nil {
+				return prefix + theme.Subtle.Render("  couldn't load guilds"), nil
+			}
 			return prefix + theme.Subtle.Render("  no guilds yet"), nil
 		}
 		offsets := make([]int, len(m.guilds))
@@ -651,6 +655,9 @@ func (m GuildsModel) buildContent() (string, []int) {
 
 	if m.view == viewGuildMembers {
 		if len(m.members) == 0 {
+			if m.err != nil {
+				return prefix + theme.Subtle.Render("  couldn't load members"), nil
+			}
 			return prefix + theme.Subtle.Render("  no members"), nil
 		}
 		offsets := make([]int, len(m.members))
@@ -668,6 +675,9 @@ func (m GuildsModel) buildContent() (string, []int) {
 
 	// viewGuildPosts
 	if len(m.posts) == 0 {
+		if m.err != nil {
+			return prefix + theme.Subtle.Render("  couldn't load threads"), nil
+		}
 		return prefix + theme.Subtle.Render("  no threads"), nil
 	}
 	visible := m.visiblePosts()

--- a/internal/ui/screens/journal.go
+++ b/internal/ui/screens/journal.go
@@ -78,6 +78,7 @@ func NewJournalModel(width int) JournalModel {
 
 func (m JournalModel) SetFetching() JournalModel {
 	m.fetching = true
+	m.err = nil
 	if m.ready {
 		m = m.refreshContent()
 	}
@@ -186,6 +187,9 @@ func (m JournalModel) SetError(err error) JournalModel {
 	m.err = err
 	m.loading = false
 	m.fetching = false
+	if m.ready {
+		m = m.refreshContent()
+	}
 	return m
 }
 
@@ -521,6 +525,9 @@ func (m JournalModel) refreshRevisionsContent() JournalModel {
 // buildRevisionListContent renders the list of revisions.
 func (m JournalModel) buildRevisionListContent() string {
 	if len(m.revisions) == 0 {
+		if m.err != nil {
+			return theme.Subtle.Render("  couldn't load revisions.")
+		}
 		return theme.Subtle.Render("  no revisions found.")
 	}
 
@@ -702,6 +709,9 @@ func (m JournalModel) buildContent() (string, []int) {
 		if m.loading {
 			return theme.Subtle.Render("  loading notes…"), nil
 		}
+		if m.err != nil {
+			return theme.Subtle.Render("  couldn't load notes"), nil
+		}
 		return theme.Subtle.Render("  no notes yet"), nil
 	}
 
@@ -786,9 +796,6 @@ func (m JournalModel) renderNote(note model.Note, selected bool) string {
 }
 
 func (m JournalModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("journal error: %s", m.err))
-	}
 	if !m.ready {
 		return theme.Subtle.Render("loading journal…")
 	}

--- a/internal/ui/screens/notifications.go
+++ b/internal/ui/screens/notifications.go
@@ -1,7 +1,6 @@
 package screens
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -62,6 +61,7 @@ func (m NotificationsModel) IsReady() bool { return m.ready }
 
 func (m NotificationsModel) SetFetching() NotificationsModel {
 	m.fetching = true
+	m.err = nil
 	if m.ready {
 		m = m.refreshContent()
 	}
@@ -72,6 +72,7 @@ func (m NotificationsModel) SetNotifs(notifs []model.Notification, cursor string
 	m.notifs = notifs
 	m.nextCursor = cursor
 	m.exhausted = cursor == ""
+	m.err = nil
 	m.loading = false
 	m.fetching = false
 	m.refreshing = false
@@ -100,6 +101,9 @@ func (m NotificationsModel) SetError(err error) NotificationsModel {
 	m.loading = false
 	m.fetching = false
 	m.refreshing = false
+	if m.ready {
+		m = m.refreshContent()
+	}
 	return m
 }
 
@@ -359,6 +363,9 @@ func (m NotificationsModel) buildContent() (string, []int) {
 	}
 
 	if len(visible) == 0 {
+		if m.err != nil {
+			return prefix + theme.Subtle.Render("  couldn't load notifications"), nil
+		}
 		if m.showUnreadOnly {
 			return prefix + theme.Subtle.Render("  all caught up"), nil
 		}
@@ -531,9 +538,6 @@ func (m NotificationsModel) renderNotif(n model.Notification, selected bool) str
 }
 
 func (m NotificationsModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("notifications error: %s", m.err))
-	}
 	if !m.ready {
 		return theme.Subtle.Render("loading notifications...")
 	}

--- a/internal/ui/screens/notifications.go
+++ b/internal/ui/screens/notifications.go
@@ -407,8 +407,32 @@ func (m NotificationsModel) buildContent() (string, []int) {
 	return prefix + out, offsets
 }
 
-// notifSummary returns the action text for a notification.
+// notifSummary returns the action text for a notification. For post/reply
+// activity inside a guild it appends an " in #<guild>" clause (see withGuild).
 func notifSummary(n model.Notification) string {
+	base := baseNotifSummary(n)
+	switch n.Type {
+	case "new_post_friend", "new_post_following", "reply", "thread_reply":
+		if n.GuildName != "" {
+			return withGuild(base, n.GuildName)
+		}
+	}
+	return base
+}
+
+// withGuild inserts " in #<guild>" before a single trailing period. The guild
+// name is used verbatim (guilds choose their own casing); the leading # marks it
+// as a guild, matching the app's existing convention (join/leave banners, icons).
+func withGuild(base, guild string) string {
+	clause := " in #" + guild
+	if strings.HasSuffix(base, ".") {
+		return base[:len(base)-1] + clause + "."
+	}
+	return base + clause
+}
+
+// baseNotifSummary returns the action text for a notification without any guild clause.
+func baseNotifSummary(n model.Notification) string {
 	switch n.Type {
 	case "new_post_friend", "new_post_following":
 		return "published something."
@@ -435,7 +459,7 @@ func notifSummary(n model.Notification) string {
 		return "replied in a thread you're following."
 	case "guild_new_thread":
 		if n.GuildName != "" {
-			return "posted a new thread in " + n.GuildName + "."
+			return "posted a new thread in #" + n.GuildName + "."
 		}
 		return "posted a new thread."
 	case "poke":

--- a/internal/ui/screens/notifications_test.go
+++ b/internal/ui/screens/notifications_test.go
@@ -880,6 +880,34 @@ func TestNotifs_SetError_SetsErr(t *testing.T) {
 	}
 }
 
+// A failed initial load must not blank/block the screen: the view shows a subtle
+// inline "couldn't load" line instead of a full-screen error.
+func TestNotifs_SetError_ShowsInlineEmptyState(t *testing.T) {
+	m := initNotifs(nil) // ready, no notifications
+	m = m.SetError(errForTest("boom"))
+	view := m.View()
+	if strings.Contains(view, "boom") {
+		t.Errorf("raw error must not appear in the screen (banner handles it), got: %s", view)
+	}
+	if !strings.Contains(view, "couldn't load notifications") {
+		t.Errorf("expected inline 'couldn't load' empty-state, got: %s", view)
+	}
+}
+
+// Re-fetching clears a prior error so the screen is never a permanent trap.
+func TestNotifs_SetFetchingClearsError(t *testing.T) {
+	m := initNotifs(nil)
+	m = m.SetError(errForTest("boom"))
+	m = m.SetFetching()
+	if m.err != nil {
+		t.Error("SetFetching should clear a prior error")
+	}
+	m = m.SetNotifs(nil, "")
+	if m.err != nil {
+		t.Error("SetNotifs should clear a prior error")
+	}
+}
+
 func TestNotifs_UnreadCount(t *testing.T) {
 	notifs := []model.Notification{
 		makeNotif("n1", "reply", "p1", false),

--- a/internal/ui/screens/notifications_test.go
+++ b/internal/ui/screens/notifications_test.go
@@ -365,6 +365,45 @@ func TestNotifSummary_ThreadReply_NoAuthor(t *testing.T) {
 	}
 }
 
+// --- guild clause: post/reply notifications include "in #<guild>" verbatim ---
+
+func TestNotifSummary_Reply_WithGuild(t *testing.T) {
+	n := model.Notification{Type: "reply", GuildName: "technica"}
+	if got := notifSummary(n); got != "replied to your post in #technica." {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+func TestNotifSummary_ThreadReply_WithGuild(t *testing.T) {
+	n := model.Notification{Type: "thread_reply", ThreadAuthorUsername: "7spires", GuildName: "technica"}
+	if got := notifSummary(n); got != "replied in @7spires's thread in #technica." {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+func TestNotifSummary_NewPost_WithGuild_PreservesCasing(t *testing.T) {
+	// Guild names keep their own casing; only a leading # is added.
+	n := model.Notification{Type: "new_post_following", GuildName: "CHOOMS"}
+	if got := notifSummary(n); got != "published something in #CHOOMS." {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+func TestNotifSummary_Reply_NoGuild_Unchanged(t *testing.T) {
+	n := model.Notification{Type: "reply"}
+	if got := notifSummary(n); got != "replied to your post." {
+		t.Errorf("non-guild reply must be unchanged, got %q", got)
+	}
+}
+
+func TestNotifSummary_Mention_NoGuildClause(t *testing.T) {
+	// *_mention types are intentionally excluded from the guild clause.
+	n := model.Notification{Type: "post_mention", GuildName: "technica"}
+	if got := notifSummary(n); got != "mentioned you in a post." {
+		t.Errorf("mention should not get a guild clause, got %q", got)
+	}
+}
+
 // --- notifIcon ---
 
 func TestNotifIcon_Reply_Unread(t *testing.T) {
@@ -433,7 +472,7 @@ func TestNotifs_Enter_GuildNewThread_EmitsShowPost(t *testing.T) {
 func TestNotifSummary_GuildNewThread_WithName(t *testing.T) {
 	n := model.Notification{Type: "guild_new_thread", GuildName: "technica"}
 	result := notifSummary(n)
-	if result != "posted a new thread in technica." {
+	if result != "posted a new thread in #technica." {
 		t.Errorf("unexpected summary: %q", result)
 	}
 }

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -156,6 +156,7 @@ func (m PostDetailModel) SetPost(post model.Post) PostDetailModel {
 func (m PostDetailModel) SetReplies(replies []model.Reply) PostDetailModel {
 	m.selectedReply = -1 // keep post selected after replies load
 	m.loading = false
+	m.err = nil
 	if len(replies) > m.post.RepliesCount {
 		m.post.RepliesCount = len(replies)
 	}
@@ -217,6 +218,9 @@ func (m PostDetailModel) ComposeActive() bool { return m.compose.IsActive() }
 func (m PostDetailModel) SetError(err error) PostDetailModel {
 	m.err = err
 	m.loading = false
+	if m.ready {
+		m = m.refreshContent()
+	}
 	return m
 }
 
@@ -772,9 +776,6 @@ func (m PostDetailModel) renderReply(node replyNode, selected bool) string {
 }
 
 func (m PostDetailModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("error: %s", m.err))
-	}
 	if !m.ready {
 		return theme.Subtle.Render("loading…")
 	}

--- a/internal/ui/screens/profile.go
+++ b/internal/ui/screens/profile.go
@@ -192,6 +192,7 @@ func (m ProfileModel) SetFollowFeedback(text string) ProfileModel {
 func (m ProfileModel) SetUser(u model.User) ProfileModel {
 	m.user = u
 	m.followFeedback = ""
+	m.err = nil
 	return m
 }
 
@@ -218,6 +219,7 @@ func (m ProfileModel) SetUserPosts(posts []model.Post, cursor string) ProfileMod
 	m.posts = posts
 	m.tabMeta[tabPosts] = tabScrollMeta{cursor: cursor, loaded: true, exhausted: cursor == ""}
 	m.tabSelected = 0
+	m.err = nil
 	return m
 }
 
@@ -234,6 +236,7 @@ func (m ProfileModel) SetUserReplies(replies []model.Reply, cursor string) Profi
 	m.replies = replies
 	m.tabMeta[tabReplies] = tabScrollMeta{cursor: cursor, loaded: true, exhausted: cursor == ""}
 	m.tabSelected = 0
+	m.err = nil
 	return m
 }
 
@@ -250,6 +253,7 @@ func (m ProfileModel) SetUserFollowing(follows []model.Follow, cursor string) Pr
 	m.following = follows
 	m.tabMeta[tabFollowing] = tabScrollMeta{cursor: cursor, loaded: true, exhausted: cursor == ""}
 	m.tabSelected = 0
+	m.err = nil
 	return m
 }
 
@@ -266,6 +270,7 @@ func (m ProfileModel) SetUserFollowers(follows []model.Follow, cursor string) Pr
 	m.followers = follows
 	m.tabMeta[tabFollowers] = tabScrollMeta{cursor: cursor, loaded: true, exhausted: cursor == ""}
 	m.tabSelected = 0
+	m.err = nil
 	return m
 }
 
@@ -672,8 +677,14 @@ func (m ProfileModel) Update(msg tea.Msg) (ProfileModel, tea.Cmd) {
 
 // View renders the profile screen.
 func (m ProfileModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("profile error: %s", m.err))
+	// The core profile hasn't loaded yet: show a non-blocking placeholder rather
+	// than a broken header. A failed load surfaces in the global banner; navigating
+	// away and back re-fetches.
+	if m.user.Username == "" {
+		if m.err != nil {
+			return theme.Subtle.Render("couldn't load profile")
+		}
+		return theme.Subtle.Render("loading profile…")
 	}
 
 	username := theme.Title.Render("@" + m.user.Username)

--- a/internal/ui/screens/screens_test.go
+++ b/internal/ui/screens/screens_test.go
@@ -318,12 +318,21 @@ func TestPostDetail_SetError_ClearsLoading(t *testing.T) {
 	}
 }
 
-func TestPostDetail_SetError_ShowsErrorInView(t *testing.T) {
+// TestPostDetail_SetError_DoesNotBlockView verifies the non-blocking error
+// contract: a load error must never collapse the screen to a bare error string.
+// The post (loaded before the error) stays rendered; the failure is surfaced in
+// the global banner instead.
+func TestPostDetail_SetError_DoesNotBlockView(t *testing.T) {
 	m := screens.NewPostDetailModel()
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetPost(makePost())
 	m = m.SetError(fmt.Errorf("connection refused"))
-	if !strings.Contains(m.View(), "connection refused") {
-		t.Errorf("expected error message in view, got: %s", m.View())
+	view := m.View()
+	if strings.Contains(view, "connection refused") {
+		t.Errorf("error must not block the view (it belongs in the global banner), got: %s", view)
+	}
+	if !strings.Contains(view, makePost().Content) {
+		t.Errorf("expected post content to remain visible after error, got: %s", view)
 	}
 }
 

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -92,6 +92,7 @@ func (m TopicsModel) IsLoaded() bool { return m.loaded }
 
 func (m TopicsModel) SetFetching() TopicsModel {
 	m.fetching = true
+	m.err = nil
 	if m.ready {
 		m = m.refreshContent()
 	}
@@ -162,6 +163,9 @@ func (m TopicsModel) SetError(err error) TopicsModel {
 	m.loading = false
 	m.fetching = false
 	m.refreshing = false
+	if m.ready {
+		m = m.refreshContent()
+	}
 	return m
 }
 
@@ -295,9 +299,6 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 }
 
 func (m TopicsModel) View() string {
-	if m.err != nil {
-		return theme.Error.Render(fmt.Sprintf("topics error: %s", m.err))
-	}
 	if !m.ready {
 		return theme.Subtle.Render("loading topics...")
 	}
@@ -325,6 +326,9 @@ func (m TopicsModel) buildContent() (string, []int) {
 
 	if m.view == viewTopicList {
 		if len(m.topics) == 0 {
+			if m.err != nil {
+				return prefix + theme.Subtle.Render("  couldn't load topics"), nil
+			}
 			return prefix + theme.Subtle.Render("  no topics yet"), nil
 		}
 		offsets := make([]int, len(m.topics))
@@ -343,6 +347,9 @@ func (m TopicsModel) buildContent() (string, []int) {
 
 	// viewTopicPosts
 	if len(m.posts) == 0 {
+		if m.err != nil {
+			return prefix + theme.Subtle.Render("  couldn't load posts"), nil
+		}
 		return prefix + theme.Subtle.Render("  no posts"), nil
 	}
 	visible := m.visiblePosts()


### PR DESCRIPTION
@
## Summary

Three related changes, starting from a reported bug and broadening into the general rule it exposed.

### 1. Errors never block a screen (`e3d32b5`)
**Bug:** selecting a notification pointing to a deleted post 404d and rendered a full-screen red error on the Notifications screen with no way out but to quit. This was systemic — 9 of 10 screens collapsed their `View()` to a full-screen error on any load failure, and four (CMail, Notifications, Profile, Bookmarks) never cleared it, trapping the user.

- `handleErr` now fires the transient global banner (text via new `friendlyErr`) instead of a blocking full-screen error; the per-screen `err` only feeds a subtle inline "couldnt load …" empty-state.
- Every screen clears `err` on `SetFetching` and on its success setters, so a load error can never persist across a refresh.
- Removed the full-screen-error branch from all blocking `View()`s; removed the dead, never-set `err` field + branch from chatrooms.
- Deleted-post notifications are special-cased via a new `notifPostLoadErrMsg`: 404 → friendly **"This post has been deleted"** banner, 401 → login redirect, other errors → error banner. (The notification payload exposes no deleted-target field — confirmed against API v0.4.1 — so the 404 on open is the only signal.)

### 2. Align recorded API version to v0.4.1 (`4763e2e`)
The snapshot `docs/00-latest-api-reference.md` was already byte-identical to live v0.4.1 and the code was already built against v0.4 — only stale version labels remained. Updated `CLAUDE.md`, `CONTRIBUTING.md`, `docs/00-project-reference.md`, and the `release.yml` example tag. Label-only; no behavioral change.

### 3. Guild name in guild post/reply notifications (`35257be`)
Post/reply notifications inside a guild now append `in #<guildName>` — e.g. `@ragnar replied to your post in #technica.` The name is rendered verbatim (guilds own their casing: `CHOOMS`, `TTRPG`, `technica`); the leading `#` marks it as a guild, matching existing app convention (join/leave banners, the `guild_new_thread` icon). Applies to `new_post_*`, `reply`, `thread_reply` when `metadata.guildName` is present; `guild_new_thread` gains the `#` too. `*_mention` excluded.

## Testing
- `go test ./...`, `go vet ./...`, `staticcheck ./...` — all clean.
- New app-level tests (deleted-post banner, 401 redirect, `friendlyErr`, non-blocking `handleErr`) and screen tests (inline empty-state, error self-heal, guild-clause per type).

## Caveat
This accounts recent notifications had no guild post/reply entries, so server population of `metadata.guildName` for `reply`/`thread_reply`/`new_post_*` is unconfirmed (only `guild_new_thread` is). The client renders it whenever present; if the server omits it for those types, thats a server-side gap to log in `docs/00-api-backlog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@