### PR TITLE
feat: thread watching with ◉ icon and w key

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -1,6 +1,6 @@
 # API Backlog — Outstanding Features & Known Issues
 
-Tracks gaps between the cyberspace.online API (v0.5.0) and what is currently implemented in the TUI client.
+Tracks gaps between the cyberspace.online API (v0.5.1) and what is currently implemented in the TUI client.
 Update this file whenever a feature is implemented or an issue is discovered/resolved.
 
 ---
@@ -26,8 +26,8 @@ Ordered roughly by implementation effort / priority.
 
 | Endpoint | Method | Description | Priority |
 |---|---|---|---|
-| `/v1/auth/register` | POST | User registration (email, password, username) | Out of scope — registration and account management are web-only flows |
-| `/v1/auth/resend-verification` | POST | Resend email verification link | Out of scope — same as above |
+| `/v1/auth/register` | POST | ~~Removed in v0.5.1~~ — registration is web-only; endpoint no longer in the API spec | N/A |
+| `/v1/auth/resend-verification` | POST | Resend email verification link | Out of scope — web-only flow |
 | `/v1/auth/check-username` | POST | Check if a username is available (no auth required) | Out of scope — only relevant alongside registration |
 
 ### Posts
@@ -74,6 +74,23 @@ Notes:
 | `profilePictureUrl` on Guild / GuildMember | v0.4.1 adds this field to the guild list response and the member list response. Not in model types or wire layer. Low value for a TUI but keeps model in sync. | Low |
 | Guild join (`POST /v1/guilds/:slug/join`) | Now an official API endpoint. One guild per user; 409 if already in one. | **Done** |
 | Guild leave (`POST /v1/guilds/:slug/leave`) | Now an official API endpoint. Founders get 403 — must use web. | **Done** |
+
+### Thread Watching (new in v0.5.1)
+
+Watching a thread means you receive `thread_reply` notifications when anyone replies to it. Posting a reply auto-watches the thread (controlled by the `autoWatchOnReply` setting, default on).
+
+| Endpoint | Method | Description | Priority |
+|---|---|---|---|
+| `GET /v1/posts/:id/watch` | GET | Check whether the current user is watching a thread | **Done** |
+| `POST /v1/posts/:id/watch` | POST | Watch a thread (idempotent; rate limit: 10/min, 100/day) | **Done** |
+| `DELETE /v1/posts/:id/watch` | DELETE | Unwatch a thread | **Done** |
+| `GET /v1/watches` | GET | List watched threads — used at startup to populate `◉` icons | **Done** |
+
+Notes:
+- `w` key in feed and post detail (root post only) toggles watch with optimistic update. `◉` icon displayed in feed, post detail, guild threads, and topics.
+- All pages of `GET /v1/watches` are fetched progressively at login; icon set updates after each page.
+- A dedicated "Watched Threads" screen (similar to bookmarks) remains a future low-priority option.
+- The `autoWatchOnReply` settings field (v0.5.1) is already surfaced in the Settings screen.
 
 ### Notifications (new in v0.4.1)
 

--- a/docs/00-latest-api-reference.md
+++ b/docs/00-latest-api-reference.md
@@ -1,4 +1,4 @@
-﻿# ᑕ¥βєяรקค¢є API v0.5.0
+﻿# ᑕ¥βєяรקค¢є API v0.5.1
 
 ## Access
 
@@ -52,24 +52,6 @@ Returns:
 - `idToken` -- use as Bearer token for all API requests
 - `refreshToken` -- use to get a new idToken when it expires
 - `rtdbToken` -- use to connect to Realtime Database for chat/DMs
-
-### Register
-
-```
-POST /v1/auth/register
-```
-
-```json
-{ "email": "you@example.com", "password": "your_password", "username": "your_username" }
-```
-
-Username rules:
-- 3-20 characters
-- Lowercase letters, numbers, underscores only
-- Cannot be a reserved name (admin, system, etc.)
-- Cannot contain prohibited words
-
-Returns the same token structure as login (201).
 
 ### Refresh Token
 
@@ -255,6 +237,8 @@ POST /v1/replies
 
 Returns `{ "data": { "replyId": "..." } }` (201).
 
+Posting a reply auto-watches the thread (see Thread Watching) unless you've disabled `autoWatchOnReply` in Settings.
+
 Rate limit: 3/min, 15/day.
 
 ### Delete Reply
@@ -264,6 +248,55 @@ DELETE /v1/replies/:id
 ```
 
 Deletes the reply. Only the author (or site admin) can delete.
+
+---
+
+## Thread Watching
+
+Watching a thread means you receive `thread_reply` notifications when anyone replies to it. You're auto-watched when you reply to a thread (unless `autoWatchOnReply` is off) or when you're `@mentioned` in an entry; you can also watch/unwatch manually.
+
+### Watch Status
+
+```
+GET /v1/posts/:id/watch
+```
+
+Returns `{ "data": { "watching": true } }` -- whether you currently watch this thread.
+
+### Watch Thread
+
+```
+POST /v1/posts/:id/watch
+```
+
+Idempotent. Returns `{ "data": { "watching": true } }` (201).
+
+Rate limit: 10/min, 100/day.
+
+### Unwatch Thread
+
+```
+DELETE /v1/posts/:id/watch
+```
+
+Returns `{ "data": { "watching": false } }`.
+
+### List Watched Threads
+
+```
+GET /v1/watches?limit=20&cursor=<id>
+```
+
+Returns your watched threads, newest first:
+
+```json
+{
+  "data": [
+    { "id": "<userId>_<postId>", "postId": "abc123", "createdAt": "..." }
+  ],
+  "cursor": "<id>"
+}
+```
 
 ---
 
@@ -279,40 +312,6 @@ GET /v1/users/me
 
 ```
 GET /v1/users/:username
-```
-
-Both endpoints return the same user object shape:
-
-```json
-{
-  "userId": "uid",
-  "username": "someone",
-  "displayName": "Some One",
-  "bio": "text",
-  "websiteUrl": "https://example.com",
-  "websiteName": "My Site",
-  "websiteImageUrl": "https://example.com/button.png",
-  "pinnedPostId": "abc123",
-  "locationName": "London, UK",
-  "locationLatitude": 51.5074,
-  "locationLongitude": -0.1278,
-  "followersCount": 42,
-  "followingCount": 10,
-  "postsCount": 14,
-  "publicPostsCount": 1,
-  "hasPublicPosts": true,
-  "guildSlug": "night-owls",
-  "guildId": "guildId",
-  "guildName": "Night Owls",
-  "guildIcon": "owl",
-  "profilePictureUrl": "https://…",
-  "isSupporter": true,
-  "supporterIcon": "pi",
-  "serialNumber": 3889,
-  "createdAt": "2025-11-22T07:07:18.652Z",
-  "lastActiveAt": "2026-06-14T13:58:16.284Z",
-  "updatedAt": "2026-06-14T14:32:17.365Z"
-}
 ```
 
 Rate limit: 30/min.
@@ -807,6 +806,8 @@ PATCH /v1/settings
 
 Available fields: `notifications`, `filterNSFW`, `showFollowerCount`, `hideImagesInFeed`, `hideAudioInFeed`, `autoWatchOnReply`, `keyboardBindings`, `keyboardPreset`, `mutedUsersByRoom`, `iconTheme`, `followedTopics`, `mutedTopics`, `imagePixelSize`, `timeDisplayFormat`, `useLegacyMenuOrder`, `defaultPublicPost`.
 
+`autoWatchOnReply` (default on) controls whether posting a reply auto-watches that thread (see Thread Watching). Set it to `false` to opt out.
+
 Rate limit: 2/min, 15/day.
 
 ---
@@ -865,6 +866,7 @@ All responses follow this structure:
 | Guild leave | 3 | 15 |
 | Profile updates | 2 | 15 |
 | Settings updates | 2 | 15 |
+| Watch thread | 10 | 100 |
 
 `POST /v1/auth/resend-verification` is limited separately to 1/min and 5/hour.
 
@@ -886,6 +888,7 @@ All responses follow this structure:
 | View user profile | 30 |
 | List guilds / members | 30 |
 | List guild threads | 45 |
+| Watch status / list watched | 30 |
 
 Exceeding a rate limit returns `429`. Limits use a rolling window (24 hours for daily, 60 seconds for per-minute).
 
@@ -904,3 +907,4 @@ Exceeding a rate limit returns `429`. Limits use a rolling window (24 hours for 
 | Location name | 64 chars |
 | Topics per entry | 3 |
 | Username | 3-20 chars |
+

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -123,6 +123,7 @@ Shared domain types used by both the API client and the UI. All types map 1-to-1
 | `Tokens` | IDToken, RefreshToken, RTDBToken returned from login |
 | `User` | Profile (ID, username, displayName, email, bio, websiteUrl, websiteName, websiteImageUrl, pinnedPostID, locationName, locationLatitude, locationLongitude) |
 | `Post` | Feed item (ID, authorID, authorUsername, content, title, slug, guildID, guildSlug, isGuildThread, topics, repliesCount, bookmarksCount, isPublic, isNSFW, deleted, createdAt) |
+| `Watch` | Thread-watch record (ID, PostID, CreatedAt) — returned by GET /v1/watches |
 | `Reply` | Comment on a post (ID, postID, authorID, authorUsername, content, parentReplyID, createdAt) |
 | `ProfileUpdate` | Optional fields for PATCH /v1/users/me (all pointer types, includes new website/location fields) |
 | `Message` | DM/chat message (ID, from, body, createdAt) |
@@ -155,6 +156,7 @@ Defines the `Client` interface — the only type the UI layer imports from this 
 |---|---|
 | Auth | `Login(email, password)`, `LoginWithRefreshToken(token)`, `Logout()` |
 | Feed | `GetFeed(cursor)`, `CreatePost(content, title, topics, isPublic, isNSFW)`, `GetPost(postID)`, `DeletePost(postID)` |
+| Thread watching | `GetWatches(cursor)`, `WatchPost(postID)`, `UnwatchPost(postID)` |
 | Replies | `GetPostReplies(postID)`, `GetReply(replyID)`, `CreateReply(postID, content, parentReplyID)`, `DeleteReply(replyID)` |
 | Profile | `GetOwnProfile()`, `GetProfile(username)`, `UpdateProfile(update)` |
 | User History | `GetUserPosts(username, cursor)`, `GetUserReplies(username, cursor)` |
@@ -694,6 +696,7 @@ All screens implement Bubble Tea's `Model` interface. `ComposeModel` is embedded
 | `n` | New post |
 | `d` | Delete selected post (own posts only — prompts y/n) |
 | `p` | View author's profile |
+| `w` | Watch / unwatch the selected thread |
 
 ### Post Detail
 
@@ -704,6 +707,7 @@ All screens implement Bubble Tea's `Model` interface. `ComposeModel` is embedded
 | `r` | Reply to selected post or reply |
 | `d` | Delete selected post or reply (own content only — prompts y/n) |
 | `p` | View author's profile |
+| `w` | Watch / unwatch the thread (root post focused only; no-op on replies) |
 | `esc` | Back to feed |
 
 ### Compose (embedded)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -163,6 +163,12 @@ type wireBookmark struct {
 	CreatedAt  string     `json:"createdAt"`
 }
 
+type wireWatch struct {
+	ID        string `json:"id"`
+	PostID    string `json:"postId"`
+	CreatedAt string `json:"createdAt"`
+}
+
 type wireTopic struct {
 	TopicID   string `json:"topicId"`
 	Name      string `json:"name"`
@@ -1110,6 +1116,34 @@ func (c *HTTPClient) CreateBookmark(postID, replyID string) (string, error) {
 
 func (c *HTTPClient) DeleteBookmark(id string) error {
 	_, err := c.doRequest("DELETE", "/v1/bookmarks/"+url.PathEscape(id), nil)
+	return err
+}
+
+// --- Thread watching ---
+
+func wireWatchToModel(w wireWatch) model.Watch {
+	return model.Watch{
+		ID:        w.ID,
+		PostID:    w.PostID,
+		CreatedAt: parseTime(w.CreatedAt),
+	}
+}
+
+func (c *HTTPClient) GetWatches(cursor string) ([]model.Watch, string, error) {
+	path := "/v1/watches?limit=50"
+	if cursor != "" {
+		path += "&cursor=" + url.QueryEscape(cursor)
+	}
+	return fetchPage(c, path, wireWatchToModel)
+}
+
+func (c *HTTPClient) WatchPost(postID string) error {
+	_, err := c.doRequest("POST", "/v1/posts/"+url.PathEscape(postID)+"/watch", nil)
+	return err
+}
+
+func (c *HTTPClient) UnwatchPost(postID string) error {
+	_, err := c.doRequest("DELETE", "/v1/posts/"+url.PathEscape(postID)+"/watch", nil)
 	return err
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1535,3 +1535,89 @@ func TestHTTPGetUserReplies_BuildsCorrectPath(t *testing.T) {
 		t.Errorf("AuthorUsername = %q, want neuromancer", replies[0].AuthorUsername)
 	}
 }
+
+// --- Watch ---
+
+func TestHTTPGetWatches_ReturnsList(t *testing.T) {
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/watches" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		writeOKWithCursor(t, w, []map[string]any{
+			{"id": "uid_p1", "postId": "p1", "createdAt": "2025-01-01T12:00:00.000Z"},
+			{"id": "uid_p2", "postId": "p2", "createdAt": "2025-01-02T08:00:00.000Z"},
+		}, "")
+	})))
+	c.Login("u@example.com", "pass")
+
+	watches, cursor, err := c.GetWatches("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor != "" {
+		t.Errorf("cursor = %q, want empty", cursor)
+	}
+	if len(watches) != 2 {
+		t.Fatalf("len(watches) = %d, want 2", len(watches))
+	}
+	if watches[0].PostID != "p1" {
+		t.Errorf("watches[0].PostID = %q, want p1", watches[0].PostID)
+	}
+	if watches[1].PostID != "p2" {
+		t.Errorf("watches[1].PostID = %q, want p2", watches[1].PostID)
+	}
+}
+
+func TestHTTPGetWatches_UsesCursor(t *testing.T) {
+	var gotQuery string
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		writeOKWithCursor(t, w, []map[string]any{}, "")
+	})))
+	c.Login("u@example.com", "pass")
+
+	c.GetWatches("abc123")
+	if !strings.Contains(gotQuery, "cursor=abc123") {
+		t.Errorf("query = %q, want cursor=abc123", gotQuery)
+	}
+}
+
+func TestHTTPWatchPost_CallsCorrectEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		writeOK(t, w, map[string]any{"watching": true})
+	})))
+	c.Login("u@example.com", "pass")
+
+	if err := c.WatchPost("p42"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/posts/p42/watch" {
+		t.Errorf("path = %q, want /v1/posts/p42/watch", gotPath)
+	}
+}
+
+func TestHTTPUnwatchPost_CallsCorrectEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		writeOK(t, w, map[string]any{"watching": false})
+	})))
+	c.Login("u@example.com", "pass")
+
+	if err := c.UnwatchPost("p42"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "DELETE" {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/v1/posts/p42/watch" {
+		t.Errorf("path = %q, want /v1/posts/p42/watch", gotPath)
+	}
+}

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -104,6 +104,15 @@ type Client interface {
 	// is the founder (403) or is not a member.
 	LeaveGuild(slug string) error
 
+	// Thread watching — watch/unwatch individual threads.
+	// GetWatches returns all watched threads, cursor-paginated (limit=50).
+	// Pass empty cursor for first page; use returned cursor for next page.
+	GetWatches(cursor string) ([]model.Watch, string, error)
+	// WatchPost subscribes the user to thread_reply notifications for the given post.
+	WatchPost(postID string) error
+	// UnwatchPost unsubscribes the user from the given thread.
+	UnwatchPost(postID string) error
+
 	// Posts — deletion.
 	// DeletePost soft-deletes a post owned by the authenticated user.
 	DeletePost(postID string) error

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -325,6 +325,12 @@ func (m *MockClient) GetGuildMembers(slug, cursor string) ([]model.GuildMember, 
 func (m *MockClient) JoinGuild(slug string) error  { return nil }
 func (m *MockClient) LeaveGuild(slug string) error { return nil }
 
+func (m *MockClient) GetWatches(cursor string) ([]model.Watch, string, error) {
+	return nil, "", nil
+}
+func (m *MockClient) WatchPost(postID string) error   { return nil }
+func (m *MockClient) UnwatchPost(postID string) error { return nil }
+
 func (m *MockClient) GetNotifications(cursor string, unreadOnly bool) ([]model.Notification, string, error) {
 	if !unreadOnly {
 		return mockNotifications, "", nil

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -216,6 +216,13 @@ type Note struct {
 	CreatedAt      time.Time
 }
 
+// Watch represents a thread-watch record returned by GET /v1/watches.
+type Watch struct {
+	ID        string // "<userId>_<postId>"
+	PostID    string
+	CreatedAt time.Time
+}
+
 // NoteRevision represents a single historical revision of a note,
 // returned by GET /v1/notes/:id/revisions.
 type NoteRevision struct {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -174,6 +174,11 @@ type App struct {
 	postBookmarkIDs  map[string]string // postID  → bookmark UUID
 	replyBookmarkIDs map[string]string // replyID → bookmark UUID
 
+	// watchedPostIDs tracks which thread-root posts the current user is watching.
+	// Populated progressively at login via GET /v1/watches (all pages) and kept in
+	// sync on watch/unwatch. Used to show [◉] indicators in feed and post detail.
+	watchedPostIDs map[string]struct{}
+
 	// notifyText is the transient global notification shown in place of the status
 	// bar. Empty means no notification is visible. notifyGen is bumped on every new
 	// notification and on dismissal so a stale expire tick can never clear a newer one.
@@ -205,6 +210,7 @@ func NewApp(client api.Client) App {
 		bookmarkedReplyIDs: make(map[string]struct{}),
 		postBookmarkIDs:    make(map[string]string),
 		replyBookmarkIDs:   make(map[string]string),
+		watchedPostIDs:     make(map[string]struct{}),
 	}
 }
 
@@ -341,6 +347,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if a2, cmd, ok := a.handleBookmarks(msg); ok {
 		return a2, cmd
 	}
+	if a2, cmd, ok := a.handleWatches(msg); ok {
+		return a2, cmd
+	}
 	if a2, cmd, ok := a.handleGuilds(msg); ok {
 		return a2, cmd
 	}
@@ -398,6 +407,17 @@ func (a *App) broadcastBookmarkedIDs() {
 		PostIDs:  a.bookmarkedPostIDs,
 		ReplyIDs: a.bookmarkedReplyIDs,
 	}
+	a.feed, _ = a.feed.Update(msg)
+	a.postDetail, _ = a.postDetail.Update(msg)
+	a.guilds, _ = a.guilds.Update(msg)
+	a.topics, _ = a.topics.Update(msg)
+}
+
+// broadcastWatchedIDs pushes the current watched-post ID set to all screens
+// that render posts (feed, postDetail, guilds, topics). Call this whenever
+// the set changes (progressive load page, watch, unwatch).
+func (a *App) broadcastWatchedIDs() {
+	msg := screens.WatchedPostIDsMsg{PostIDs: a.watchedPostIDs}
 	a.feed, _ = a.feed.Update(msg)
 	a.postDetail, _ = a.postDetail.Update(msg)
 	a.guilds, _ = a.guilds.Update(msg)
@@ -991,6 +1011,87 @@ func (a App) handleBookmarks(msg tea.Msg) (App, tea.Cmd, bool) {
 		if !msg.fromBookmarksScreen {
 			a.bookmarks = a.bookmarks.SetFetching()
 			return a, a.loadBookmarksCmd(""), true
+		}
+		return a, nil, true
+	}
+	return a, nil, false
+}
+
+// --- Watch messages ---
+
+type watchPageMsg struct {
+	postIDs []string
+	cursor  string
+	err     error
+}
+
+type watchResultMsg struct {
+	postID string
+	err    error
+	added  bool // true = watch was added, false = watch was removed
+}
+
+// handleWatches processes progressive watch-page loads and watch/unwatch toggle messages.
+func (a App) handleWatches(msg tea.Msg) (App, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case watchPageMsg:
+		if msg.err != nil {
+			// Watches are non-critical; silently ignore load errors.
+			return a, nil, true
+		}
+		newIDs := make(map[string]struct{}, len(a.watchedPostIDs)+len(msg.postIDs))
+		for k := range a.watchedPostIDs {
+			newIDs[k] = struct{}{}
+		}
+		for _, id := range msg.postIDs {
+			newIDs[id] = struct{}{}
+		}
+		a.watchedPostIDs = newIDs
+		a.broadcastWatchedIDs()
+		if msg.cursor != "" {
+			return a, a.loadWatchesPageCmd(msg.cursor), true
+		}
+		return a, nil, true
+
+	case screens.ToggleWatchPostMsg:
+		postID := msg.PostID
+		if _, alreadyWatched := a.watchedPostIDs[postID]; alreadyWatched {
+			// Toggle off: optimistic remove.
+			newIDs := make(map[string]struct{}, len(a.watchedPostIDs))
+			for k := range a.watchedPostIDs {
+				newIDs[k] = struct{}{}
+			}
+			delete(newIDs, postID)
+			a.watchedPostIDs = newIDs
+			a.broadcastWatchedIDs()
+			return a, a.unwatchPostCmd(postID), true
+		}
+		// Toggle on: optimistic add.
+		newIDs := make(map[string]struct{}, len(a.watchedPostIDs)+1)
+		for k := range a.watchedPostIDs {
+			newIDs[k] = struct{}{}
+		}
+		newIDs[postID] = struct{}{}
+		a.watchedPostIDs = newIDs
+		a.broadcastWatchedIDs()
+		return a, a.watchPostCmd(postID), true
+
+	case watchResultMsg:
+		if msg.err != nil {
+			// Revert the optimistic update.
+			newIDs := make(map[string]struct{}, len(a.watchedPostIDs))
+			for k := range a.watchedPostIDs {
+				newIDs[k] = struct{}{}
+			}
+			if msg.added {
+				delete(newIDs, msg.postID)
+			} else {
+				newIDs[msg.postID] = struct{}{}
+			}
+			a.watchedPostIDs = newIDs
+			a.broadcastWatchedIDs()
+			a2, cmd := a.notify(notifyError, msg.err.Error())
+			return a2, cmd, true
 		}
 		return a, nil, true
 	}
@@ -1591,12 +1692,12 @@ func (a App) screenHints() []hint {
 		if a.feed.ComposeActive() {
 			return []hint{{"tab", "cycle"}, {"space", "toggle"}, {"Ctrl+s", "send"}, {"Esc", "cancel"}}
 		}
-		return []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"r", "reply"}, {"n", "new"}, {"b", "bookmark"}, more}
+		return []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"r", "reply"}, {"n", "new"}, {"b", "bookmark"}, {"w", "watch"}, more}
 	case screenPostDetail:
 		if a.postDetail.ComposeActive() {
 			return []hint{{"Ctrl+s", "send"}, {"Esc", "cancel"}}
 		}
-		return []hint{{"↑↓", "navigate"}, {"r", "reply"}, {"b", "bookmark"}, {"esc", "back"}, more}
+		return []hint{{"↑↓", "navigate"}, {"r", "reply"}, {"b", "bookmark"}, {"w", "watch"}, {"esc", "back"}, more}
 	case screenProfile:
 		if a.profile.ComposeActive() {
 			return []hint{{"Ctrl+s", "save"}, {"Esc", "cancel"}, {"tab", "cycle"}}
@@ -2298,6 +2399,7 @@ func (a *App) afterLoginCmd() tea.Cmd {
 	return tea.Batch(
 		a.loadFeedCmd(),
 		a.loadBookmarksCmd(""),
+		a.loadWatchesPageCmd(""),
 		a.loadTopicsCmd(),
 		a.loadProfileCmd(),
 		a.fetchUnreadCountCmd(),
@@ -2955,6 +3057,34 @@ func enrichBookmarks(client api.Client, items []model.Bookmark) []model.Bookmark
 		}
 	}
 	return out
+}
+
+func (a *App) loadWatchesPageCmd(cursor string) tea.Cmd {
+	return func() tea.Msg {
+		watches, nextCursor, err := a.client.GetWatches(cursor)
+		if err != nil {
+			return watchPageMsg{err: err}
+		}
+		ids := make([]string, len(watches))
+		for i, w := range watches {
+			ids[i] = w.PostID
+		}
+		return watchPageMsg{postIDs: ids, cursor: nextCursor}
+	}
+}
+
+func (a *App) watchPostCmd(postID string) tea.Cmd {
+	return func() tea.Msg {
+		err := a.client.WatchPost(postID)
+		return watchResultMsg{postID: postID, err: err, added: true}
+	}
+}
+
+func (a *App) unwatchPostCmd(postID string) tea.Cmd {
+	return func() tea.Msg {
+		err := a.client.UnwatchPost(postID)
+		return watchResultMsg{postID: postID, err: err, added: false}
+	}
 }
 
 func (a *App) loadBookmarksCmd(cursor string) tea.Cmd {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -59,6 +59,7 @@ type FeedModel struct {
 	confirmingDelete bool   // true while the delete-post confirmation overlay is shown
 
 	bookmarkedPostIDs map[string]struct{}
+	watchedPostIDs    map[string]struct{}
 	filterNSFW        bool
 }
 
@@ -285,6 +286,13 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case WatchedPostIDsMsg:
+		m.watchedPostIDs = msg.PostIDs
+		if m.ready {
+			m = m.refreshContent()
+		}
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -376,6 +384,12 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 			if visible := m.visiblePosts(); len(visible) > 0 && m.selectedIndex < len(visible) {
 				postID := visible[m.selectedIndex].ID
 				return m, func() tea.Msg { return BookmarkPostMsg{PostID: postID} }
+			}
+			return m, nil
+		case "w":
+			if visible := m.visiblePosts(); len(visible) > 0 && m.selectedIndex < len(visible) {
+				postID := visible[m.selectedIndex].ID
+				return m, func() tea.Msg { return ToggleWatchPostMsg{PostID: postID} }
 			}
 			return m, nil
 		case "d":
@@ -497,7 +511,8 @@ func (m FeedModel) buildContent() (string, []int) {
 
 func (m FeedModel) renderPost(p model.Post, selected bool) string {
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
-	return RenderPost(p, selected, bookmarked, m.width, m.location(), m.timeDisplayFormat)
+	_, watched := m.watchedPostIDs[p.ID]
+	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat)
 }
 
 func (m FeedModel) View() string {

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -108,6 +108,7 @@ type GuildsModel struct {
 	itemOffsets       []int
 	width             int
 	bookmarkedPostIDs map[string]struct{}
+	watchedPostIDs    map[string]struct{}
 	height            int
 	ready             bool
 	err               error
@@ -321,6 +322,13 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 
 	case BookmarkedIDsMsg:
 		m.bookmarkedPostIDs = msg.PostIDs
+		if m.ready {
+			m = m.refreshContent()
+		}
+		return m, nil
+
+	case WatchedPostIDsMsg:
+		m.watchedPostIDs = msg.PostIDs
 		if m.ready {
 			m = m.refreshContent()
 		}
@@ -805,7 +813,8 @@ func (m GuildsModel) renderMemberItem(mem model.GuildMember, selected bool) stri
 
 func (m GuildsModel) renderPostItem(p model.Post, selected bool) string {
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
-	return RenderPost(p, selected, bookmarked, m.width, m.location(), m.timeDisplayFormat)
+	_, watched := m.watchedPostIDs[p.ID]
+	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat)
 }
 
 func (m GuildsModel) refreshContent() GuildsModel {

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -14,6 +14,19 @@ type BookmarkedIDsMsg struct {
 	ReplyIDs map[string]struct{}
 }
 
+// WatchedPostIDsMsg is broadcast by App whenever the set of watched thread IDs
+// changes (progressive load, watch, unwatch). Screens handle this to show the
+// [◉] indicator on watched threads.
+type WatchedPostIDsMsg struct {
+	PostIDs map[string]struct{}
+}
+
+// ToggleWatchPostMsg is emitted by Feed or PostDetail when the user presses 'w'
+// on a thread-root post to toggle its watch state.
+type ToggleWatchPostMsg struct {
+	PostID string
+}
+
 // SharedConfigMsg is broadcast by App whenever display-affecting settings change
 // (dimensions, timezone, display density). Each screen handles the fields it cares
 // about in its own Update; fields it doesn't use are ignored.

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -129,6 +129,7 @@ type PostDetailModel struct {
 
 	bookmarkedPostIDs  map[string]struct{}
 	bookmarkedReplyIDs map[string]struct{}
+	watchedPostIDs     map[string]struct{}
 }
 
 func NewPostDetailModel() PostDetailModel {
@@ -382,6 +383,13 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case WatchedPostIDsMsg:
+		m.watchedPostIDs = msg.PostIDs
+		if m.ready {
+			m = m.refreshContent()
+		}
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -502,6 +510,13 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 			if m.post.ID != "" {
 				postID := m.post.ID
 				return m, func() tea.Msg { return BookmarkPostMsg{PostID: postID} }
+			}
+			return m, nil
+		case "w":
+			// Watch applies to the thread root only — ignore when a reply is focused.
+			if m.selectedReply < 0 && m.post.ID != "" {
+				postID := m.post.ID
+				return m, func() tea.Msg { return ToggleWatchPostMsg{PostID: postID} }
 			}
 			return m, nil
 		case "up", "k":
@@ -665,10 +680,11 @@ func (m PostDetailModel) renderFullPost(selected bool) string {
 	innerWidth := m.width - 4
 
 	_, postBookmarked := m.bookmarkedPostIDs[m.post.ID]
+	_, postWatched := m.watchedPostIDs[m.post.ID]
 	left := lipgloss.JoinHorizontal(lipgloss.Top,
 		theme.Highlight.Render("@"+m.post.AuthorUsername),
 		theme.Subtle.Render("  "+displayTime(m.post.CreatedAt, m.location(), m.timeDisplayFormat, false)),
-	) + audioIcon(m.post.Attachments) + bookmarkIcon(postBookmarked)
+	) + audioIcon(m.post.Attachments) + bookmarkIcon(postBookmarked) + watchIcon(postWatched)
 	var rightParts []string
 	if ind := attachmentIndicator(m.post.Attachments); ind != "" {
 		rightParts = append(rightParts, ind)

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -15,15 +15,15 @@ const postMaxBodyLines = 4
 
 // RenderPost renders a model.Post as a bordered card matching the feed style.
 // selected controls the border colour (active vs inactive).
-// bookmarked adds a [★] badge to the header right side.
+// bookmarked adds a [★] badge; watched adds a [◉] badge — both in the header.
 // width is the full terminal width; loc and timeFormat control the timestamp display.
-func RenderPost(p model.Post, selected bool, bookmarked bool, width int, loc *time.Location, timeFormat string) string {
+func RenderPost(p model.Post, selected bool, bookmarked bool, watched bool, width int, loc *time.Location, timeFormat string) string {
 	innerWidth := width - 4
 
 	left := lipgloss.JoinHorizontal(lipgloss.Top,
 		theme.Highlight.Render("@"+p.AuthorUsername),
 		theme.Subtle.Render("  "+displayTime(p.CreatedAt, loc, timeFormat, false)),
-	) + audioIcon(p.Attachments) + bookmarkIcon(bookmarked)
+	) + audioIcon(p.Attachments) + bookmarkIcon(bookmarked) + watchIcon(watched)
 	var rightParts []string
 	if ind := attachmentIndicator(p.Attachments); ind != "" {
 		rightParts = append(rightParts, ind)
@@ -131,6 +131,14 @@ func audioIcon(attachments []model.Attachment) string {
 func bookmarkIcon(bookmarked bool) string {
 	if bookmarked {
 		return "  " + theme.Highlight.Render("★")
+	}
+	return ""
+}
+
+// watchIcon returns a ◉ icon (with leading spaces) when the thread is watched, else "".
+func watchIcon(watched bool) string {
+	if watched {
+		return "  " + theme.Highlight.Render("◉")
 	}
 	return ""
 }

--- a/internal/ui/screens/screens_test.go
+++ b/internal/ui/screens/screens_test.go
@@ -1356,3 +1356,32 @@ func TestJournal_SetFetching_ClearedBySetNotes(t *testing.T) {
 		t.Errorf("expected loading message to be gone after SetNotes, got: %q", view)
 	}
 }
+
+// --- RenderPost watch icon ---
+
+func TestRenderPost_WatchIconPresent(t *testing.T) {
+	p := model.Post{ID: "p1", AuthorUsername: "user", Content: "hello", CreatedAt: time.Now()}
+	out := screens.RenderPost(p, false, false, true, 80, time.UTC, "datetime")
+	if !strings.Contains(out, "◉") {
+		t.Errorf("expected ◉ watch icon in output, got: %q", out)
+	}
+}
+
+func TestRenderPost_WatchIconAbsentWhenNotWatched(t *testing.T) {
+	p := model.Post{ID: "p1", AuthorUsername: "user", Content: "hello", CreatedAt: time.Now()}
+	out := screens.RenderPost(p, false, false, false, 80, time.UTC, "datetime")
+	if strings.Contains(out, "◉") {
+		t.Errorf("expected no ◉ watch icon in output, got: %q", out)
+	}
+}
+
+func TestRenderPost_BookmarkAndWatchIconsStack(t *testing.T) {
+	p := model.Post{ID: "p1", AuthorUsername: "user", Content: "hello", CreatedAt: time.Now()}
+	out := screens.RenderPost(p, false, true, true, 80, time.UTC, "datetime")
+	if !strings.Contains(out, "★") {
+		t.Errorf("expected ★ bookmark icon in output")
+	}
+	if !strings.Contains(out, "◉") {
+		t.Errorf("expected ◉ watch icon in output")
+	}
+}

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -62,6 +62,7 @@ type TopicsModel struct {
 	width       int
 
 	bookmarkedPostIDs map[string]struct{}
+	watchedPostIDs    map[string]struct{}
 	height            int
 	ready             bool
 	err               error
@@ -190,6 +191,13 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 
 	case BookmarkedIDsMsg:
 		m.bookmarkedPostIDs = msg.PostIDs
+		if m.ready {
+			m = m.refreshContent()
+		}
+		return m, nil
+
+	case WatchedPostIDsMsg:
+		m.watchedPostIDs = msg.PostIDs
 		if m.ready {
 			m = m.refreshContent()
 		}
@@ -409,7 +417,8 @@ func (m TopicsModel) renderTopicItem(index int) string {
 
 func (m TopicsModel) renderPostItem(p model.Post, selected bool) string {
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
-	return RenderPost(p, selected, bookmarked, m.width, m.location(), m.timeDisplayFormat)
+	_, watched := m.watchedPostIDs[p.ID]
+	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat)
 }
 
 func (m TopicsModel) refreshContent() TopicsModel {


### PR DESCRIPTION
## Summary

- Implements the v0.5.1 thread-watching API (`GET/POST/DELETE /v1/posts/:id/watch`, `GET /v1/watches`)
- `w` toggles watch/unwatch on thread-root posts in feed and post detail (no-op when a reply is focused, matching web-UI behaviour)
- `◉` (fisheye) icon appears in the post header alongside `★` (bookmark) and `♫` (audio): `@author  5m ago  ★  ◉`
- Icon is visible in feed, post detail (root post only), guild threads, and topics
- All watched thread IDs are loaded progressively at login — all pages are fetched (limit=50 each), broadcasting after each page so icons appear as data arrives
- Optimistic toggle with revert-on-error, identical pattern to bookmarks

## Test plan

- [ ] Log in — `◉` icons appear on already-watched posts in the feed within a second or two
- [ ] Press `w` on a feed post — `◉` appears immediately (optimistic), confirm no error banner
- [ ] Press `w` again — `◉` disappears immediately
- [ ] Open a thread (`enter`) — `◉` shows on root post if watched; pressing `w` toggles it
- [ ] Navigate to a reply with `j` — pressing `w` does nothing (no icon change, no error)
- [ ] Both `★` and `◉` display side-by-side on a post that is bookmarked and watched
- [ ] `go test ./...`, `go vet ./...`, `staticcheck ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)