### PR TITLE
feat: align profile with API v0.5.0, fix display issues, add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ragnar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Align profile screen with API v0.5.0 response shape and improve display rendering
- Fix bio wrapping at 80 cols without breaking ASCII art or collapsing newlines
- Strip Unicode Cf chars and Spacing Modifier Letters in `stripAmbiguousRunes`
- Add MIT license

## Test plan

- [ ] Profile screen renders correctly against API v0.5.0 response
- [ ] Bio wrapping does not break ASCII art or collapse intentional newlines
- [ ] Unicode stripping handles Cf/Spacing Modifier Letter edge cases
- [ ] LICENSE file present and correctly attributed

🤖 Generated with [Claude Code](https://claude.com/claude-code)