### PR TITLE
docs: retarget API baseline to v0.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file defines workflow guardrails for Claude. It is not project documentatio
 - **Stack:** Go + Bubble Tea (TUI), Lip Gloss (styling), Wish (SSH hosting)
 - **Code map:** `docs/00-project-reference.md` — comprehensive architecture, package structure, and file listing; **read this first to understand the codebase before targeting specific files for changes**
 - **Project docs:** `docs/` folder — numbered per feature (e.g. `docs/01-auth.md`)
-- **API status:** v0.4.1 — docs at https://api.cyberspace.online/docs.md — **always fetch before any API work** to catch changes
+- **API status:** v0.5.0 — docs at https://api.cyberspace.online/docs.md — **always fetch before any API work** to catch changes
 - **API snapshot:** `docs/00-latest-api-reference.md` — current baseline we're building against (check for drift against live URL)
 - **Key API facts:** login uses email (not username) · chat/DMs use Firebase RTDB (SSE), not REST · cursor-based pagination
 - **API backlog:** `docs/00-api-backlog.md` — unimplemented features and known server-side bugs; update whenever issues are found or features land
@@ -55,11 +55,11 @@ This file defines workflow guardrails for Claude. It is not project documentatio
 - `dev` → `main` only when a full milestone is complete and user approves
 
 ### Releases — API-aligned versioning
-- Release tags mirror the cyberspace.online API version they target: `v0.4.0`, `v0.4.1`, etc.
-- Current target: **v0.4.1** (see `docs/00-latest-api-reference.md`)
+- Release tags mirror the cyberspace.online API version they target: `v0.4.1`, `v0.5.0`, etc.
+- Current target: **v0.5.0** (see `docs/00-latest-api-reference.md`)
 - When the API ships a new version, open a new milestone on `dev` targeting that version
 - When the milestone is complete and the user approves, merge `dev` → `main` and tag with the API version
-- Incremental TUI releases within an API version use a fourth segment: `v0.4.1.1`, `v0.4.1.2`, etc.
+- Incremental TUI releases within an API version use a fourth segment: `v0.5.0.1`, `v0.5.0.2`, etc.
 - A milestone is a named set of features forming a coherent releasable version; the user defines scope and approves each release
 
 ---

--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -1,6 +1,6 @@
 # API Backlog — Outstanding Features & Known Issues
 
-Tracks gaps between the cyberspace.online API (v0.4.1) and what is currently implemented in the TUI client.
+Tracks gaps between the cyberspace.online API (v0.5.0) and what is currently implemented in the TUI client.
 Update this file whenever a feature is implemented or an issue is discovered/resolved.
 
 ---
@@ -13,7 +13,7 @@ These bugs exist in the server — no client-side fix is possible. Report to the
 |---|---|---|---|---|
 | `/v1/follows` | GET | **Open** | Response does not include `followerUsername` or `followedUsername`. Confirmed still missing in v0.4 (re-tested 2026-05-29). The profile Following/Followers tabs fall back to showing a truncated user ID; profile navigation from those tabs is disabled until the API returns usernames. | 2026-04-17 |
 | `/v1/notifications` | GET | **Open (by design?)** | Notifications can point to posts that have since been deleted, and the notification object exposes no "target deleted/unavailable" flag — opening one is the only way to discover the target is gone (`GET /v1/posts/:id` → 404). The client now handles this gracefully (friendly "This post has been deleted" banner, non-blocking). A `targetDeleted` field (or server-side filtering of dead-target notifications) would let the client mark/skip them up front. | 2026-06-03 |
-| Rate limits (spec) | — | **Open** | Inline per-endpoint docs and the consolidated Rate Limits table still contradict each other in v0.4.1. Entries: 15/day inline vs 10/day in table. Replies: 15/day vs 10/day. Notes: 30/day vs 20/day. Bookmarks: 75/day vs 50/day. Profile updates: 15/day vs 10/day. Guild threads/join/leave are now consistent. Unknown which is authoritative — report to API maintainer. | 2026-05-29 |
+| Rate limits (spec) | — | **Resolved** | The v0.4.1 inline-vs-table contradiction is gone in v0.5.0: the consolidated Rate Limits table now matches the inline per-endpoint limits (Entries 15/day, Replies 15/day, Notes 30/day, Bookmarks 75/day, Profile/Settings 15/day). Read limits were also raised (most list endpoints 30→45/min; profile/follows/topics/bookmarks/notes 20→30/min). Resolved 2026-06-04. | 2026-05-29 |
 
 ---
 
@@ -62,7 +62,7 @@ Guilds are member groups with their own forum of threads. A user can belong to o
 Notes:
 - Guild threads are ordinary posts with `guildId`, `guildSlug`, `isGuildThread: true`; replying uses `POST /v1/replies` as normal.
 - `guild_new_thread` notifications are display-ready (`notifSummary`/`notifIcon` have explicit cases) and navigation is wired via `TargetID` → `ShowNotificationPostMsg`.
-- Notification metadata for guild **replies/posts** uses `metadata.guildSlug` + `metadata.isGuildThread: true` (observed 2026-06-03), **not** `metadata.guildName`. The client decodes `guildSlug` and shows `in #<slug>` on `reply`/`thread_reply`/`new_post_*` (prefers slug over the rarer `guildName`). The server `docs.md` does not document the notification `metadata` object schema — a server-side doc gap.
+- Notification metadata for guild **replies/posts** uses `metadata.guildSlug` + `metadata.isGuildThread: true` (observed 2026-06-03), **not** `metadata.guildName`. The client decodes `guildSlug` and shows `in #<slug>` on `reply`/`thread_reply`/`new_post_*` (prefers slug over the rarer `guildName`). As of API **v0.5.0** the server documents the notification object and its `metadata` keys (incl. `guildSlug`, `guildName`, `isGuildThread`, `threadId`, `postSlug`, `authorUsername`), closing the earlier doc gap; the client's slug-preference behavior matches the documented schema.
 - The `isMember` / `role` fields on `GET /v1/guilds/:slug` were broken in v0.4 but are **fixed in v0.4.1** (verified 2026-06-01 — see Resolved Issues). The `GetGuild()` client method could now be called to read accurate membership state, though the current `User.GuildSlug` approach also works.
 - Join/leave are now official v0.4.1 API endpoints. Any authenticated user can also create a guild thread without being a member (explicitly stated in v0.4.1 spec).
 - v0.4.1 adds `profilePictureUrl` to both the guild list response and the guild members list response. The `Guild` and `GuildMember` model types and wire layer do not yet carry this field.

--- a/docs/00-latest-api-reference.md
+++ b/docs/00-latest-api-reference.md
@@ -1,4 +1,4 @@
-﻿# ᑕ¥βєяรקค¢є API v0.4.1
+﻿# ᑕ¥βєяรקค¢є API v0.5.0
 
 ## Access
 
@@ -576,6 +576,47 @@ Notification types: `bookmark`, `reply`, `thread_reply`, `new_follower`, `unfoll
 
 Rate limit: 30/min.
 
+### Notification object
+
+Each notification has this shape:
+
+```json
+{
+  "id": "notificationId",
+  "userId": "recipientUid",
+  "type": "reply",
+  "actorId": "actorUid",
+  "actorUsername": "someone",
+  "targetId": "postId",
+  "targetType": "post",
+  "read": false,
+  "createdAt": "2026-06-03T12:00:00.000Z",
+  "metadata": { "postSlug": "my-entry", "replyId": "replyId", "authorUsername": "me" }
+}
+```
+
+- `actorId` / `actorUsername` — who triggered the notification (denormalized so no extra lookup is needed).
+- `targetType` — `post` or `reply`; `targetId` is the related entry's ID.
+- `read` — always `false` on creation.
+- `reason` — present only on some system notifications (e.g. `system_ban`).
+- `metadata` — type-dependent context. Common keys: `postSlug` and `authorUsername` (build the `/{username}/{slug}` deep link), `replyId` (the relevant reply), `postContent` / `replyContent` (the mention source text), and for guild threads `guildSlug`, `guildName`, `isGuildThread`, `threadId`. `metadata` is open-ended — clients should treat unknown keys as optional.
+
+`guildSlug` / `isGuildThread` here live inside notification `metadata`; the same names also appear as top-level fields on guild-thread **entries** (see Guilds).
+
+### How notifications are generated
+
+The API emits these notifications server-side — clients don't create them:
+
+- `new_follower` — someone follows you.
+- `bookmark` — someone bookmarks your entry or reply.
+- `reply` — someone replies to your entry.
+- `new_post_following` / `new_post_friend` — someone you follow posts a new entry. `new_post_friend` is sent when the follow is **mutual** (you follow each other); `new_post_following` when it's one-way.
+- `post_mention` / `reply_mention` — you're `@`-mentioned in an entry or reply. Mentions use the `@username` syntax (case-insensitive). Mentioning a user in an entry also subscribes them to that thread, so they receive `thread_reply` for future replies.
+- `thread_reply` — a new reply is posted to a thread you're watching.
+- `guild_new_thread` — a new thread is posted in a guild you belong to.
+
+Notifications are never sent to yourself for your own actions, and a user who would otherwise receive several notifications for the same event gets only one (the most specific). Remaining types in the list above are produced by other parts of the platform (DMs, chat, moderation, role/permission changes).
+
 ### Unread Count
 
 ```
@@ -779,34 +820,36 @@ All responses follow this structure:
 
 | Action | Per Minute | Per Day |
 |--------|-----------|---------|
-| Entries | 2 | 10 |
-| Replies | 3 | 10 |
-| Follows | 3 | 10 |
-| Unfollows | 3 | 10 |
-| Notes | 3 | 20 |
-| Bookmarks | 5 | 50 |
+| Entries | 2 | 15 |
+| Replies | 3 | 15 |
+| Follows | 3 | 15 |
+| Unfollows | 3 | 15 |
+| Notes | 3 | 30 |
+| Bookmarks | 5 | 75 |
 | Guild threads | 2 | 15 |
 | Guild join | 3 | 15 |
 | Guild leave | 3 | 15 |
-| Profile updates | 2 | 10 |
-| Settings updates | 2 | 10 |
+| Profile updates | 2 | 15 |
+| Settings updates | 2 | 15 |
+
+`POST /v1/auth/resend-verification` is limited separately to 1/min and 5/hour.
 
 ### Read Actions (Anti-Scraping)
 
 | Endpoint | Per Minute |
 |----------|-----------|
-| List entries | 30 |
-| List replies | 30 |
-| List user entries | 30 |
-| List user replies | 30 |
-| List topic entries | 30 |
-| List topics | 20 |
-| List bookmarks | 20 |
-| List notes | 20 |
+| List entries | 45 |
+| List replies | 45 |
+| List user entries | 45 |
+| List user replies | 45 |
+| List topic entries | 45 |
+| List topics | 30 |
+| List bookmarks | 30 |
+| List notes | 30 |
 | List notifications | 30 |
 | Unread notification count | 30 |
-| List followers/following | 20 |
-| View user profile | 20 |
+| List followers/following | 30 |
+| View user profile | 30 |
 | List guilds / members | 30 |
 | List guild threads | 45 |
 
@@ -827,4 +870,3 @@ Exceeding a rate limit returns `429`. Limits use a rolling window (24 hours for 
 | Location name | 64 chars |
 | Topics per entry | 3 |
 | Username | 3-20 chars |
-

--- a/docs/15-notifications.md
+++ b/docs/15-notifications.md
@@ -180,6 +180,8 @@ A notification can point to a post that has since been deleted; the notification
 
 Note: the actor is returned as flat fields (`actorId`, `actorUsername`), not a nested object.
 
+As of API **v0.5.0** the server `docs.md` documents this notification object and its `metadata` keys (previously reverse-engineered); the shape above matches the documented schema. `metadata` is open-ended — unknown keys are treated as optional.
+
 ---
 
 ## Model


### PR DESCRIPTION
## Summary
Syncs the in-repo API snapshot and version references to the live cyberspace.online API **v0.5.0** (was v0.4.1), in preparation for the `dev` → `main` milestone release.

The **v0.5.0 vs v0.4.1** delta is non-breaking:
- **Rate limits raised** (more permissive). Write/day: Entries/Replies/Follows/Unfollows 10→15, Notes 20→30, Bookmarks 50→75, Profile/Settings 10→15. Read/min: most list endpoints 30→45; topics/bookmarks/notes/follows/profile 20→30.
- **Notification object + generation rules now documented** (additive). Formalizes the notification shape and `metadata` keys.
- No endpoint additions/removals; no request/response schema changes.

**No client code changes required** — `dev` already decodes `metadata.{replyId,authorUsername,guildName,guildSlug}` and renders the `in #<slug>` clause; the v0.5.0 keys we don't parse are optional and unused by navigation.

## Changes
- `docs/00-latest-api-reference.md` — replaced with verbatim v0.5.0 docs (BOM preserved)
- `CLAUDE.md` — API status / current target / tag examples → v0.5.0
- `docs/00-api-backlog.md` — marked the rate-limit table-vs-inline contradiction **Resolved** (reconciled in v0.5.0); updated the notification-metadata note (schema now officially documented)
- `docs/15-notifications.md` — noted the wire schema is now documented in v0.5.0

## Validation
`go test ./...` (565 tests), `go vet ./...`, `staticcheck ./...`, `govulncheck ./...` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)