### PR TITLE
fix: show guild handle on guild reply/post notifications via guildSlug

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -61,7 +61,8 @@ Guilds are member groups with their own forum of threads. A user can belong to o
 
 Notes:
 - Guild threads are ordinary posts with `guildId`, `guildSlug`, `isGuildThread: true`; replying uses `POST /v1/replies` as normal.
-- `guild_new_thread` notifications are already display-ready (`notifSummary`/`notifIcon` have explicit cases) and navigation is wired via `TargetID` → `ShowNotificationPostMsg`.
+- `guild_new_thread` notifications are display-ready (`notifSummary`/`notifIcon` have explicit cases) and navigation is wired via `TargetID` → `ShowNotificationPostMsg`.
+- Notification metadata for guild **replies/posts** uses `metadata.guildSlug` + `metadata.isGuildThread: true` (observed 2026-06-03), **not** `metadata.guildName`. The client decodes `guildSlug` and shows `in #<slug>` on `reply`/`thread_reply`/`new_post_*` (prefers slug over the rarer `guildName`). The server `docs.md` does not document the notification `metadata` object schema — a server-side doc gap.
 - The `isMember` / `role` fields on `GET /v1/guilds/:slug` were broken in v0.4 but are **fixed in v0.4.1** (verified 2026-06-01 — see Resolved Issues). The `GetGuild()` client method could now be called to read accurate membership state, though the current `User.GuildSlug` approach also works.
 - Join/leave are now official v0.4.1 API endpoints. Any authenticated user can also create a guild thread without being a member (explicitly stated in v0.4.1 spec).
 - v0.4.1 adds `profilePictureUrl` to both the guild list response and the guild members list response. The `Guild` and `GuildMember` model types and wire layer do not yet carry this field.

--- a/docs/15-notifications.md
+++ b/docs/15-notifications.md
@@ -102,7 +102,9 @@ Pressing `enter` on `poke` or `new_follower` notifications (or any with an empty
 
 ### Guild context
 
-When a post or reply notification happens inside a guild, the summary appends an `in #<guildName>` clause — e.g. `replied to your post in #technica.` or `published something in #CHOOMS.` This applies to `new_post_friend`, `new_post_following`, `reply`, and `thread_reply` whenever the notification carries `metadata.guildName`; `guild_new_thread` always shows it. The guild name is rendered **verbatim** (guilds choose their own casing); the leading `#` marks it as a guild, matching the app's existing convention (join/leave banners, the `guild_new_thread` icon). `*_mention` types are excluded to avoid awkward phrasing. The handling lives in `notifSummary` / `withGuild` in `internal/ui/screens/notifications.go`.
+When a post or reply notification happens inside a guild, the summary appends an `in #<guild>` clause — e.g. `replied to your post in #chooms.` or `posted a new thread in #technica.` This applies to `new_post_friend`, `new_post_following`, `reply`, and `thread_reply` whenever the notification carries guild context; `guild_new_thread` always shows it.
+
+The guild handle comes from `metadata.guildSlug` (the lowercase handle the server sends for guild replies/posts, alongside `metadata.isGuildThread: true`); `metadata.guildName` is a rarer display-name variant. The UI prefers the slug (`guildLabel` in `internal/ui/screens/notifications.go`), so the value is rendered **verbatim** with a leading `#`, matching the app's existing convention (join/leave banners, the `guild_new_thread` icon). `*_mention` types are excluded to avoid awkward phrasing. The clause is applied by `notifSummary` / `withGuild`.
 
 ---
 
@@ -163,7 +165,13 @@ A notification can point to a post that has since been deleted; the notification
       "actorId": "user-123",
       "actorUsername": "molly_millions",
       "targetId": "post-456",
-      "targetType": "post"
+      "targetType": "reply",
+      "metadata": {
+        "replyId": "reply-789",
+        "authorUsername": "ragnar",
+        "guildSlug": "chooms",
+        "isGuildThread": true
+      }
     }
   ],
   "nextCursor": "cursor-xyz"
@@ -178,13 +186,17 @@ Note: the actor is returned as flat fields (`actorId`, `actorUsername`), not a n
 
 ```go
 type Notification struct {
-    ID         string
-    Type       string
-    Read       bool
-    CreatedAt  time.Time
-    Actor      NotificationActor
-    TargetID   string
-    TargetType string // "post", "reply", or ""
+    ID                   string
+    Type                 string
+    Read                 bool
+    CreatedAt            time.Time
+    Actor                NotificationActor
+    TargetID             string
+    TargetType           string // "post", "reply", or ""
+    ReplyID              string // metadata.replyId; reply to scroll to in PostDetail
+    ThreadAuthorUsername string // metadata.authorUsername; set for thread_reply
+    GuildName            string // metadata.guildName; rarer display-name variant
+    GuildSlug            string // metadata.guildSlug; guild handle shown as #slug
 }
 
 type NotificationActor struct {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -252,6 +252,7 @@ type wireNotificationMetadata struct {
 	ReplyID        string `json:"replyId"`
 	AuthorUsername string `json:"authorUsername"`
 	GuildName      string `json:"guildName"`
+	GuildSlug      string `json:"guildSlug"`
 }
 
 type wireNotification struct {
@@ -706,6 +707,7 @@ func wireNotificationToModel(w wireNotification) model.Notification {
 		ReplyID:              w.Metadata.ReplyID,
 		ThreadAuthorUsername: w.Metadata.AuthorUsername,
 		GuildName:            w.Metadata.GuildName,
+		GuildSlug:            w.Metadata.GuildSlug,
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -639,7 +639,7 @@ func TestHTTPGetNotifications_ParsesNotifs(t *testing.T) {
 				"actorUsername": "molly_millions",
 				"targetId":      "p1",
 				"targetType":    "reply",
-				"metadata":      map[string]any{"replyId": "r42"},
+				"metadata":      map[string]any{"replyId": "r42", "guildSlug": "chooms", "isGuildThread": true},
 			},
 			{
 				"id":            "n2",
@@ -671,6 +671,9 @@ func TestHTTPGetNotifications_ParsesNotifs(t *testing.T) {
 	}
 	if notifs[0].ReplyID != "r42" {
 		t.Errorf("replyID mismatch: got %q, want %q", notifs[0].ReplyID, "r42")
+	}
+	if notifs[0].GuildSlug != "chooms" {
+		t.Errorf("guildSlug mismatch: got %q, want %q", notifs[0].GuildSlug, "chooms")
 	}
 	if notifs[1].ID != "n2" || notifs[1].Read != true {
 		t.Errorf("notifs[1] mismatch: %+v", notifs[1])

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -224,6 +224,8 @@ type NotificationActor struct {
 // TargetType describes the notification category ("post" or "reply"); empty for poke/new_follower.
 // ReplyID is set from metadata.replyId for reply/thread_reply notifications and identifies
 // the specific reply to scroll to in PostDetail.
+// GuildSlug is set when the activity happened inside a guild (metadata.guildSlug); it is the
+// handle the UI shows as #slug. GuildName is the rarer display-name variant.
 type Notification struct {
 	ID                   string
 	Type                 string // "reply", "reply_mention", "post_mention", "thread_reply", "new_post_friend", "new_post_following", "new_follower", "unfollowed", "bookmark", "poke", "guild_new_thread", "chat_mention", "dm_message", "supporter_granted", "supporter_removed", "hacker_granted", "hacker_removed", "image_permission_granted", "image_permission_removed", "attachment_permission_granted", "attachment_permission_removed", "system_ban"
@@ -234,5 +236,6 @@ type Notification struct {
 	TargetType           string // "post", "reply", or ""
 	ReplyID              string // populated for reply/thread_reply; the specific reply to highlight
 	ThreadAuthorUsername string // set for thread_reply; the original thread's author
-	GuildName            string // set for guild_new_thread; the guild display name
+	GuildName            string // guild display name (seen on guild_new_thread)
+	GuildSlug            string // guild handle from metadata.guildSlug; set on guild reply/post notifications (with isGuildThread)
 }

--- a/internal/ui/screens/notifications.go
+++ b/internal/ui/screens/notifications.go
@@ -413,11 +413,21 @@ func notifSummary(n model.Notification) string {
 	base := baseNotifSummary(n)
 	switch n.Type {
 	case "new_post_friend", "new_post_following", "reply", "thread_reply":
-		if n.GuildName != "" {
-			return withGuild(base, n.GuildName)
+		if g := guildLabel(n); g != "" {
+			return withGuild(base, g)
 		}
 	}
 	return base
+}
+
+// guildLabel returns the guild handle to display, preferring the slug — the stable
+// lowercase handle the server sends for guild replies/posts (metadata.guildSlug) —
+// over the rarer display name. Empty when the notification has no guild context.
+func guildLabel(n model.Notification) string {
+	if n.GuildSlug != "" {
+		return n.GuildSlug
+	}
+	return n.GuildName
 }
 
 // withGuild inserts " in #<guild>" before a single trailing period. The guild
@@ -458,8 +468,8 @@ func baseNotifSummary(n model.Notification) string {
 		}
 		return "replied in a thread you're following."
 	case "guild_new_thread":
-		if n.GuildName != "" {
-			return "posted a new thread in #" + n.GuildName + "."
+		if g := guildLabel(n); g != "" {
+			return "posted a new thread in #" + g + "."
 		}
 		return "posted a new thread."
 	case "poke":

--- a/internal/ui/screens/notifications_test.go
+++ b/internal/ui/screens/notifications_test.go
@@ -374,6 +374,22 @@ func TestNotifSummary_Reply_WithGuild(t *testing.T) {
 	}
 }
 
+// The server sends guildSlug (not guildName) for guild replies; it must drive the clause.
+func TestNotifSummary_Reply_WithGuildSlug(t *testing.T) {
+	n := model.Notification{Type: "reply", GuildSlug: "chooms"}
+	if got := notifSummary(n); got != "replied to your post in #chooms." {
+		t.Errorf("unexpected summary: %q", got)
+	}
+}
+
+// When both are present the slug (the stable lowercase handle) wins.
+func TestNotifSummary_GuildSlug_PreferredOverName(t *testing.T) {
+	n := model.Notification{Type: "reply", GuildName: "CHOOMS", GuildSlug: "chooms"}
+	if got := notifSummary(n); got != "replied to your post in #chooms." {
+		t.Errorf("expected slug to win, got: %q", got)
+	}
+}
+
 func TestNotifSummary_ThreadReply_WithGuild(t *testing.T) {
 	n := model.Notification{Type: "thread_reply", ThreadAuthorUsername: "7spires", GuildName: "technica"}
 	if got := notifSummary(n); got != "replied in @7spires's thread in #technica." {


### PR DESCRIPTION
@
## Summary

Follow-up fix to PR #7. Guild post/reply notifications gained an `in #<guild>` clause, but a real guild thread reply still showed no guild. Inspecting live `/v1/notifications` revealed the cause: **guild reply/post notifications carry `metadata.guildSlug` (+ `isGuildThread: true`), not `metadata.guildName`** — and the client only decoded `guildName`, dropping `guildSlug` entirely.

Example payload (the reported case):
`type=reply, actor=krowe, metadata={"authorUsername":"ragnar","guildSlug":"chooms","isGuildThread":true,...}`

## Changes
- Decode `metadata.guildSlug` into `model.Notification.GuildSlug` (`internal/api/client.go`).
- Add `guildLabel()` which **prefers the slug** (the stable lowercase handle the server actually sends, e.g. `chooms`) over the rarer `guildName`.
- Use `guildLabel` in `notifSummary` for `reply`/`thread_reply`/`new_post_*` and in the `guild_new_thread` case.

Result: `@krowe replied to your post in #chooms.` ✅ Confirmed working in the running TUI.

## Tests
- Decoder test asserts `guildSlug` is parsed.
- Summary tests: slug drives the clause; slug wins when both `guildName` and `guildSlug` are present; non-guild notifications unchanged.
- `go test ./...`, `go vet ./...`, `staticcheck ./...` — all clean.

## Docs
- `docs/15-notifications.md` — corrected guild-context note + Notification struct fields + wire-format example.
- `docs/00-api-backlog.md` — recorded the confirmed notification `metadata` schema (`guildSlug` + `isGuildThread`) and the server-side doc gap (the schema is undocumented in `docs.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@