### PR TITLE
feat: increase max thread depth setting to 20

### DIFF
--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -115,7 +115,7 @@ var settingsGroups = []settingsGroup{
 			},
 			{
 				label: "thread depth", kind: "enum",
-				options: []string{"1", "2", "3", "4", "5"},
+				options: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"},
 				getEnum: func(m SettingsModel) string {
 					if m.maxThreadDepth == 0 {
 						return "3"
@@ -126,7 +126,7 @@ var settingsGroups = []settingsGroup{
 					if m.maxThreadDepth == 0 {
 						m.maxThreadDepth = 3
 					}
-					m.maxThreadDepth = cycleIntEnum(m.maxThreadDepth, []string{"1", "2", "3", "4", "5"}, delta)
+					m.maxThreadDepth = cycleIntEnum(m.maxThreadDepth, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"}, delta)
 					return m
 				},
 			},


### PR DESCRIPTION
## Summary
- Extends the thread depth setting in the Settings screen from a max of 5 to a max of 20
- Users can now cycle through values 1–20 when adjusting thread depth

## Test plan
- [x] Open Settings, navigate to "thread depth", and cycle past 5 to confirm values continue up to 20
- [x] Confirm the setting is saved and applied correctly in post detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)