### PR TITLE
feat: update local watch state on reply when auto-watch-on-reply is on

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -660,6 +660,17 @@ func (a App) handlePostDetail(msg tea.Msg) (App, tea.Cmd, bool) {
 	case screens.SubmitReplyMsg:
 		return a, a.createReplyCmd(msg.PostID, msg.Content, msg.ParentReplyID), true
 	case replyCreatedMsg:
+		if a.settings.AutoWatchOnReply {
+			if _, alreadyWatched := a.watchedPostIDs[msg.postID]; !alreadyWatched {
+				newIDs := make(map[string]struct{}, len(a.watchedPostIDs)+1)
+				for k := range a.watchedPostIDs {
+					newIDs[k] = struct{}{}
+				}
+				newIDs[msg.postID] = struct{}{}
+				a.watchedPostIDs = newIDs
+				a.broadcastWatchedIDs()
+			}
+		}
 		return a, a.loadRepliesCmd(msg.postID), true
 	case screens.BackToFeedMsg:
 		a.active = a.postDetailReturn


### PR DESCRIPTION
## Summary

- When a reply is posted and `AutoWatchOnReply` is enabled, the thread is immediately added to the local `watchedPostIDs` so the ◉ indicator appears without delay.
- No explicit `WatchPost` API call is made — the server handles the subscription automatically when the reply is created.
- Skips the update if the thread is already watched.

## Test plan

- [x] Enable "Auto-watch on reply" in settings
- [x] Reply to an unwatched thread — ◉ icon should appear on the thread immediately after the reply is submitted
- [x] Reply to an already-watched thread — no change in watch state
- [x] Disable "Auto-watch on reply" and reply to an unwatched thread — ◉ icon should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)