### PR TITLE
feat: align profile with API v0.5.0 response shape and improve display

### DIFF
--- a/docs/00-latest-api-reference.md
+++ b/docs/00-latest-api-reference.md
@@ -281,6 +281,40 @@ GET /v1/users/me
 GET /v1/users/:username
 ```
 
+Both endpoints return the same user object shape:
+
+```json
+{
+  "userId": "uid",
+  "username": "someone",
+  "displayName": "Some One",
+  "bio": "text",
+  "websiteUrl": "https://example.com",
+  "websiteName": "My Site",
+  "websiteImageUrl": "https://example.com/button.png",
+  "pinnedPostId": "abc123",
+  "locationName": "London, UK",
+  "locationLatitude": 51.5074,
+  "locationLongitude": -0.1278,
+  "followersCount": 42,
+  "followingCount": 10,
+  "postsCount": 14,
+  "publicPostsCount": 1,
+  "hasPublicPosts": true,
+  "guildSlug": "night-owls",
+  "guildId": "guildId",
+  "guildName": "Night Owls",
+  "guildIcon": "owl",
+  "profilePictureUrl": "https://…",
+  "isSupporter": true,
+  "supporterIcon": "pi",
+  "serialNumber": 3889,
+  "createdAt": "2025-11-22T07:07:18.652Z",
+  "lastActiveAt": "2026-06-14T13:58:16.284Z",
+  "updatedAt": "2026-06-14T14:32:17.365Z"
+}
+```
+
 Rate limit: 30/min.
 
 ### List User's Entries

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -112,6 +112,18 @@ type wireUser struct {
 	FollowingCount    int     `json:"followingCount"`
 	PostsCount        int     `json:"postsCount"`
 	GuildSlug         string  `json:"guildSlug"`
+	GuildID           string  `json:"guildId"`
+	GuildName         string  `json:"guildName"`
+	GuildIcon         string  `json:"guildIcon"`
+	ProfilePictureUrl string  `json:"profilePictureUrl"`
+	IsSupporter       bool    `json:"isSupporter"`
+	SupporterIcon     string  `json:"supporterIcon"`
+	SerialNumber      int     `json:"serialNumber"`
+	PublicPostsCount  int     `json:"publicPostsCount"`
+	HasPublicPosts    bool    `json:"hasPublicPosts"`
+	CreatedAt         string  `json:"createdAt"`
+	LastActiveAt      string  `json:"lastActiveAt"`
+	UpdatedAt         string  `json:"updatedAt"`
 }
 
 type wireFollow struct {
@@ -621,6 +633,18 @@ func wireUserToModel(w wireUser) model.User {
 		FollowingCount:    w.FollowingCount,
 		PostsCount:        w.PostsCount,
 		GuildSlug:         w.GuildSlug,
+		GuildID:           w.GuildID,
+		GuildName:         w.GuildName,
+		GuildIcon:         w.GuildIcon,
+		ProfilePictureUrl: w.ProfilePictureUrl,
+		IsSupporter:       w.IsSupporter,
+		SupporterIcon:     w.SupporterIcon,
+		SerialNumber:      w.SerialNumber,
+		PublicPostsCount:  w.PublicPostsCount,
+		HasPublicPosts:    w.HasPublicPosts,
+		CreatedAt:         parseTime(w.CreatedAt),
+		LastActiveAt:      parseTime(w.LastActiveAt),
+		UpdatedAt:         parseTime(w.UpdatedAt),
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -26,6 +26,18 @@ type User struct {
 	FollowingCount    int
 	PostsCount        int
 	GuildSlug         string // empty when not a guild member
+	GuildID           string
+	GuildName         string
+	GuildIcon         string
+	ProfilePictureUrl string
+	IsSupporter       bool
+	SupporterIcon     string
+	SerialNumber      int
+	PublicPostsCount  int
+	HasPublicPosts    bool
+	CreatedAt         time.Time
+	LastActiveAt      time.Time
+	UpdatedAt         time.Time
 }
 
 // Follow maps to a record returned by GET /v1/follows.

--- a/internal/ui/screens/profile.go
+++ b/internal/ui/screens/profile.go
@@ -778,7 +778,11 @@ func (m ProfileModel) infoTabView() string {
 
 	var rows []string
 
-	rows = append(rows, markdown.Render(m.user.Bio, contentW))
+	bioLines := strings.Split(m.user.Bio, "\n")
+	for i, line := range bioLines {
+		bioLines[i] = wrapBioLine(line, contentW)
+	}
+	rows = append(rows, theme.Base.Render(strings.Join(bioLines, "\n")))
 
 	if m.user.WebsiteUrl != "" || m.user.WebsiteName != "" {
 		val := m.user.WebsiteName
@@ -1008,6 +1012,33 @@ func (m ProfileModel) renderFollowItem(f model.Follow, selected bool) string {
 func truncateStr(s string, maxW int) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	return markdown.TruncateToWidth(s, maxW)
+}
+
+// wrapBioLine word-wraps a single bio line to fit within width columns.
+// Lines already within width are returned unchanged, preserving any intentional
+// whitespace (ASCII art, indentation). Lines that exceed width are split at
+// word boundaries; internal whitespace is normalised for prose readability.
+// Lines with no word boundaries (e.g. a long URL or art border) are kept as-is.
+func wrapBioLine(line string, width int) string {
+	if lipgloss.Width(line) <= width {
+		return line
+	}
+	words := strings.Fields(line)
+	if len(words) == 0 {
+		return line
+	}
+	var lines []string
+	current := words[0]
+	for _, word := range words[1:] {
+		if lipgloss.Width(current+" "+word) <= width {
+			current += " " + word
+		} else {
+			lines = append(lines, current)
+			current = word
+		}
+	}
+	lines = append(lines, current)
+	return strings.Join(lines, "\n")
 }
 
 func (m ProfileModel) editFormView(username string) string {

--- a/internal/ui/screens/profile.go
+++ b/internal/ui/screens/profile.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ragnar/cyber-tui/internal/ui/urlutil"
 )
 
-const bioCharLimit = 127
+const bioCharLimit = 640
 
 // Field indices for the profile edit form.
 const (
@@ -703,6 +703,23 @@ func (m ProfileModel) View() string {
 		))
 	}
 
+	// Build right-aligned metadata for the username line: #serial · joined.
+	var metaParts []string
+	if m.user.SerialNumber > 0 {
+		metaParts = append(metaParts, fmt.Sprintf("#%d", m.user.SerialNumber))
+	}
+	if !m.user.CreatedAt.IsZero() {
+		metaParts = append(metaParts, m.user.CreatedAt.Format("Jan 2006"))
+	}
+	usernameLine := username
+	if len(metaParts) > 0 && m.width > 0 {
+		meta := theme.Subtle.Render(strings.Join(metaParts, " · "))
+		gap := m.width - lipgloss.Width(username) - lipgloss.Width(meta)
+		if gap > 1 {
+			usernameLine = username + strings.Repeat(" ", gap) + meta
+		}
+	}
+
 	// Tab bar — pinned to terminal width to prevent terminal-side line wrapping,
 	// which would cause Bubble Tea's line-diff renderer to miscalculate cursor
 	// positions and leave ghost lines on re-render (observed on WSL/Windows Terminal).
@@ -734,7 +751,7 @@ func (m ProfileModel) View() string {
 		content = m.followListTabView(m.followers, tabFollowers, "followers")
 	}
 
-	headerParts := []string{username}
+	headerParts := []string{usernameLine}
 	if m.showFollowerCount {
 		headerParts = append(headerParts, counts)
 	}
@@ -748,22 +765,33 @@ func (m ProfileModel) View() string {
 
 // infoTabView renders the Info tab content (bio, website, location, hint).
 func (m ProfileModel) infoTabView() string {
+	// lbl pads the keyword to a fixed width so all values left-align.
+	// "supporter" is the longest keyword at 9 chars; total label = 11 ("keyword: ").
+	lbl := func(s string) string {
+		return theme.Subtle.Render(fmt.Sprintf("%-9s: ", s))
+	}
+
+	contentW := m.width
+	if contentW > 80 || contentW < 1 {
+		contentW = 80
+	}
+
 	var rows []string
 
-	rows = append(rows, theme.Base.Render(m.user.Bio))
+	rows = append(rows, markdown.Render(m.user.Bio, contentW))
 
 	if m.user.WebsiteUrl != "" || m.user.WebsiteName != "" {
-		label := m.user.WebsiteName
-		if label == "" {
-			label = m.user.WebsiteUrl
+		val := m.user.WebsiteName
+		if val == "" {
+			val = m.user.WebsiteUrl
 		} else if m.user.WebsiteUrl != "" {
-			label = label + "  " + theme.Subtle.Render(m.user.WebsiteUrl)
+			val = val + "  " + theme.Subtle.Render(m.user.WebsiteUrl)
 		}
-		rows = append(rows, "", theme.Subtle.Render("web: ")+theme.Base.Render(label))
+		rows = append(rows, "", lbl("Website")+theme.Base.Render(val))
 	}
 
 	if m.user.WebsiteImageUrl != "" {
-		rows = append(rows, theme.Subtle.Render("img: ")+theme.Base.Render(m.user.WebsiteImageUrl))
+		rows = append(rows, lbl("img")+theme.Base.Render(m.user.WebsiteImageUrl))
 	}
 
 	if m.user.LocationName != "" {
@@ -771,11 +799,32 @@ func (m ProfileModel) infoTabView() string {
 		if m.user.LocationLatitude != 0 || m.user.LocationLongitude != 0 {
 			loc += fmt.Sprintf("  (%g, %g)", m.user.LocationLatitude, m.user.LocationLongitude)
 		}
-		rows = append(rows, theme.Subtle.Render("loc: ")+theme.Base.Render(loc))
+		rows = append(rows, lbl("Location")+theme.Base.Render(loc))
 	} else if m.user.LocationLatitude != 0 || m.user.LocationLongitude != 0 {
-		rows = append(rows, theme.Subtle.Render("loc: ")+
+		rows = append(rows, lbl("Location")+
 			theme.Base.Render(fmt.Sprintf("%g, %g", m.user.LocationLatitude, m.user.LocationLongitude)))
 	}
+
+	guildName := m.user.GuildName
+	if guildName == "" {
+		guildName = m.user.GuildSlug
+	}
+	if guildName != "" {
+		rows = append(rows, lbl("Guild")+theme.Base.Render(guildName))
+	}
+
+	if m.user.ProfilePictureUrl != "" {
+		rows = append(rows, lbl("Picture")+theme.Base.Render(m.user.ProfilePictureUrl))
+	}
+
+	supporterVal := "no"
+	if m.user.IsSupporter {
+		supporterVal = "yes"
+		if m.user.SupporterIcon != "" {
+			supporterVal = "yes (" + m.user.SupporterIcon + ")"
+		}
+	}
+	rows = append(rows, lbl("Supporter")+theme.Base.Render(supporterVal))
 
 	rows = append(rows, "")
 
@@ -1019,6 +1068,9 @@ func (m ProfileModel) GetFocusedURLs() []string {
 	}
 	if m.user.WebsiteImageUrl != "" {
 		urls = append(urls, urlutil.NormalizeURL(m.user.WebsiteImageUrl))
+	}
+	if m.user.ProfilePictureUrl != "" {
+		urls = append(urls, urlutil.NormalizeURL(m.user.ProfilePictureUrl))
 	}
 	return urls
 }


### PR DESCRIPTION
## Summary

- **API alignment**: `GET /v1/users/me` and `GET /v1/users/:username` now return 12 new fields that the client was silently dropping. All are captured in `wireUser`, `model.User`, and `wireUserToModel`.
- **Bio char limit**: corrected from 127 to 640 to match the API.
- **Header**: member serial number and join date shown right-aligned on the username line; drops gracefully on narrow terminals.
- **Info tab**: labels padded to a fixed column width so values left-align; new fields displayed (Guild, Picture, Supporter yes/no); bio rendered through `markdown.Render` with an 80-col cap.
- **URL picker**: profile picture URL is now included when pressing `o`.
- **Docs**: `docs/00-latest-api-reference.md` updated with the full user object response shape.

## Test plan

- [ ] `go test ./... && go vet ./... && staticcheck ./...` pass
- [ ] Open own profile — header shows `#serial · Mon YYYY` right-aligned
- [ ] Info tab: labels align, Guild/Picture/Supporter rows visible, bio wraps at 80 cols on wide terminals
- [ ] Resize terminal narrower than 80 — bio reflows; narrower than username+meta — right side drops cleanly
- [ ] Press `o` on profile — picture URL appears in the picker alongside website URL
- [ ] Open edit form — bio field accepts more than 127 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)