### PR TITLE
feat: Miller Columns layout + feed tab lazy reload

### DIFF
--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -66,6 +66,9 @@ type Config struct {
 	// protocol is detected. "terminal" (default) displays the image in a
 	// fullscreen modal; "browser" always opens in the OS default browser.
 	ImageViewer string `json:"imageViewer,omitempty"`
+
+	// Layout selects the UI layout. "" or "tabs" = tab bar (default); "miller" = sidebar columns.
+	Layout string `json:"layout,omitempty"`
 }
 
 // GetMaxThreadDepth returns MaxThreadDepth, substituting the default (3) when

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -42,8 +42,9 @@ const (
 type focusTarget int
 
 const (
-	focusMenu focusTarget = iota
-	focusList             // reserved for future list navigation
+	focusMenu   focusTarget = iota
+	focusList               // list pane (compact post list in 3-pane Miller)
+	focusDetail             // reading pane (full post view in 3-pane Miller)
 )
 
 // availableThemes is the ordered list of selectable themes shown in the picker.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1176,6 +1176,22 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 			return a, nil, true
 		}
 		a.guilds = a.guilds.SetGuildPosts(msg.posts, msg.cursor)
+		var detailCmd tea.Cmd
+		a.guilds, detailCmd = a.guilds.CurrentDetailCmd()
+		if detailCmd != nil {
+			return a, detailCmd, true
+		}
+		return a, nil, true
+
+	case screens.LoadGuildThreadMsg:
+		return a, a.loadGuildThreadCmd(msg.PostID), true
+
+	case screens.GuildThreadRepliesMsg:
+		a.guilds, _ = a.guilds.Update(msg)
+		return a, nil, true
+
+	case screens.GuildThreadNavMsg:
+		a.guilds, _ = a.guilds.Update(msg)
 		return a, nil, true
 
 	case screens.LoadMoreGuildPostsMsg:
@@ -1275,6 +1291,22 @@ func (a App) handleTopics(msg tea.Msg) (App, tea.Cmd, bool) {
 
 	case topicPostsLoadedMsg:
 		a.topics = a.topics.SetTopicPosts(msg.posts, msg.cursor)
+		var detailCmd tea.Cmd
+		a.topics, detailCmd = a.topics.CurrentDetailCmd()
+		if detailCmd != nil {
+			return a, detailCmd, true
+		}
+		return a, nil, true
+
+	case screens.LoadTopicThreadMsg:
+		return a, a.loadTopicThreadCmd(msg.PostID), true
+
+	case screens.TopicThreadRepliesMsg:
+		a.topics, _ = a.topics.Update(msg)
+		return a, nil, true
+
+	case screens.TopicThreadNavMsg:
+		a.topics, _ = a.topics.Update(msg)
 		return a, nil, true
 
 	case screens.LoadMoreTopicPostsMsg:
@@ -2251,6 +2283,26 @@ func (a *App) loadFeedDetailCmd(postID string) tea.Cmd {
 			return screens.FeedDetailRepliesMsg{PostID: postID}
 		}
 		return screens.FeedDetailRepliesMsg{PostID: postID, Replies: replies}
+	}
+}
+
+func (a *App) loadGuildThreadCmd(postID string) tea.Cmd {
+	return func() tea.Msg {
+		replies, err := a.client.GetPostReplies(postID)
+		if err != nil {
+			return screens.GuildThreadRepliesMsg{PostID: postID}
+		}
+		return screens.GuildThreadRepliesMsg{PostID: postID, Replies: replies}
+	}
+}
+
+func (a *App) loadTopicThreadCmd(postID string) tea.Cmd {
+	return func() tea.Msg {
+		replies, err := a.client.GetPostReplies(postID)
+		if err != nil {
+			return screens.TopicThreadRepliesMsg{PostID: postID}
+		}
+		return screens.TopicThreadRepliesMsg{PostID: postID, Replies: replies}
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -80,6 +80,7 @@ func randomCyberRune(exclude rune) rune {
 
 type App struct {
 	layout      Layout
+	layoutName  string // "tabs" (default) or "miller"; used when persisting to config
 	client      api.Client
 	tokens      model.Tokens
 	currentUser model.User
@@ -204,6 +205,7 @@ type App struct {
 func NewApp(client api.Client) App {
 	return App{
 		layout:             TabsLayout{},
+		layoutName:         "tabs",
 		client:             client,
 		active:             screenLogin,
 		focus:              focusMenu,
@@ -259,7 +261,16 @@ func (a App) WithSavedSession(s config.Config) App {
 	a.wanderLust = s.WanderLust
 	a.maxThreadDepth = s.GetMaxThreadDepth()
 	a.imageViewer = s.ImageViewer
+	a.layoutName = s.Layout
+	a.layout = layoutFromName(s.Layout)
 	return a
+}
+
+func layoutFromName(name string) Layout {
+	if name == "miller" {
+		return MillerLayout{}
+	}
+	return TabsLayout{}
 }
 
 // WithGraphicsProtocol sets the terminal graphics protocol detected at startup.
@@ -415,7 +426,7 @@ func (a App) updateAll(msg tea.Msg) App {
 // Call this whenever loc, relaxed, or dimensions change outside of a
 // WindowSizeMsg (e.g. after login, timezone change, or density toggle).
 func (a *App) broadcastConfig() {
-	msg := screens.SharedConfigMsg{Width: a.width, Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, OwnGuildSlug: a.currentUser.GuildSlug}
+	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
 	*a = a.updateAll(msg)
 }
 
@@ -792,6 +803,7 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		td := msg.MaxThreadDepth
 		tz := msg.Timezone
 		iv := msg.ImageViewer
+		ln := msg.LayoutName
 		return a, func() tea.Msg {
 			if err := a.client.UpdateSettings(s); err != nil {
 				return actionErrMsg{err}
@@ -801,8 +813,9 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 				cfg.MaxThreadDepth = td
 				cfg.Timezone = tz
 				cfg.ImageViewer = iv
+				cfg.Layout = ln
 			})
-			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv}
+			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, layoutName: ln}
 		}, true
 
 	case settingsSavedMsg:
@@ -811,8 +824,10 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.maxThreadDepth = msg.maxThreadDepth
 		a.timezone = msg.timezone
 		a.imageViewer = msg.imageViewer
+		a.layoutName = msg.layoutName
+		a.layout = layoutFromName(msg.layoutName)
 		a.loc = config.ParseTimezoneLabel(msg.timezone)
-		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer)
+		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.layoutName)
 		a.broadcastConfig()
 		a.refreshViewports()
 		return a, nil, true
@@ -1810,6 +1825,7 @@ type settingsSavedMsg struct {
 	maxThreadDepth int
 	timezone       string
 	imageViewer    string
+	layoutName     string
 }
 type wanderTickMsg struct{}
 type wanderDoneMsg struct{ at time.Time } // zero At means no update was made

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -329,9 +329,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if m, ok := msg.(tea.WindowSizeMsg); ok {
 		a = a.applyWindowSize(m)
-		cmd := a.delegateUpdate(msg)
-		a.broadcastConfig()
-		return a, cmd
+		contentMsg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(m.Width), Height: m.Height}
+		return a, a.delegateUpdate(contentMsg)
 	}
 	// Any keypress dismisses a visible notification early. We do NOT return here,
 	// so the key still flows on to do its normal job; bumping notifyGen neutralizes
@@ -463,7 +462,8 @@ func (a *App) broadcastWatchedIDs() {
 func (a App) applyWindowSize(m tea.WindowSizeMsg) App {
 	a.width = m.Width
 	a.height = m.Height
-	return a.updateAll(m)
+	contentMsg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(m.Width), Height: m.Height}
+	return a.updateAll(contentMsg)
 }
 
 // handleKeys processes tea.KeyMsg events: modal intercepts, focused-input
@@ -1538,7 +1538,7 @@ func (a App) handleThemePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // theme by re-broadcasting the current terminal size. Called synchronously so
 // View() sees fresh content in the same frame.
 func (a *App) refreshViewports() {
-	msg := tea.WindowSizeMsg{Width: a.width, Height: a.height}
+	msg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(a.width), Height: a.height}
 	a.feed, _ = a.feed.Update(msg)
 	a.chatrooms, _ = a.chatrooms.Update(msg)
 	a.cmail, _ = a.cmail.Update(msg)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -329,7 +329,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if m, ok := msg.(tea.WindowSizeMsg); ok {
 		a = a.applyWindowSize(m)
-		contentMsg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(m.Width), Height: m.Height}
+		contentMsg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(m.Width), Height: a.layout.ContentHeight(m.Height)}
 		return a, a.delegateUpdate(contentMsg)
 	}
 	// Any keypress dismisses a visible notification early. We do NOT return here,
@@ -462,7 +462,7 @@ func (a *App) broadcastWatchedIDs() {
 func (a App) applyWindowSize(m tea.WindowSizeMsg) App {
 	a.width = m.Width
 	a.height = m.Height
-	contentMsg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(m.Width), Height: m.Height}
+	contentMsg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(m.Width), Height: a.layout.ContentHeight(m.Height)}
 	return a.updateAll(contentMsg)
 }
 
@@ -1538,7 +1538,7 @@ func (a App) handleThemePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // theme by re-broadcasting the current terminal size. Called synchronously so
 // View() sees fresh content in the same frame.
 func (a *App) refreshViewports() {
-	msg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(a.width), Height: a.height}
+	msg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(a.width), Height: a.layout.ContentHeight(a.height)}
 	a.feed, _ = a.feed.Update(msg)
 	a.chatrooms, _ = a.chatrooms.Update(msg)
 	a.cmail, _ = a.cmail.Update(msg)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -562,9 +562,24 @@ func (a App) handleFeed(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.feed = a.feed.SetPosts(msg.posts, msg.cursor)
 		var detailCmd tea.Cmd
 		a.feed, detailCmd = a.feed.CurrentDetailCmd()
+		// In Miller layout the compact list is 1 row per post; auto-fill if the
+		// initial page is shorter than the column height.
+		if _, isMiller := a.layout.(MillerLayout); isMiller && msg.cursor != "" {
+			compactH := a.height - 2 // header row + status bar
+			if a.feed.PostCount() < compactH {
+				return a, tea.Batch(detailCmd, a.loadFeedPageCmd(msg.cursor)), true
+			}
+		}
 		return a, detailCmd, true
 	case feedPageMsg:
 		a.feed = a.feed.AppendPosts(msg.posts, msg.cursor)
+		// Keep auto-filling until the compact list column is full.
+		if _, isMiller := a.layout.(MillerLayout); isMiller && msg.cursor != "" {
+			compactH := a.height - 2
+			if a.feed.PostCount() < compactH {
+				return a, a.loadFeedPageCmd(msg.cursor), true
+			}
+		}
 		return a, nil, true
 	case screens.RefreshFeedMsg:
 		return a, a.loadFeedCmd(), true
@@ -573,6 +588,9 @@ func (a App) handleFeed(msg tea.Msg) (App, tea.Cmd, bool) {
 	case screens.LoadFeedDetailMsg:
 		return a, a.loadFeedDetailCmd(msg.PostID), true
 	case screens.FeedDetailRepliesMsg:
+		a.feed, _ = a.feed.Update(msg)
+		return a, nil, true
+	case screens.FeedDetailNavMsg:
 		a.feed, _ = a.feed.Update(msg)
 		return a, nil, true
 	case screens.ShowPostMsg:

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -329,6 +329,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if m, ok := msg.(tea.WindowSizeMsg); ok {
 		a = a.applyWindowSize(m)
+		a.broadcastConfig()
 		return a, a.delegateUpdate(msg)
 	}
 	// Any keypress dismisses a visible notification early. We do NOT return here,

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -560,7 +560,9 @@ func (a App) handleFeed(msg tea.Msg) (App, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case feedLoadedMsg:
 		a.feed = a.feed.SetPosts(msg.posts, msg.cursor)
-		return a, nil, true
+		var detailCmd tea.Cmd
+		a.feed, detailCmd = a.feed.CurrentDetailCmd()
+		return a, detailCmd, true
 	case feedPageMsg:
 		a.feed = a.feed.AppendPosts(msg.posts, msg.cursor)
 		return a, nil, true
@@ -568,6 +570,11 @@ func (a App) handleFeed(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, a.loadFeedCmd(), true
 	case screens.LoadMoreFeedMsg:
 		return a, a.loadFeedPageCmd(msg.Cursor), true
+	case screens.LoadFeedDetailMsg:
+		return a, a.loadFeedDetailCmd(msg.PostID), true
+	case screens.FeedDetailRepliesMsg:
+		a.feed, _ = a.feed.Update(msg)
+		return a, nil, true
 	case screens.ShowPostMsg:
 		a.postDetailReturn = a.active
 		a.active = screenPostDetail
@@ -2216,6 +2223,16 @@ func (a *App) loadRepliesCmd(postID string) tea.Cmd {
 			return errMsg{err}
 		}
 		return repliesLoadedMsg{replies: replies}
+	}
+}
+
+func (a *App) loadFeedDetailCmd(postID string) tea.Cmd {
+	return func() tea.Msg {
+		replies, err := a.client.GetPostReplies(postID)
+		if err != nil {
+			return screens.FeedDetailRepliesMsg{PostID: postID}
+		}
+		return screens.FeedDetailRepliesMsg{PostID: postID, Replies: replies}
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -329,8 +329,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if m, ok := msg.(tea.WindowSizeMsg); ok {
 		a = a.applyWindowSize(m)
+		cmd := a.delegateUpdate(msg)
 		a.broadcastConfig()
-		return a, a.delegateUpdate(msg)
+		return a, cmd
 	}
 	// Any keypress dismisses a visible notification early. We do NOT return here,
 	// so the key still flows on to do its normal job; bumping notifyGen neutralizes

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -9,4 +9,5 @@ type Layout interface {
 	HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool)
 	DelegateUpdate(msg tea.Msg, a App) (App, tea.Cmd)
 	HasFocusedInput(a App) bool
+	ContentWidth(termWidth int) int
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -10,4 +10,8 @@ type Layout interface {
 	DelegateUpdate(msg tea.Msg, a App) (App, tea.Cmd)
 	HasFocusedInput(a App) bool
 	ContentWidth(termWidth int) int
+	// ContentHeight returns the height to send to screens in WindowSizeMsg. Screens subtract
+	// theme.ChromeHeight to get viewport height; layouts that use fewer chrome rows must compensate
+	// so the viewport fills the available content pane exactly.
+	ContentHeight(termHeight int) int
 }

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -153,8 +153,11 @@ func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 			if a.active != screenLogin {
 				a.cmail = a.cmail.CancelSubscription()
 				a.active = screenFeed
-				a.feed = a.feed.SetFetching()
-				return a, a.loadFeedCmd(), true
+				if !a.feed.IsLoaded() {
+					a.feed = a.feed.SetFetching()
+					return a, a.loadFeedCmd(), true
+				}
+				return a, nil, true
 			}
 		case "2":
 			if a.active != screenLogin {

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -26,7 +26,7 @@ func (l MillerLayout) View(a App) string {
 	navPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderNav(a))
 	contentPane := lipgloss.NewStyle().Width(contentW).Height(contentH).MaxHeight(contentH).Render(l.renderContent(a))
 
-	sep := theme.Subtle.Render(strings.Repeat("│\n", contentH))
+	sep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
 	base := lipgloss.JoinVertical(lipgloss.Left,
 		lipgloss.JoinHorizontal(lipgloss.Top, navPane, sep, contentPane),
 		l.renderBottomBar(a),
@@ -222,8 +222,14 @@ func (l MillerLayout) HasFocusedInput(a App) bool {
 	return false
 }
 
-func (l MillerLayout) ContentWidth(termWidth int) int {
-	return termWidth - millerSidebarWidth
+func (l MillerLayout) ContentWidth(termWidth int) int { return termWidth - millerSidebarWidth }
+
+// ContentHeight inflates the height sent to screens so their viewport (which subtracts
+// theme.ChromeHeight = 3) fills the content pane exactly. Miller layout only uses 1 chrome
+// row (the status bar), so we add back the 2 rows that TabsLayout would have used for the
+// tab bar and separator.
+func (l MillerLayout) ContentHeight(termHeight int) int {
+	return termHeight + theme.TabBarHeight + theme.SeparatorHeight
 }
 
 func (l MillerLayout) renderNav(a App) string {

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -316,6 +316,13 @@ func (l MillerLayout) renderNotification(a App) string {
 		Render(prefix + text + suffix)
 }
 
+func (l MillerLayout) screenHints(a App) []hint {
+	if a.focus == focusMenu {
+		return []hint{{"j/k", "nav"}, {"l/↵", "enter"}, {"1-8", "jump"}, {"?", "more"}}
+	}
+	return append([]hint{{"h/←", "menu"}}, TabsLayout{}.screenHints(a)...)
+}
+
 func (l MillerLayout) renderStatusBar(a App) string {
 	user := sbStyle().Foreground(theme.ColorCyan).Bold(true)
 	meta := sbStyle().Foreground(theme.ColorWhite)
@@ -329,21 +336,49 @@ func (l MillerLayout) renderStatusBar(a App) string {
 	if tzLabel == "" {
 		tzLabel = "UTC"
 	}
-	timeFmt := a.settings.TimeDisplayFormat
-	if timeFmt == "" {
-		timeFmt = "datetime"
-	}
 
 	username := user.Render("@" + a.currentUser.Username)
 	infoItems := []string{
-		meta.Render(densityLabel),
-		meta.Render(timeFmt),
-		meta.Render(tzLabel),
-		meta.Render("miller"),
+		sep + meta.Render(densityLabel),
+		sep + meta.Render(tzLabel),
+		sep + meta.Render("miller"),
 	}
-	info := strings.Join(infoItems, sep)
-	spacer := strings.Repeat(" ", max(0, a.width-lipgloss.Width(username)-lipgloss.Width(info)-2))
-	return sbStyle().Width(a.width).Render(username + spacer + info)
+
+	hints := l.screenHints(a)
+	const barPad = 2
+
+	measure := func(numInfo, numHints int) int {
+		left := lipgloss.Width(username)
+		for _, item := range infoItems[:numInfo] {
+			left += lipgloss.Width(item)
+		}
+		right := lipgloss.Width(renderHints(hints[:numHints]))
+		return left + right + barPad
+	}
+
+	numInfo := len(infoItems)
+	numHints := len(hints)
+	for numInfo >= 0 {
+		if measure(numInfo, numHints) <= a.width {
+			break
+		}
+		numInfo--
+	}
+	if numInfo < 0 {
+		numInfo = 0
+		for numHints > 1 && measure(0, numHints) > a.width {
+			numHints--
+		}
+	}
+
+	bg := sbStyle()
+	leftParts := []string{username}
+	leftParts = append(leftParts, infoItems[:numInfo]...)
+	left := lipgloss.JoinHorizontal(lipgloss.Top, leftParts...)
+	right := renderHints(hints[:numHints])
+	spacer := bg.Width(max(0, a.width-lipgloss.Width(left)-lipgloss.Width(right)-barPad)).Render("")
+	bar := lipgloss.JoinHorizontal(lipgloss.Top, left, spacer, right)
+	return bg.Padding(0, 1).Render(bar)
 }
 
 func (l MillerLayout) renderThemePicker(a App) string {

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -1,0 +1,419 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
+)
+
+const millerSidebarWidth = 18 // nav pane (17 chars) + "│" separator (1 char)
+
+// MillerLayout renders a left navigation sidebar alongside the active screen.
+type MillerLayout struct{}
+
+func (l MillerLayout) View(a App) string {
+	if a.active == screenLogin {
+		return a.login.View()
+	}
+
+	contentH := a.height - 1 // full height minus bottom bar
+	navPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderNav(a))
+	contentPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderContent(a))
+
+	sep := theme.Subtle.Render(strings.Repeat("│\n", contentH))
+	base := lipgloss.JoinVertical(lipgloss.Left,
+		lipgloss.JoinHorizontal(lipgloss.Top, navPane, sep, contentPane),
+		l.renderBottomBar(a),
+	)
+
+	if a.themePickerOpen {
+		return overlayCenter(base, l.renderThemePicker(a), a.width, a.height)
+	}
+	if a.helpModalOpen {
+		return overlayCenter(base, l.renderHelpModal(a), a.width, a.height)
+	}
+	if a.urlPickerOpen {
+		return overlayCenter(base, l.renderURLPicker(a), a.width, a.height)
+	}
+	if a.imageModalOpen {
+		textModal := l.renderImageModal(a)
+		composed := overlayCenter(base, textModal, a.width, a.height)
+		modalW := lipgloss.Width(textModal)
+		modalH := len(strings.Split(textModal, "\n"))
+		xOff := (a.width - modalW) / 2
+		yOff := (a.height - modalH) / 2
+		if xOff < 0 {
+			xOff = 0
+		}
+		if yOff < 0 {
+			yOff = 0
+		}
+		imgRow := yOff + 2
+		imgCol := xOff + 3
+		return composed + fmt.Sprintf("\x1b[%d;%dH%s\x1b[%d;1H", imgRow, imgCol, a.imageModalEncoded, a.height)
+	}
+	if a.imageNeedsCleanup && a.graphicsProtocol == imgview.ProtocolKitty {
+		modalH := a.imageModalRows + 2
+		yOff := (a.height - modalH) / 2
+		if yOff < 0 {
+			yOff = 0
+		}
+		lines := strings.Split(base, "\n")
+		if yOff < len(lines) {
+			lines[yOff] = "\x1b_Ga=d,d=A\x1b\\" + lines[yOff]
+		}
+		return strings.Join(lines, "\n")
+	}
+	return base
+}
+
+func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
+	if a.focus == focusMenu {
+		switch msg.String() {
+		case "j", "down":
+			if a.active != screenLogin {
+				var cmd tea.Cmd
+				a, cmd = navigateTabBy(a, +1)
+				return a, cmd, true
+			}
+		case "k", "up":
+			if a.active != screenLogin {
+				var cmd tea.Cmd
+				a, cmd = navigateTabBy(a, -1)
+				return a, cmd, true
+			}
+		case "l", "right", "enter":
+			if a.active != screenLogin {
+				a.focus = focusList
+				return a, nil, true
+			}
+		case "1":
+			if a.active != screenLogin {
+				a.cmail = a.cmail.CancelSubscription()
+				a.active = screenFeed
+				a.feed = a.feed.SetFetching()
+				return a, a.loadFeedCmd(), true
+			}
+		case "2":
+			if a.active != screenLogin {
+				a.cmail = a.cmail.CancelSubscription()
+				a.active = screenNotifications
+				a.notifications = a.notifications.SetFetching()
+				return a, a.loadNotifsCmd(), true
+			}
+		case "3":
+			if a.active != screenLogin {
+				a.cmail = a.cmail.CancelSubscription()
+				a.active = screenJournal
+				a.journal = a.journal.SetFetching()
+				return a, a.loadJournalCmd(), true
+			}
+		case "4":
+			if a.active != screenLogin {
+				a.cmail = a.cmail.CancelSubscription()
+				a.active = screenBookmarks
+				if !a.bookmarks.IsLoaded() {
+					a.bookmarks = a.bookmarks.SetFetching()
+					return a, a.loadBookmarksCmd(""), true
+				}
+				return a, nil, true
+			}
+		case "5":
+			if a.active != screenLogin {
+				a.cmail = a.cmail.CancelSubscription()
+				a.active = screenGuilds
+				if !a.guilds.IsLoaded() {
+					a.guilds = a.guilds.SetFetching()
+					return a, a.loadGuildsCmd(""), true
+				}
+				return a, nil, true
+			}
+		case "6":
+			if a.active != screenLogin {
+				a.cmail = a.cmail.CancelSubscription()
+				a.active = screenTopics
+				if !a.topics.IsLoaded() {
+					a.topics = a.topics.SetFetching()
+					return a, a.loadTopicsCmd(), true
+				}
+				return a, nil, true
+			}
+		case "7":
+			if a.active != screenLogin {
+				a.cmail = a.cmail.CancelSubscription()
+				a.active = screenProfile
+				return a, a.loadProfileCmd(), true
+			}
+		case "8":
+			if a.active != screenLogin {
+				a.cmail = a.cmail.CancelSubscription()
+				a.active = screenSettings
+				return a, nil, true
+			}
+		}
+		return a, nil, false
+	}
+
+	// Content pane focused: h/left returns to nav.
+	if msg.String() == "h" || msg.String() == "left" {
+		a.focus = focusMenu
+		return a, nil, true
+	}
+	return a, nil, false
+}
+
+func (l MillerLayout) DelegateUpdate(msg tea.Msg, a App) (App, tea.Cmd) {
+	var cmd tea.Cmd
+	switch a.active {
+	case screenLogin:
+		a.login, cmd = a.login.Update(msg)
+	case screenFeed:
+		a.feed, cmd = a.feed.Update(msg)
+	case screenChatrooms:
+		a.chatrooms, cmd = a.chatrooms.Update(msg)
+	case screenCMail:
+		a.cmail, cmd = a.cmail.Update(msg)
+	case screenProfile:
+		a.profile, cmd = a.profile.Update(msg)
+	case screenPostDetail:
+		a.postDetail, cmd = a.postDetail.Update(msg)
+	case screenNotifications:
+		a.notifications, cmd = a.notifications.Update(msg)
+	case screenSettings:
+		a.settingsScreen, cmd = a.settingsScreen.Update(msg)
+	case screenBookmarks:
+		a.bookmarks, cmd = a.bookmarks.Update(msg)
+	case screenGuilds:
+		a.guilds, cmd = a.guilds.Update(msg)
+	case screenTopics:
+		a.topics, cmd = a.topics.Update(msg)
+	case screenJournal:
+		a.journal, cmd = a.journal.Update(msg)
+	}
+	return a, cmd
+}
+
+func (l MillerLayout) HasFocusedInput(a App) bool {
+	if a.focus == focusMenu {
+		return false
+	}
+	switch a.active {
+	case screenChatrooms:
+		return a.chatrooms.InputFocused()
+	case screenCMail:
+		return a.cmail.InputFocused()
+	case screenPostDetail:
+		return a.postDetail.ComposeActive()
+	case screenFeed:
+		return a.feed.ComposeActive()
+	case screenGuilds:
+		return a.guilds.ComposeActive()
+	case screenProfile:
+		return a.profile.ComposeActive()
+	case screenJournal:
+		return a.journal.ComposeActive()
+	}
+	return false
+}
+
+func (l MillerLayout) ContentWidth(termWidth int) int {
+	return termWidth - millerSidebarWidth
+}
+
+func (l MillerLayout) renderNav(a App) string {
+	navW := millerSidebarWidth - 1 // leave 1 col for the "│" separator
+	header := lipgloss.NewStyle().Width(navW).Render(theme.Title.Render("spaces"))
+	sep := theme.Subtle.Render(strings.Repeat("─", navW))
+
+	rows := []string{header, sep}
+	for _, t := range menuTabs {
+		label := t.label
+		if t.s == screenNotifications && a.polledUnreadCount > 0 {
+			label = fmt.Sprintf("%s ●%d", label, a.polledUnreadCount)
+		}
+		var row string
+		if a.active == t.s {
+			if a.focus == focusMenu {
+				row = theme.Highlight.Width(navW).Render("▶ " + label)
+			} else {
+				row = theme.Subtle.Width(navW).Render("▶ " + label)
+			}
+		} else {
+			row = theme.Subtle.Width(navW).Render("  " + label)
+		}
+		rows = append(rows, row)
+	}
+	return strings.Join(rows, "\n")
+}
+
+func (l MillerLayout) renderContent(a App) string {
+	switch a.active {
+	case screenFeed:
+		return a.feed.View()
+	case screenChatrooms:
+		return a.chatrooms.View()
+	case screenCMail:
+		return a.cmail.View()
+	case screenProfile:
+		return a.profile.View()
+	case screenPostDetail:
+		return a.postDetail.View()
+	case screenNotifications:
+		return a.notifications.View()
+	case screenSettings:
+		return a.settingsScreen.View()
+	case screenBookmarks:
+		return a.bookmarks.View()
+	case screenGuilds:
+		return a.guilds.View()
+	case screenTopics:
+		return a.topics.View()
+	case screenJournal:
+		return a.journal.View()
+	}
+	return ""
+}
+
+func (l MillerLayout) renderBottomBar(a App) string {
+	if a.notifyText == "" {
+		return l.renderStatusBar(a)
+	}
+	return l.renderNotification(a)
+}
+
+func (l MillerLayout) renderNotification(a App) string {
+	color := theme.ColorGreen
+	prefix := "✓ "
+	switch a.notifyLevel {
+	case notifyWarn:
+		color = theme.ColorYellow
+		prefix = "! "
+	case notifyError:
+		color = theme.ColorRed
+		prefix = "✕ "
+	}
+	const suffix = "  (any key to dismiss)"
+	budget := a.width - lipgloss.Width(prefix) - lipgloss.Width(suffix) - 2
+	text := ansi.Truncate(a.notifyText, max(0, budget), "…")
+	return lipgloss.NewStyle().
+		Foreground(theme.ColorBackground).
+		Background(color).
+		Bold(true).
+		Width(a.width).
+		Padding(0, 1).
+		Render(prefix + text + suffix)
+}
+
+func (l MillerLayout) renderStatusBar(a App) string {
+	user := sbStyle().Foreground(theme.ColorCyan).Bold(true)
+	meta := sbStyle().Foreground(theme.ColorWhite)
+	sep := sbStyle().Foreground(theme.ColorMuted).Render(" · ")
+
+	densityLabel := "dense"
+	if a.relaxed {
+		densityLabel = "relaxed"
+	}
+	tzLabel := a.timezone
+	if tzLabel == "" {
+		tzLabel = "UTC"
+	}
+	timeFmt := a.settings.TimeDisplayFormat
+	if timeFmt == "" {
+		timeFmt = "datetime"
+	}
+
+	username := user.Render("@" + a.currentUser.Username)
+	infoItems := []string{
+		meta.Render(densityLabel),
+		meta.Render(timeFmt),
+		meta.Render(tzLabel),
+		meta.Render("miller"),
+	}
+	info := strings.Join(infoItems, sep)
+	spacer := strings.Repeat(" ", max(0, a.width-lipgloss.Width(username)-lipgloss.Width(info)-2))
+	return sbStyle().Width(a.width).Render(username + spacer + info)
+}
+
+func (l MillerLayout) renderThemePicker(a App) string {
+	var rows []string
+	for i, name := range availableThemes {
+		if i == a.themePickerCursor {
+			rows = append(rows, theme.Highlight.Render("▸ "+name))
+		} else {
+			rows = append(rows, theme.Subtle.Render("  "+name))
+		}
+	}
+	body := lipgloss.JoinVertical(lipgloss.Left,
+		theme.Title.Render("theme"),
+		"",
+		strings.Join(rows, "\n"),
+		"",
+		theme.Subtle.Render("↑↓ select   enter apply   esc cancel"),
+	)
+	return theme.ActiveBorder.Render(body)
+}
+
+func (l MillerLayout) renderHelpModal(a App) string {
+	title := theme.Title.Render("shortcuts")
+	sectionStyle := theme.Subtle.Bold(true)
+	row := func(key, desc string) string {
+		k := theme.Highlight.Render(fmt.Sprintf("%-14s", key))
+		return lipgloss.JoinHorizontal(lipgloss.Top, k, theme.Subtle.Render(desc))
+	}
+
+	globalSection := lipgloss.JoinVertical(lipgloss.Left,
+		sectionStyle.Render("global"),
+		row("j/k", "move nav · select section"),
+		row("l / enter", "enter content pane"),
+		row("h", "return to nav pane"),
+		row("1-8", "jump to section"),
+		row("t", "theme"),
+		row("v", "density"),
+		row("o", "open url"),
+		row("q", "quit"),
+	)
+
+	body := lipgloss.JoinVertical(lipgloss.Left,
+		title,
+		"",
+		globalSection,
+		"",
+		theme.Subtle.Render("any key · close"),
+		renderedVersionLine,
+	)
+	return theme.ActiveBorder.Render(body)
+}
+
+func (l MillerLayout) renderURLPicker(a App) string {
+	title := theme.Title.Render("open url")
+	items := make([]string, len(a.urlPickerItems))
+	for i, u := range a.urlPickerItems {
+		display := u
+		if len(display) > 60 {
+			display = display[:57] + "..."
+		}
+		if i == a.urlPickerCursor {
+			items[i] = theme.Highlight.Render("▸ " + display)
+		} else {
+			items[i] = theme.Subtle.Render("  " + display)
+		}
+	}
+	hint := theme.Subtle.Render("↑↓ select   enter open   esc cancel")
+	rows := append([]string{title, ""}, items...)
+	rows = append(rows, "", hint)
+	return theme.ActiveBorder.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}
+
+func (l MillerLayout) renderImageModal(a App) string {
+	blankLine := strings.Repeat(" ", a.imageModalCols)
+	lines := make([]string, a.imageModalRows)
+	for i := range lines {
+		lines[i] = blankLine
+	}
+	return theme.ActiveBorder.Render(strings.Join(lines, "\n"))
+}

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
-const millerSidebarWidth = 18  // nav pane (17 chars) + "│" separator (1 char)
+const millerSidebarWidth = 22  // nav pane (21 chars) + "│" separator (1 char)
 const millerListWidth = 42     // compact post list pane width in 3-pane Feed view
 const millerHeaderHeight = 1   // column title row at the top of the layout
 
@@ -235,6 +235,8 @@ func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 
 	// Reading pane focused (3-pane Miller).
 	if a.focus == focusDetail {
+		paneH := a.height - 1 - millerHeaderHeight
+		paneW := (a.width - millerSidebarWidth) - millerListWidth - 1
 		switch msg.String() {
 		case "h", "left":
 			a.focus = focusList
@@ -242,20 +244,26 @@ func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 		case "j", "down":
 			switch a.active {
 			case screenGuilds:
-				return a, func() tea.Msg { return screens.GuildThreadNavMsg{Delta: +1} }, true
+				ph, pw := paneH, paneW
+				return a, func() tea.Msg { return screens.GuildThreadNavMsg{Delta: +1, PaneHeight: ph, PaneWidth: pw} }, true
 			case screenTopics:
-				return a, func() tea.Msg { return screens.TopicThreadNavMsg{Delta: +1} }, true
+				ph, pw := paneH, paneW
+				return a, func() tea.Msg { return screens.TopicThreadNavMsg{Delta: +1, PaneHeight: ph, PaneWidth: pw} }, true
 			default:
-				return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: +1} }, true
+				ph, pw := paneH, paneW
+				return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: +1, PaneHeight: ph, PaneWidth: pw} }, true
 			}
 		case "k", "up":
 			switch a.active {
 			case screenGuilds:
-				return a, func() tea.Msg { return screens.GuildThreadNavMsg{Delta: -1} }, true
+				ph, pw := paneH, paneW
+				return a, func() tea.Msg { return screens.GuildThreadNavMsg{Delta: -1, PaneHeight: ph, PaneWidth: pw} }, true
 			case screenTopics:
-				return a, func() tea.Msg { return screens.TopicThreadNavMsg{Delta: -1} }, true
+				ph, pw := paneH, paneW
+				return a, func() tea.Msg { return screens.TopicThreadNavMsg{Delta: -1, PaneHeight: ph, PaneWidth: pw} }, true
 			default:
-				return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: -1} }, true
+				ph, pw := paneH, paneW
+				return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: -1, PaneHeight: ph, PaneWidth: pw} }, true
 			}
 		}
 		// enter, r, n, etc. fall through to DelegateUpdate

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -8,11 +8,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+	"github.com/ragnar/cyber-tui/internal/ui/screens"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
-const millerSidebarWidth = 18 // nav pane (17 chars) + "│" separator (1 char)
-const millerListWidth = 42    // compact post list pane width in 3-pane Feed view
+const millerSidebarWidth = 18  // nav pane (17 chars) + "│" separator (1 char)
+const millerListWidth = 42     // compact post list pane width in 3-pane Feed view
+const millerHeaderHeight = 1   // column title row at the top of the layout
 
 // MillerLayout renders a left navigation sidebar alongside the active screen.
 type MillerLayout struct{}
@@ -22,14 +24,23 @@ func (l MillerLayout) View(a App) string {
 		return a.login.View()
 	}
 
-	contentH := a.height - 1 // full height minus bottom bar
+	contentH := a.height - 1 - millerHeaderHeight // full height minus bottom bar and column header
 	contentW := a.width - millerSidebarWidth
 	navPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderNav(a))
 
-	var contentPane string
+	// Column header row — active column title in accent, others muted.
+	navHdr := l.renderColumnHeader("spaces", a.focus == focusMenu, millerSidebarWidth-1)
+	colSep := theme.Subtle.Render("│")
+
+	var contentPane, hdrRow string
 	if a.active == screenFeed {
 		listW := millerListWidth
 		detailW := contentW - listW - 1 // -1 for the │ separator
+
+		listHdr := l.renderColumnHeader("posts", a.focus == focusList, listW)
+		detailHdr := l.renderColumnHeader("thread", a.focus == focusDetail, detailW)
+		hdrRow = lipgloss.JoinHorizontal(lipgloss.Top, navHdr, colSep, listHdr, colSep, detailHdr)
+
 		listP := lipgloss.NewStyle().Width(listW).Height(contentH).MaxHeight(contentH).
 			Render(a.feed.CompactListView(listW, contentH))
 		listSep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
@@ -37,11 +48,14 @@ func (l MillerLayout) View(a App) string {
 			Render(a.feed.DetailView(detailW, contentH))
 		contentPane = lipgloss.JoinHorizontal(lipgloss.Top, listP, listSep, detailP)
 	} else {
+		contentHdr := l.renderColumnHeader(l.screenTitle(a), a.focus != focusMenu, contentW)
+		hdrRow = lipgloss.JoinHorizontal(lipgloss.Top, navHdr, colSep, contentHdr)
 		contentPane = lipgloss.NewStyle().Width(contentW).Height(contentH).MaxHeight(contentH).Render(l.renderContent(a))
 	}
 
 	sep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
 	base := lipgloss.JoinVertical(lipgloss.Left,
+		hdrRow,
 		lipgloss.JoinHorizontal(lipgloss.Top, navPane, sep, contentPane),
 		l.renderBottomBar(a),
 	)
@@ -185,7 +199,7 @@ func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 				a.focus = focusDetail
 				return a, nil, true
 			}
-		}
+}
 		return a, nil, false
 	}
 
@@ -195,8 +209,12 @@ func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 		case "h", "left":
 			a.focus = focusList
 			return a, nil, true
+		case "j", "down":
+			return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: +1} }, true
+		case "k", "up":
+			return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: -1} }, true
 		}
-		// All other keys (enter, r, j, k, etc.) fall through to the feed screen.
+		// enter, r, n, etc. fall through to DelegateUpdate → feed.Update
 		return a, nil, false
 	}
 
@@ -260,19 +278,16 @@ func (l MillerLayout) HasFocusedInput(a App) bool {
 func (l MillerLayout) ContentWidth(termWidth int) int { return termWidth - millerSidebarWidth }
 
 // ContentHeight inflates the height sent to screens so their viewport (which subtracts
-// theme.ChromeHeight = 3) fills the content pane exactly. Miller layout only uses 1 chrome
-// row (the status bar), so we add back the 2 rows that TabsLayout would have used for the
-// tab bar and separator.
+// theme.ChromeHeight = 3) fills the content pane exactly. Miller layout uses 2 chrome rows
+// (column header + status bar), so we add back only 1 of the 2 rows TabsLayout uses.
 func (l MillerLayout) ContentHeight(termHeight int) int {
-	return termHeight + theme.TabBarHeight + theme.SeparatorHeight
+	return termHeight + theme.TabBarHeight
 }
 
 func (l MillerLayout) renderNav(a App) string {
 	navW := millerSidebarWidth - 1 // leave 1 col for the "│" separator
-	header := lipgloss.NewStyle().Width(navW).Render(theme.Title.Render("spaces"))
-	sep := theme.Subtle.Render(strings.Repeat("─", navW))
 
-	rows := []string{header, sep}
+	var rows []string
 	for _, t := range menuTabs {
 		label := t.label
 		if t.s == screenNotifications && a.polledUnreadCount > 0 {
@@ -291,6 +306,41 @@ func (l MillerLayout) renderNav(a App) string {
 		rows = append(rows, row)
 	}
 	return strings.Join(rows, "\n")
+}
+
+func (l MillerLayout) renderColumnHeader(title string, active bool, width int) string {
+	if active {
+		return theme.Highlight.Width(width).Render(title)
+	}
+	return theme.Subtle.Width(width).Render(title)
+}
+
+func (l MillerLayout) screenTitle(a App) string {
+	switch a.active {
+	case screenFeed:
+		return "posts"
+	case screenNotifications:
+		return "notifs"
+	case screenJournal:
+		return "journal"
+	case screenBookmarks:
+		return "bookmarks"
+	case screenGuilds:
+		return "guilds"
+	case screenTopics:
+		return "topics"
+	case screenProfile:
+		return "profile"
+	case screenSettings:
+		return "settings"
+	case screenCMail:
+		return "c-mail"
+	case screenChatrooms:
+		return "chat"
+	case screenPostDetail:
+		return "thread"
+	}
+	return ""
 }
 
 func (l MillerLayout) renderContent(a App) string {
@@ -356,7 +406,7 @@ func (l MillerLayout) screenHints(a App) []hint {
 	case focusMenu:
 		return []hint{{"j/k", "nav"}, {"l/↵", "enter"}, {"1-8", "jump"}, {"?", "more"}}
 	case focusDetail:
-		return []hint{{"h/←", "list"}, {"↵", "thread"}, {"r", "reply"}, {"n", "post"}}
+		return []hint{{"h/←", "list"}, {"j/k", "replies"}, {"↵", "thread"}, {"r", "reply"}}
 	default: // focusList
 		return append([]hint{{"h/←", "menu"}, {"→/↵", "preview"}}, TabsLayout{}.screenHints(a)...)
 	}

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -35,7 +35,7 @@ func (l MillerLayout) View(a App) string {
 	var contentPane, hdrRow string
 	if a.active == screenFeed {
 		listW := millerListWidth
-		detailW := contentW - listW - 1 // -1 for the │ separator
+		detailW := contentW - listW - 1
 
 		listHdr := l.renderColumnHeader("posts", a.focus == focusList, listW)
 		detailHdr := l.renderColumnHeader("thread", a.focus == focusDetail, detailW)
@@ -46,6 +46,34 @@ func (l MillerLayout) View(a App) string {
 		listSep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
 		detailP := lipgloss.NewStyle().Width(detailW).Height(contentH).MaxHeight(contentH).
 			Render(a.feed.DetailView(detailW, contentH))
+		contentPane = lipgloss.JoinHorizontal(lipgloss.Top, listP, listSep, detailP)
+	} else if a.active == screenGuilds && a.guilds.IsViewingGuildPosts() {
+		listW := millerListWidth
+		detailW := contentW - listW - 1
+
+		listHdr := l.renderColumnHeader("posts", a.focus == focusList, listW)
+		detailHdr := l.renderColumnHeader("thread", a.focus == focusDetail, detailW)
+		hdrRow = lipgloss.JoinHorizontal(lipgloss.Top, navHdr, colSep, listHdr, colSep, detailHdr)
+
+		listP := lipgloss.NewStyle().Width(listW).Height(contentH).MaxHeight(contentH).
+			Render(a.guilds.CompactListView(listW, contentH))
+		listSep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
+		detailP := lipgloss.NewStyle().Width(detailW).Height(contentH).MaxHeight(contentH).
+			Render(a.guilds.DetailView(detailW, contentH))
+		contentPane = lipgloss.JoinHorizontal(lipgloss.Top, listP, listSep, detailP)
+	} else if a.active == screenTopics && a.topics.IsViewingTopicPosts() {
+		listW := millerListWidth
+		detailW := contentW - listW - 1
+
+		listHdr := l.renderColumnHeader("posts", a.focus == focusList, listW)
+		detailHdr := l.renderColumnHeader("thread", a.focus == focusDetail, detailW)
+		hdrRow = lipgloss.JoinHorizontal(lipgloss.Top, navHdr, colSep, listHdr, colSep, detailHdr)
+
+		listP := lipgloss.NewStyle().Width(listW).Height(contentH).MaxHeight(contentH).
+			Render(a.topics.CompactListView(listW, contentH))
+		listSep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
+		detailP := lipgloss.NewStyle().Width(detailW).Height(contentH).MaxHeight(contentH).
+			Render(a.topics.DetailView(detailW, contentH))
 		contentPane = lipgloss.JoinHorizontal(lipgloss.Top, listP, listSep, detailP)
 	} else {
 		contentHdr := l.renderColumnHeader(l.screenTitle(a), a.focus != focusMenu, contentW)
@@ -188,33 +216,49 @@ func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 		return a, nil, false
 	}
 
-	// List pane focused (Feed 3-pane or other screens).
+	// List pane focused (Feed/Guilds/Topics 3-pane or other screens).
 	if a.focus == focusList {
 		switch msg.String() {
 		case "h", "left":
 			a.focus = focusMenu
 			return a, nil, true
 		case "l", "right", "enter":
-			if a.active == screenFeed {
+			if a.active == screenFeed ||
+				(a.active == screenGuilds && a.guilds.IsViewingGuildPosts()) ||
+				(a.active == screenTopics && a.topics.IsViewingTopicPosts()) {
 				a.focus = focusDetail
 				return a, nil, true
 			}
-}
+		}
 		return a, nil, false
 	}
 
-	// Reading pane focused (Feed 3-pane only).
+	// Reading pane focused (3-pane Miller).
 	if a.focus == focusDetail {
 		switch msg.String() {
 		case "h", "left":
 			a.focus = focusList
 			return a, nil, true
 		case "j", "down":
-			return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: +1} }, true
+			switch a.active {
+			case screenGuilds:
+				return a, func() tea.Msg { return screens.GuildThreadNavMsg{Delta: +1} }, true
+			case screenTopics:
+				return a, func() tea.Msg { return screens.TopicThreadNavMsg{Delta: +1} }, true
+			default:
+				return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: +1} }, true
+			}
 		case "k", "up":
-			return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: -1} }, true
+			switch a.active {
+			case screenGuilds:
+				return a, func() tea.Msg { return screens.GuildThreadNavMsg{Delta: -1} }, true
+			case screenTopics:
+				return a, func() tea.Msg { return screens.TopicThreadNavMsg{Delta: -1} }, true
+			default:
+				return a, func() tea.Msg { return screens.FeedDetailNavMsg{Delta: -1} }, true
+			}
 		}
-		// enter, r, n, etc. fall through to DelegateUpdate → feed.Update
+		// enter, r, n, etc. fall through to DelegateUpdate
 		return a, nil, false
 	}
 

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -22,8 +22,9 @@ func (l MillerLayout) View(a App) string {
 	}
 
 	contentH := a.height - 1 // full height minus bottom bar
+	contentW := a.width - millerSidebarWidth
 	navPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderNav(a))
-	contentPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderContent(a))
+	contentPane := lipgloss.NewStyle().Width(contentW).Height(contentH).MaxHeight(contentH).Render(l.renderContent(a))
 
 	sep := theme.Subtle.Render(strings.Repeat("│\n", contentH))
 	base := lipgloss.JoinVertical(lipgloss.Left,

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -12,6 +12,7 @@ import (
 )
 
 const millerSidebarWidth = 18 // nav pane (17 chars) + "│" separator (1 char)
+const millerListWidth = 42    // compact post list pane width in 3-pane Feed view
 
 // MillerLayout renders a left navigation sidebar alongside the active screen.
 type MillerLayout struct{}
@@ -24,7 +25,20 @@ func (l MillerLayout) View(a App) string {
 	contentH := a.height - 1 // full height minus bottom bar
 	contentW := a.width - millerSidebarWidth
 	navPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderNav(a))
-	contentPane := lipgloss.NewStyle().Width(contentW).Height(contentH).MaxHeight(contentH).Render(l.renderContent(a))
+
+	var contentPane string
+	if a.active == screenFeed {
+		listW := millerListWidth
+		detailW := contentW - listW - 1 // -1 for the │ separator
+		listP := lipgloss.NewStyle().Width(listW).Height(contentH).MaxHeight(contentH).
+			Render(a.feed.CompactListView(listW, contentH))
+		listSep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
+		detailP := lipgloss.NewStyle().Width(detailW).Height(contentH).MaxHeight(contentH).
+			Render(a.feed.DetailView(detailW, contentH))
+		contentPane = lipgloss.JoinHorizontal(lipgloss.Top, listP, listSep, detailP)
+	} else {
+		contentPane = lipgloss.NewStyle().Width(contentW).Height(contentH).MaxHeight(contentH).Render(l.renderContent(a))
+	}
 
 	sep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
 	base := lipgloss.JoinVertical(lipgloss.Left,
@@ -160,11 +174,32 @@ func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 		return a, nil, false
 	}
 
-	// Content pane focused: h/left returns to nav.
-	if msg.String() == "h" || msg.String() == "left" {
-		a.focus = focusMenu
-		return a, nil, true
+	// List pane focused (Feed 3-pane or other screens).
+	if a.focus == focusList {
+		switch msg.String() {
+		case "h", "left":
+			a.focus = focusMenu
+			return a, nil, true
+		case "l", "right", "enter":
+			if a.active == screenFeed {
+				a.focus = focusDetail
+				return a, nil, true
+			}
+		}
+		return a, nil, false
 	}
+
+	// Reading pane focused (Feed 3-pane only).
+	if a.focus == focusDetail {
+		switch msg.String() {
+		case "h", "left":
+			a.focus = focusList
+			return a, nil, true
+		}
+		// All other keys (enter, r, j, k, etc.) fall through to the feed screen.
+		return a, nil, false
+	}
+
 	return a, nil, false
 }
 
@@ -317,10 +352,14 @@ func (l MillerLayout) renderNotification(a App) string {
 }
 
 func (l MillerLayout) screenHints(a App) []hint {
-	if a.focus == focusMenu {
+	switch a.focus {
+	case focusMenu:
 		return []hint{{"j/k", "nav"}, {"l/↵", "enter"}, {"1-8", "jump"}, {"?", "more"}}
+	case focusDetail:
+		return []hint{{"h/←", "list"}, {"↵", "thread"}, {"r", "reply"}, {"n", "post"}}
+	default: // focusList
+		return append([]hint{{"h/←", "menu"}, {"→/↵", "preview"}}, TabsLayout{}.screenHints(a)...)
 	}
-	return append([]hint{{"h/←", "menu"}}, TabsLayout{}.screenHints(a)...)
 }
 
 func (l MillerLayout) renderStatusBar(a App) string {

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -382,6 +382,8 @@ func (l TabsLayout) HasFocusedInput(a App) bool {
 	return false
 }
 
+func (l TabsLayout) ContentWidth(termWidth int) int { return termWidth }
+
 func (l TabsLayout) renderTabBar(a App) string {
 	var tabs string
 	for _, t := range menuTabs {

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -382,7 +382,8 @@ func (l TabsLayout) HasFocusedInput(a App) bool {
 	return false
 }
 
-func (l TabsLayout) ContentWidth(termWidth int) int { return termWidth }
+func (l TabsLayout) ContentWidth(termWidth int) int  { return termWidth }
+func (l TabsLayout) ContentHeight(termHeight int) int { return termHeight }
 
 func (l TabsLayout) renderTabBar(a App) string {
 	var tabs string

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -143,8 +143,11 @@ func navigateTabBy(a App, delta int) (App, tea.Cmd) {
 	a.active = menuTabs[idx].s
 	switch a.active {
 	case screenFeed:
-		a.feed = a.feed.SetFetching()
-		return a, a.loadFeedCmd()
+		if !a.feed.IsLoaded() {
+			a.feed = a.feed.SetFetching()
+			return a, a.loadFeedCmd()
+		}
+		return a, nil
 	case screenChatrooms:
 		return a, a.loadRoomsCmd()
 	case screenCMail:
@@ -254,8 +257,11 @@ func (l TabsLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 		if a.active != screenLogin {
 			a.cmail = a.cmail.CancelSubscription()
 			a.active = screenFeed
-			a.feed = a.feed.SetFetching()
-			return a, a.loadFeedCmd(), true
+			if !a.feed.IsLoaded() {
+				a.feed = a.feed.SetFetching()
+				return a, a.loadFeedCmd(), true
+			}
+			return a, nil, true
 		}
 	case "2":
 		if a.active != screenLogin {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -70,6 +70,7 @@ type FeedModel struct {
 	loading           bool
 	fetching          bool           // true while the initial (or tab-switch) load is in flight
 	refreshing        bool           // true while re-fetching newest posts (up at top)
+	loaded            bool           // true once the first page has successfully loaded
 	exhausted         bool           // true once API returned an empty cursor
 	relaxed           bool           // true = blank line between posts (relaxed density)
 	loc               *time.Location // timezone for timestamp display; nil = UTC
@@ -114,6 +115,8 @@ func ParseTopics(s string) []string {
 	return out
 }
 
+func (m FeedModel) IsLoaded() bool { return m.loaded }
+
 func (m FeedModel) SetFetching() FeedModel {
 	m.fetching = true
 	m.err = nil
@@ -136,6 +139,7 @@ func (m FeedModel) SetPosts(posts []model.Post, cursor string) FeedModel {
 	m.loading = false
 	m.fetching = false
 	m.refreshing = false
+	m.loaded = true
 	m.selectedIndex = 0
 	if prevID != "" {
 		for i, p := range m.visiblePosts() {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -512,7 +512,100 @@ func (m FeedModel) buildContent() (string, []int) {
 func (m FeedModel) renderPost(p model.Post, selected bool) string {
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
 	_, watched := m.watchedPostIDs[p.ID]
-	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat)
+	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat, postMaxBodyLines)
+}
+
+// renderCompactPost renders a single-line summary of a post for the Miller compact list pane.
+// Format: "▶ @username  title_or_first_line" (selected) or "  @username  title_or_first_line".
+func (m FeedModel) renderCompactPost(p model.Post, selected bool, width int) string {
+	indicator := "  "
+	style := theme.Subtle
+	if selected {
+		indicator = "▶ "
+		style = theme.Highlight
+	}
+	username := "@" + p.AuthorUsername
+	var preview string
+	if p.Title != "" {
+		preview = p.Title
+	} else {
+		preview = strings.TrimSpace(strings.SplitN(p.Content, "\n", 2)[0])
+	}
+	prefix := indicator + username + "  "
+	remaining := width - lipgloss.Width(prefix)
+	if remaining > 1 {
+		// ansi.Truncate handles multi-byte runes correctly
+		preview = ansiTruncate(preview, remaining)
+	} else {
+		preview = ""
+	}
+	return style.Render(prefix + preview)
+}
+
+// ansiTruncate truncates s to at most maxWidth terminal columns, appending "…" if truncated.
+// Operates on plain text (no ANSI codes in post titles or raw content first lines).
+func ansiTruncate(s string, maxWidth int) string {
+	runes := []rune(s)
+	if len(runes) <= maxWidth {
+		return s
+	}
+	return string(runes[:maxWidth-1]) + "…"
+}
+
+// CompactListView returns the compact single-line post list for the Miller reading pane.
+// It calculates a sticky-scroll window of height rows without storing extra state.
+func (m FeedModel) CompactListView(width, height int) string {
+	if !m.ready || m.fetching {
+		return theme.Subtle.Render("  loading…")
+	}
+	visible := m.visiblePosts()
+	if len(visible) == 0 {
+		return theme.Subtle.Render("  no posts")
+	}
+	n := len(visible)
+	// Sticky scroll: keep selectedIndex visible, scrolling so it stays at the bottom of the window.
+	offset := m.selectedIndex - height + 1
+	if offset < 0 {
+		offset = 0
+	}
+	if offset+height > n {
+		offset = n - height
+		if offset < 0 {
+			offset = 0
+		}
+	}
+	end := offset + height
+	if end > n {
+		end = n
+	}
+	lines := make([]string, 0, end-offset)
+	for i := offset; i < end; i++ {
+		lines = append(lines, m.renderCompactPost(visible[i], i == m.selectedIndex, width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// DetailView returns the full post card for the Miller reading pane.
+// The selected post is rendered without body truncation (maxBodyLines = 0).
+func (m FeedModel) DetailView(width, height int) string {
+	if !m.ready {
+		return theme.Subtle.Render("  loading…")
+	}
+	visible := m.visiblePosts()
+	if len(visible) == 0 {
+		return theme.Subtle.Render("  no posts")
+	}
+	if m.selectedIndex >= len(visible) {
+		return theme.Subtle.Render("  select a post")
+	}
+	p := visible[m.selectedIndex]
+	_, bookmarked := m.bookmarkedPostIDs[p.ID]
+	_, watched := m.watchedPostIDs[p.ID]
+	card := RenderPost(p, true, bookmarked, watched, width, m.location(), m.timeDisplayFormat, 0)
+	if m.panel.IsActive() {
+		return lipgloss.JoinVertical(lipgloss.Left, card, m.panel.View())
+	}
+	return card
 }
 
 func (m FeedModel) View() string {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -37,6 +37,10 @@ type FeedDetailRepliesMsg struct {
 	Replies []model.Reply
 }
 
+// FeedDetailNavMsg is emitted by the Miller layout when the user presses j/k in
+// focusDetail, so the reading pane navigates between the post and its replies.
+type FeedDetailNavMsg struct{ Delta int }
+
 // SubmitNewPostMsg is emitted when the user submits a new post from the Feed.
 type SubmitNewPostMsg struct {
 	Content  string
@@ -74,14 +78,17 @@ type FeedModel struct {
 	filterNSFW        bool
 
 	// Miller reading pane: replies for the currently selected post.
-	detailPostID  string
-	detailReplies []model.Reply
-	detailLoading bool
+	detailPostID    string
+	detailReplies   []model.Reply
+	detailFlatTree  []replyNode // DFS-ordered tree built from detailReplies
+	detailReplyIndex int        // -1 = post selected; 0+ = index into detailFlatTree
+	detailLoading   bool
 }
 
 func NewFeedModel() FeedModel {
 	return FeedModel{
-		panel: NewPostComposePanel(0),
+		panel:            NewPostComposePanel(0),
+		detailReplyIndex: -1,
 	}
 }
 
@@ -314,7 +321,20 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		if m.selectedIndex < len(visible) && visible[m.selectedIndex].ID == msg.PostID {
 			m.detailPostID = msg.PostID
 			m.detailReplies = msg.Replies
+			m.detailFlatTree = buildReplyTree(msg.Replies, 3)
+			m.detailReplyIndex = -1
 			m.detailLoading = false
+		}
+		return m, nil
+
+	case FeedDetailNavMsg:
+		maxIdx := len(m.detailFlatTree) - 1
+		m.detailReplyIndex += msg.Delta
+		if m.detailReplyIndex < -1 {
+			m.detailReplyIndex = -1
+		}
+		if m.detailReplyIndex > maxIdx {
+			m.detailReplyIndex = maxIdx
 		}
 		return m, nil
 
@@ -560,6 +580,8 @@ func (m FeedModel) currentDetailCmd() (FeedModel, tea.Cmd) {
 	m.detailPostID = postID
 	m.detailLoading = true
 	m.detailReplies = nil
+	m.detailFlatTree = nil
+	m.detailReplyIndex = -1
 	return m, func() tea.Msg { return LoadFeedDetailMsg{PostID: postID} }
 }
 
@@ -569,29 +591,45 @@ func (m FeedModel) CurrentDetailCmd() (FeedModel, tea.Cmd) {
 	return m.currentDetailCmd()
 }
 
-// renderDetailReply renders a single reply below the post card in the reading pane.
-func (m FeedModel) renderDetailReply(r model.Reply, width int) string {
-	header := theme.Subtle.Render("  ↳ ") +
-		theme.Highlight.Render("@"+r.AuthorUsername) +
-		theme.Subtle.Render("  "+displayTime(r.CreatedAt, m.location(), m.timeDisplayFormat, true))
-	innerWidth := width - 4
+// renderDetailReply renders a reply in the Miller reading pane using the same tree-aware
+// card style as the post-detail screen: depth indentation, parent back-reference, active border.
+func (m FeedModel) renderDetailReply(node replyNode, selected bool, width int) string {
+	indentW := node.Depth * 3
+	cardWidth := width - 2 - indentW
+	if cardWidth < 4 {
+		cardWidth = 4
+	}
+	innerWidth := cardWidth - 2
 	if innerWidth < 1 {
 		innerWidth = 1
 	}
-	body := strings.TrimRight(markdown.Render(r.Content, innerWidth), "\n")
-	body = "    " + strings.ReplaceAll(body, "\n", "\n    ")
-	return lipgloss.JoinVertical(lipgloss.Left, header, body)
+
+	header := theme.Highlight.Render("@" + node.Reply.AuthorUsername)
+	if node.ParentUsername != "" {
+		header += theme.Subtle.Render("  ↩ @" + node.ParentUsername)
+	}
+	header += theme.Subtle.Render("  " + displayTime(node.Reply.CreatedAt, m.location(), m.timeDisplayFormat, false))
+
+	body := strings.TrimRight(markdown.Render(node.Reply.Content, innerWidth), "\n")
+
+	boxStyle := theme.Border
+	if selected {
+		boxStyle = theme.ActiveBorder
+	}
+	if cardWidth > 0 {
+		boxStyle = boxStyle.Width(cardWidth)
+	}
+	card := boxStyle.Render(lipgloss.JoinVertical(lipgloss.Left, header, body))
+	if indentW > 0 {
+		return lipgloss.NewStyle().MarginLeft(indentW).Render(card)
+	}
+	return card
 }
 
 // renderCompactPost renders a single-line summary of a post for the Miller compact list pane.
-// Format: "▶ @username  title_or_first_line" (selected) or "  @username  title_or_first_line".
+// Selected: "▶ @username" in accent + preview in subtle.
+// Unselected: "  @username" in base colour + preview in subtle.
 func (m FeedModel) renderCompactPost(p model.Post, selected bool, width int) string {
-	indicator := "  "
-	style := theme.Subtle
-	if selected {
-		indicator = "▶ "
-		style = theme.Highlight
-	}
 	username := "@" + p.AuthorUsername
 	var preview string
 	if p.Title != "" {
@@ -599,16 +637,30 @@ func (m FeedModel) renderCompactPost(p model.Post, selected bool, width int) str
 	} else {
 		preview = strings.TrimSpace(strings.SplitN(p.Content, "\n", 2)[0])
 	}
-	prefix := indicator + username + "  "
-	remaining := width - lipgloss.Width(prefix)
+
+	const sep = "  "
+	var indicatorAndName string
+	if selected {
+		indicatorAndName = theme.Highlight.Render("▶ " + username)
+	} else {
+		indicatorAndName = theme.Subtle.Render("  ") + theme.Base.Render(username)
+	}
+	prefixWidth := 2 + lipgloss.Width(username) + len(sep) // indicator + username + separator
+	remaining := width - prefixWidth
 	if remaining > 1 {
-		// ansi.Truncate handles multi-byte runes correctly
 		preview = ansiTruncate(preview, remaining)
 	} else {
 		preview = ""
 	}
-	return style.Render(prefix + preview)
+	return indicatorAndName + theme.Subtle.Render(sep+preview)
 }
+
+// IsAtTop reports whether the first post is selected (used by the Miller layout to suppress
+// pull-to-refresh when navigating the compact list).
+func (m FeedModel) IsAtTop() bool { return m.selectedIndex == 0 }
+
+// PostCount returns the number of currently visible posts (respects NSFW filter).
+func (m FeedModel) PostCount() int { return len(m.visiblePosts()) }
 
 // ansiTruncate truncates s to at most maxWidth terminal columns, appending "…" if truncated.
 // Operates on plain text (no ANSI codes in post titles or raw content first lines).
@@ -630,31 +682,49 @@ func (m FeedModel) CompactListView(width, height int) string {
 	if len(visible) == 0 {
 		return theme.Subtle.Render("  no posts")
 	}
+
+	// When refreshing, reserve the first row for the status message and push
+	// posts down by one row, matching the behaviour of the tabbed layout.
+	headerLines := 0
+	var header string
+	if m.refreshing {
+		header = theme.Subtle.Render("  fetching new posts...")
+		headerLines = 1
+	}
+
 	n := len(visible)
+	listH := height - headerLines
+	if listH < 1 {
+		listH = 1
+	}
 	// Sticky scroll: keep selectedIndex visible, scrolling so it stays at the bottom of the window.
-	offset := m.selectedIndex - height + 1
+	offset := m.selectedIndex - listH + 1
 	if offset < 0 {
 		offset = 0
 	}
-	if offset+height > n {
-		offset = n - height
+	if offset+listH > n {
+		offset = n - listH
 		if offset < 0 {
 			offset = 0
 		}
 	}
-	end := offset + height
+	end := offset + listH
 	if end > n {
 		end = n
 	}
 	lines := make([]string, 0, end-offset)
+	if header != "" {
+		lines = append(lines, header)
+	}
 	for i := offset; i < end; i++ {
 		lines = append(lines, m.renderCompactPost(visible[i], i == m.selectedIndex, width))
 	}
 	return strings.Join(lines, "\n")
 }
 
-// DetailView returns the full post card + replies for the Miller reading pane.
-// The post body is rendered without truncation (maxBodyLines = 0).
+// DetailView returns the full post card + threaded replies for the Miller reading pane.
+// The post body is rendered without truncation (maxBodyLines = 0). The selected item
+// (post or reply, determined by detailReplyIndex) is scrolled into view.
 func (m FeedModel) DetailView(width, height int) string {
 	if !m.ready {
 		return theme.Subtle.Render("  loading…")
@@ -669,20 +739,55 @@ func (m FeedModel) DetailView(width, height int) string {
 	p := visible[m.selectedIndex]
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
 	_, watched := m.watchedPostIDs[p.ID]
-	card := RenderPost(p, true, bookmarked, watched, width, m.location(), m.timeDisplayFormat, 0)
 
-	parts := []string{card}
+	// Render all items and track each item's start line for scroll computation.
+	postSelected := m.detailReplyIndex < 0
+	card := RenderPost(p, postSelected, bookmarked, watched, width, m.location(), m.timeDisplayFormat, 0)
+
+	var parts []string
+	startLines := []int{0} // startLines[0] = post start line (always 0)
+	lineCount := lipgloss.Height(card)
+	parts = append(parts, card)
+
 	if m.detailLoading {
 		parts = append(parts, theme.Subtle.Render("  loading replies…"))
 	} else {
-		for _, r := range m.detailReplies {
-			parts = append(parts, m.renderDetailReply(r, width))
+		for i, node := range m.detailFlatTree {
+			rendered := m.renderDetailReply(node, i == m.detailReplyIndex, width)
+			startLines = append(startLines, lineCount)
+			lineCount += lipgloss.Height(rendered)
+			parts = append(parts, rendered)
 		}
 	}
 	if m.panel.IsActive() {
 		parts = append(parts, m.panel.View())
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+
+	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
+	if lineCount <= height {
+		return fullContent
+	}
+
+	// Scroll to keep the selected item at the top of the visible window.
+	// selectedItem: 0 = post, 1+ = reply[i]
+	selectedItem := m.detailReplyIndex + 1
+	offset := 0
+	if selectedItem >= 0 && selectedItem < len(startLines) {
+		offset = startLines[selectedItem]
+	}
+	if offset+height > lineCount {
+		offset = lineCount - height
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	allLines := strings.Split(fullContent, "\n")
+	end := offset + height
+	if end > len(allLines) {
+		end = len(allLines)
+	}
+	return strings.Join(allLines[offset:end], "\n")
 }
 
 func (m FeedModel) View() string {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -38,8 +38,13 @@ type FeedDetailRepliesMsg struct {
 }
 
 // FeedDetailNavMsg is emitted by the Miller layout when the user presses j/k in
-// focusDetail, so the reading pane navigates between the post and its replies.
-type FeedDetailNavMsg struct{ Delta int }
+// focusDetail. PaneHeight and PaneWidth are the detail column dimensions so the
+// handler can implement pager-style line-by-line scrolling.
+type FeedDetailNavMsg struct {
+	Delta      int
+	PaneHeight int
+	PaneWidth  int
+}
 
 // SubmitNewPostMsg is emitted when the user submits a new post from the Feed.
 type SubmitNewPostMsg struct {
@@ -78,11 +83,12 @@ type FeedModel struct {
 	filterNSFW        bool
 
 	// Miller reading pane: replies for the currently selected post.
-	detailPostID    string
-	detailReplies   []model.Reply
-	detailFlatTree  []replyNode // DFS-ordered tree built from detailReplies
-	detailReplyIndex int        // -1 = post selected; 0+ = index into detailFlatTree
-	detailLoading   bool
+	detailPostID     string
+	detailReplies    []model.Reply
+	detailFlatTree   []replyNode // DFS-ordered tree built from detailReplies
+	detailReplyIndex int         // -1 = post selected; 0+ = index into detailFlatTree
+	detailScrollOffset int       // raw line offset for pager scrolling in the detail pane
+	detailLoading    bool
 }
 
 func NewFeedModel() FeedModel {
@@ -323,18 +329,14 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 			m.detailReplies = msg.Replies
 			m.detailFlatTree = buildReplyTree(msg.Replies, 3)
 			m.detailReplyIndex = -1
+			m.detailScrollOffset = 0
 			m.detailLoading = false
 		}
 		return m, nil
 
 	case FeedDetailNavMsg:
-		maxIdx := len(m.detailFlatTree) - 1
-		m.detailReplyIndex += msg.Delta
-		if m.detailReplyIndex < -1 {
-			m.detailReplyIndex = -1
-		}
-		if m.detailReplyIndex > maxIdx {
-			m.detailReplyIndex = maxIdx
+		if msg.PaneHeight > 0 && msg.PaneWidth > 0 {
+			m = m.pageDetailNav(msg.Delta, msg.PaneHeight, msg.PaneWidth)
 		}
 		return m, nil
 
@@ -582,6 +584,7 @@ func (m FeedModel) currentDetailCmd() (FeedModel, tea.Cmd) {
 	m.detailReplies = nil
 	m.detailFlatTree = nil
 	m.detailReplyIndex = -1
+	m.detailScrollOffset = 0
 	return m, func() tea.Msg { return LoadFeedDetailMsg{PostID: postID} }
 }
 
@@ -722,6 +725,35 @@ func (m FeedModel) CompactListView(width, height int) string {
 	return strings.Join(lines, "\n")
 }
 
+// pageDetailNav implements pager-style scrolling for the Miller detail pane.
+func (m FeedModel) pageDetailNav(delta, paneH, paneW int) FeedModel {
+	visible := m.visiblePosts()
+	if m.selectedIndex >= len(visible) {
+		return m
+	}
+	p := visible[m.selectedIndex]
+	_, bookmarked := m.bookmarkedPostIDs[p.ID]
+	_, watched := m.watchedPostIDs[p.ID]
+
+	postCard := RenderPost(p, false, bookmarked, watched, paneW, m.location(), m.timeDisplayFormat, 0)
+	postH := lipgloss.Height(postCard)
+
+	replyStarts := make([]int, len(m.detailFlatTree))
+	replyHeights := make([]int, len(m.detailFlatTree))
+	pos := postH
+	for i, node := range m.detailFlatTree {
+		replyStarts[i] = pos
+		rendered := m.renderDetailReply(node, false, paneW)
+		replyHeights[i] = lipgloss.Height(rendered)
+		pos += replyHeights[i]
+	}
+
+	m.detailReplyIndex, m.detailScrollOffset = millerPageNav(
+		delta, paneH, postH, replyStarts, replyHeights, m.detailReplyIndex, m.detailScrollOffset,
+	)
+	return m
+}
+
 // DetailView returns the full post card + threaded replies for the Miller reading pane.
 // The post body is rendered without truncation (maxBodyLines = 0). The selected item
 // (post or reply, determined by detailReplyIndex) is scrolled into view.
@@ -764,30 +796,7 @@ func (m FeedModel) DetailView(width, height int) string {
 	}
 
 	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
-	if lineCount <= height {
-		return fullContent
-	}
-
-	// Scroll to keep the selected item at the top of the visible window.
-	// selectedItem: 0 = post, 1+ = reply[i]
-	selectedItem := m.detailReplyIndex + 1
-	offset := 0
-	if selectedItem >= 0 && selectedItem < len(startLines) {
-		offset = startLines[selectedItem]
-	}
-	if offset+height > lineCount {
-		offset = lineCount - height
-	}
-	if offset < 0 {
-		offset = 0
-	}
-
-	allLines := strings.Split(fullContent, "\n")
-	end := offset + height
-	if end > len(allLines) {
-		end = len(allLines)
-	}
-	return strings.Join(allLines[offset:end], "\n")
+	return sliceContent(fullContent, m.detailScrollOffset, height, lineCount)
 }
 
 func (m FeedModel) View() string {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/ragnar/cyber-tui/internal/model"
+	"github.com/ragnar/cyber-tui/internal/ui/markdown"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
@@ -25,6 +26,16 @@ type ShowPostMsg struct{ Post model.Post }
 // ShowPostForReplyMsg is emitted when the user presses 'r' on a selected post.
 // App navigates to post detail and opens the compose box immediately.
 type ShowPostForReplyMsg struct{ Post model.Post }
+
+// LoadFeedDetailMsg is emitted when the selected post changes so the app can
+// fetch replies for the Miller reading pane.
+type LoadFeedDetailMsg struct{ PostID string }
+
+// FeedDetailRepliesMsg delivers fetched replies back to FeedModel for the reading pane.
+type FeedDetailRepliesMsg struct {
+	PostID  string
+	Replies []model.Reply
+}
 
 // SubmitNewPostMsg is emitted when the user submits a new post from the Feed.
 type SubmitNewPostMsg struct {
@@ -61,6 +72,11 @@ type FeedModel struct {
 	bookmarkedPostIDs map[string]struct{}
 	watchedPostIDs    map[string]struct{}
 	filterNSFW        bool
+
+	// Miller reading pane: replies for the currently selected post.
+	detailPostID  string
+	detailReplies []model.Reply
+	detailLoading bool
 }
 
 func NewFeedModel() FeedModel {
@@ -293,6 +309,15 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case FeedDetailRepliesMsg:
+		visible := m.visiblePosts()
+		if m.selectedIndex < len(visible) && visible[m.selectedIndex].ID == msg.PostID {
+			m.detailPostID = msg.PostID
+			m.detailReplies = msg.Replies
+			m.detailLoading = false
+		}
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -358,6 +383,9 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 				m.selectedIndex--
 				m = m.refreshContent()
 				m = m.ensureSelectedVisible()
+				var detailCmd tea.Cmd
+				m, detailCmd = m.currentDetailCmd()
+				return m, detailCmd
 			} else if !m.loading && !m.refreshing {
 				m.refreshing = true
 				m = m.refreshContent()
@@ -409,6 +437,9 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 				m.selectedIndex++
 				m = m.refreshContent()
 				m = m.ensureSelectedVisible()
+				var detailCmd tea.Cmd
+				m, detailCmd = m.currentDetailCmd()
+				return m, detailCmd
 			} else {
 				var loadCmd tea.Cmd
 				m, loadCmd = m.triggerLoadMore()
@@ -515,6 +546,43 @@ func (m FeedModel) renderPost(p model.Post, selected bool) string {
 	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat, postMaxBodyLines)
 }
 
+// currentDetailCmd emits LoadFeedDetailMsg for the currently selected post and marks
+// the detail pane as loading. Returns the updated model and the command to run.
+func (m FeedModel) currentDetailCmd() (FeedModel, tea.Cmd) {
+	visible := m.visiblePosts()
+	if m.selectedIndex >= len(visible) {
+		return m, nil
+	}
+	postID := visible[m.selectedIndex].ID
+	if postID == m.detailPostID {
+		return m, nil // already loaded/loading this post
+	}
+	m.detailPostID = postID
+	m.detailLoading = true
+	m.detailReplies = nil
+	return m, func() tea.Msg { return LoadFeedDetailMsg{PostID: postID} }
+}
+
+// CurrentDetailCmd is exported so app.go can trigger the initial detail load after
+// the feed's first page arrives.
+func (m FeedModel) CurrentDetailCmd() (FeedModel, tea.Cmd) {
+	return m.currentDetailCmd()
+}
+
+// renderDetailReply renders a single reply below the post card in the reading pane.
+func (m FeedModel) renderDetailReply(r model.Reply, width int) string {
+	header := theme.Subtle.Render("  ↳ ") +
+		theme.Highlight.Render("@"+r.AuthorUsername) +
+		theme.Subtle.Render("  "+displayTime(r.CreatedAt, m.location(), m.timeDisplayFormat, true))
+	innerWidth := width - 4
+	if innerWidth < 1 {
+		innerWidth = 1
+	}
+	body := strings.TrimRight(markdown.Render(r.Content, innerWidth), "\n")
+	body = "    " + strings.ReplaceAll(body, "\n", "\n    ")
+	return lipgloss.JoinVertical(lipgloss.Left, header, body)
+}
+
 // renderCompactPost renders a single-line summary of a post for the Miller compact list pane.
 // Format: "▶ @username  title_or_first_line" (selected) or "  @username  title_or_first_line".
 func (m FeedModel) renderCompactPost(p model.Post, selected bool, width int) string {
@@ -585,8 +653,8 @@ func (m FeedModel) CompactListView(width, height int) string {
 	return strings.Join(lines, "\n")
 }
 
-// DetailView returns the full post card for the Miller reading pane.
-// The selected post is rendered without body truncation (maxBodyLines = 0).
+// DetailView returns the full post card + replies for the Miller reading pane.
+// The post body is rendered without truncation (maxBodyLines = 0).
 func (m FeedModel) DetailView(width, height int) string {
 	if !m.ready {
 		return theme.Subtle.Render("  loading…")
@@ -602,10 +670,19 @@ func (m FeedModel) DetailView(width, height int) string {
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
 	_, watched := m.watchedPostIDs[p.ID]
 	card := RenderPost(p, true, bookmarked, watched, width, m.location(), m.timeDisplayFormat, 0)
-	if m.panel.IsActive() {
-		return lipgloss.JoinVertical(lipgloss.Left, card, m.panel.View())
+
+	parts := []string{card}
+	if m.detailLoading {
+		parts = append(parts, theme.Subtle.Render("  loading replies…"))
+	} else {
+		for _, r := range m.detailReplies {
+			parts = append(parts, m.renderDetailReply(r, width))
+		}
 	}
-	return card
+	if m.panel.IsActive() {
+		parts = append(parts, m.panel.View())
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
 func (m FeedModel) View() string {

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -63,8 +63,12 @@ type GuildThreadRepliesMsg struct {
 }
 
 // GuildThreadNavMsg is emitted by the Miller layout when j/k is pressed in focusDetail
-// while the guilds screen is active, so the reading pane navigates between replies.
-type GuildThreadNavMsg struct{ Delta int }
+// while the guilds screen is active. PaneHeight and PaneWidth enable pager-style scrolling.
+type GuildThreadNavMsg struct {
+	Delta      int
+	PaneHeight int
+	PaneWidth  int
+}
 
 // guildsConfirm tracks whether a join/leave confirmation prompt is active.
 type guildsConfirm int
@@ -119,11 +123,12 @@ type GuildsModel struct {
 	panel PostComposePanel
 
 	// Miller reading pane: replies for the currently selected guild post.
-	threadPostID    string
-	threadReplies   []model.Reply
-	threadFlatTree  []replyNode
-	threadReplyIndex int
-	threadLoading   bool
+	threadPostID       string
+	threadReplies      []model.Reply
+	threadFlatTree     []replyNode
+	threadReplyIndex   int
+	threadScrollOffset int
+	threadLoading      bool
 
 	// Shared
 	viewport          viewport.Model
@@ -364,18 +369,14 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 			m.threadReplies = msg.Replies
 			m.threadFlatTree = buildReplyTree(msg.Replies, 3)
 			m.threadReplyIndex = -1
+			m.threadScrollOffset = 0
 			m.threadLoading = false
 		}
 		return m, nil
 
 	case GuildThreadNavMsg:
-		maxIdx := len(m.threadFlatTree) - 1
-		m.threadReplyIndex += msg.Delta
-		if m.threadReplyIndex < -1 {
-			m.threadReplyIndex = -1
-		}
-		if m.threadReplyIndex > maxIdx {
-			m.threadReplyIndex = maxIdx
+		if msg.PaneHeight > 0 && msg.PaneWidth > 0 {
+			m = m.pageThreadNav(msg.Delta, msg.PaneHeight, msg.PaneWidth)
 		}
 		return m, nil
 
@@ -995,6 +996,7 @@ func (m GuildsModel) currentDetailCmd() (GuildsModel, tea.Cmd) {
 	m.threadReplies = nil
 	m.threadFlatTree = nil
 	m.threadReplyIndex = -1
+	m.threadScrollOffset = 0
 	return m, func() tea.Msg { return LoadGuildThreadMsg{PostID: postID} }
 }
 
@@ -1102,6 +1104,35 @@ func (m GuildsModel) CompactListView(width, height int) string {
 	return strings.Join(lines, "\n")
 }
 
+// pageThreadNav implements pager-style scrolling for the Miller detail pane.
+func (m GuildsModel) pageThreadNav(delta, paneH, paneW int) GuildsModel {
+	visible := m.visiblePosts()
+	if m.postIndex >= len(visible) {
+		return m
+	}
+	p := visible[m.postIndex]
+	_, bookmarked := m.bookmarkedPostIDs[p.ID]
+	_, watched := m.watchedPostIDs[p.ID]
+
+	postCard := RenderPost(p, false, bookmarked, watched, paneW, m.location(), m.timeDisplayFormat, 0)
+	postH := lipgloss.Height(postCard)
+
+	replyStarts := make([]int, len(m.threadFlatTree))
+	replyHeights := make([]int, len(m.threadFlatTree))
+	pos := postH
+	for i, node := range m.threadFlatTree {
+		replyStarts[i] = pos
+		rendered := m.renderDetailReply(node, false, paneW)
+		replyHeights[i] = lipgloss.Height(rendered)
+		pos += replyHeights[i]
+	}
+
+	m.threadReplyIndex, m.threadScrollOffset = millerPageNav(
+		delta, paneH, postH, replyStarts, replyHeights, m.threadReplyIndex, m.threadScrollOffset,
+	)
+	return m
+}
+
 // DetailView returns the full guild post card + threaded replies for the Miller reading pane.
 func (m GuildsModel) DetailView(width, height int) string {
 	if !m.ready {
@@ -1141,25 +1172,5 @@ func (m GuildsModel) DetailView(width, height int) string {
 	}
 
 	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
-	if lineCount <= height {
-		return fullContent
-	}
-
-	selectedItem := m.threadReplyIndex + 1
-	offset := 0
-	if selectedItem >= 0 && selectedItem < len(startLines) {
-		offset = startLines[selectedItem]
-	}
-	if offset+height > lineCount {
-		offset = lineCount - height
-	}
-	if offset < 0 {
-		offset = 0
-	}
-	allLines := strings.Split(fullContent, "\n")
-	end := offset + height
-	if end > len(allLines) {
-		end = len(allLines)
-	}
-	return strings.Join(allLines[offset:end], "\n")
+	return sliceContent(fullContent, m.threadScrollOffset, height, lineCount)
 }

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/ragnar/cyber-tui/internal/model"
+	"github.com/ragnar/cyber-tui/internal/ui/markdown"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
@@ -50,6 +51,20 @@ type JoinGuildMsg struct{ Slug string }
 
 // LeaveGuildMsg is emitted when the user confirms leaving the active guild.
 type LeaveGuildMsg struct{ Slug string }
+
+// LoadGuildThreadMsg is emitted when the selected guild post changes so the app can
+// fetch replies for the Miller reading pane.
+type LoadGuildThreadMsg struct{ PostID string }
+
+// GuildThreadRepliesMsg delivers fetched replies back to GuildsModel for the reading pane.
+type GuildThreadRepliesMsg struct {
+	PostID  string
+	Replies []model.Reply
+}
+
+// GuildThreadNavMsg is emitted by the Miller layout when j/k is pressed in focusDetail
+// while the guilds screen is active, so the reading pane navigates between replies.
+type GuildThreadNavMsg struct{ Delta int }
 
 // guildsConfirm tracks whether a join/leave confirmation prompt is active.
 type guildsConfirm int
@@ -103,6 +118,13 @@ type GuildsModel struct {
 	// Compose panel for new guild threads (visible in posts view).
 	panel PostComposePanel
 
+	// Miller reading pane: replies for the currently selected guild post.
+	threadPostID    string
+	threadReplies   []model.Reply
+	threadFlatTree  []replyNode
+	threadReplyIndex int
+	threadLoading   bool
+
 	// Shared
 	viewport          viewport.Model
 	itemOffsets       []int
@@ -121,7 +143,8 @@ type GuildsModel struct {
 // NewGuildsModel returns a zero-value GuildsModel ready for first use.
 func NewGuildsModel() GuildsModel {
 	return GuildsModel{
-		panel: NewPostComposePanel(0),
+		panel:            NewPostComposePanel(0),
+		threadReplyIndex: -1,
 	}
 }
 
@@ -334,6 +357,28 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case GuildThreadRepliesMsg:
+		visible := m.visiblePosts()
+		if m.postIndex < len(visible) && visible[m.postIndex].ID == msg.PostID {
+			m.threadPostID = msg.PostID
+			m.threadReplies = msg.Replies
+			m.threadFlatTree = buildReplyTree(msg.Replies, 3)
+			m.threadReplyIndex = -1
+			m.threadLoading = false
+		}
+		return m, nil
+
+	case GuildThreadNavMsg:
+		maxIdx := len(m.threadFlatTree) - 1
+		m.threadReplyIndex += msg.Delta
+		if m.threadReplyIndex < -1 {
+			m.threadReplyIndex = -1
+		}
+		if m.threadReplyIndex > maxIdx {
+			m.threadReplyIndex = maxIdx
+		}
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -390,6 +435,9 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 				if m.postIndex > 0 {
 					m.postIndex--
 					m = m.refreshContent()
+					var detailCmd tea.Cmd
+					m, detailCmd = m.currentDetailCmd()
+					return m, detailCmd
 				} else if !m.loading && !m.refreshing {
 					slug := m.activeGuild
 					m.refreshing = true
@@ -422,6 +470,9 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 				if m.postIndex < len(m.visiblePosts())-1 {
 					m.postIndex++
 					m = m.refreshContent()
+					var detailCmd tea.Cmd
+					m, detailCmd = m.currentDetailCmd()
+					return m, detailCmd
 				} else if !m.exhausted && !m.loading {
 					slug, cursor := m.activeGuild, m.nextCursor
 					m.loading = true
@@ -919,4 +970,196 @@ func (m GuildsModel) GetFocusedURLs() []string {
 	}
 	p := visible[m.postIndex]
 	return append(extractURLs(p.Content), attachmentURLs(p.Attachments)...)
+}
+
+// IsViewingGuildPosts reports whether the guild post list is currently shown (3-pane applies).
+func (m GuildsModel) IsViewingGuildPosts() bool { return m.view == viewGuildPosts }
+
+// IsAtTop reports whether the first post is selected (used to suppress pull-to-refresh in Miller).
+func (m GuildsModel) IsAtTop() bool { return m.postIndex == 0 }
+
+// PostCount returns the number of currently visible guild posts.
+func (m GuildsModel) PostCount() int { return len(m.visiblePosts()) }
+
+func (m GuildsModel) currentDetailCmd() (GuildsModel, tea.Cmd) {
+	visible := m.visiblePosts()
+	if m.postIndex >= len(visible) {
+		return m, nil
+	}
+	postID := visible[m.postIndex].ID
+	if postID == m.threadPostID {
+		return m, nil
+	}
+	m.threadPostID = postID
+	m.threadLoading = true
+	m.threadReplies = nil
+	m.threadFlatTree = nil
+	m.threadReplyIndex = -1
+	return m, func() tea.Msg { return LoadGuildThreadMsg{PostID: postID} }
+}
+
+// CurrentDetailCmd is exported so app.go can trigger the initial detail load when guild posts first arrive.
+func (m GuildsModel) CurrentDetailCmd() (GuildsModel, tea.Cmd) {
+	return m.currentDetailCmd()
+}
+
+func (m GuildsModel) renderDetailReply(node replyNode, selected bool, width int) string {
+	indentW := node.Depth * 3
+	cardWidth := width - 2 - indentW
+	if cardWidth < 4 {
+		cardWidth = 4
+	}
+	innerWidth := cardWidth - 2
+	if innerWidth < 1 {
+		innerWidth = 1
+	}
+	header := theme.Highlight.Render("@" + node.Reply.AuthorUsername)
+	if node.ParentUsername != "" {
+		header += theme.Subtle.Render("  ↩ @" + node.ParentUsername)
+	}
+	header += theme.Subtle.Render("  " + displayTime(node.Reply.CreatedAt, m.location(), m.timeDisplayFormat, false))
+	body := strings.TrimRight(markdown.Render(node.Reply.Content, innerWidth), "\n")
+	boxStyle := theme.Border
+	if selected {
+		boxStyle = theme.ActiveBorder
+	}
+	if cardWidth > 0 {
+		boxStyle = boxStyle.Width(cardWidth)
+	}
+	card := boxStyle.Render(lipgloss.JoinVertical(lipgloss.Left, header, body))
+	if indentW > 0 {
+		return lipgloss.NewStyle().MarginLeft(indentW).Render(card)
+	}
+	return card
+}
+
+func (m GuildsModel) renderCompactPost(p model.Post, selected bool, width int) string {
+	username := "@" + p.AuthorUsername
+	var preview string
+	if p.Title != "" {
+		preview = p.Title
+	} else {
+		preview = strings.TrimSpace(strings.SplitN(p.Content, "\n", 2)[0])
+	}
+	const sep = "  "
+	var indicatorAndName string
+	if selected {
+		indicatorAndName = theme.Highlight.Render("▶ " + username)
+	} else {
+		indicatorAndName = theme.Subtle.Render("  ") + theme.Base.Render(username)
+	}
+	prefixWidth := 2 + lipgloss.Width(username) + len(sep)
+	remaining := width - prefixWidth
+	if remaining > 1 {
+		preview = ansiTruncate(preview, remaining)
+	} else {
+		preview = ""
+	}
+	return indicatorAndName + theme.Subtle.Render(sep+preview)
+}
+
+// CompactListView returns the compact single-line guild post list for the Miller list pane.
+func (m GuildsModel) CompactListView(width, height int) string {
+	if !m.ready || m.fetching {
+		return theme.Subtle.Render("  loading…")
+	}
+	visible := m.visiblePosts()
+	if len(visible) == 0 {
+		return theme.Subtle.Render("  no posts")
+	}
+	headerLines := 0
+	var header string
+	if m.refreshing {
+		header = theme.Subtle.Render("  fetching new posts...")
+		headerLines = 1
+	}
+	n := len(visible)
+	listH := height - headerLines
+	if listH < 1 {
+		listH = 1
+	}
+	offset := m.postIndex - listH + 1
+	if offset < 0 {
+		offset = 0
+	}
+	if offset+listH > n {
+		offset = n - listH
+		if offset < 0 {
+			offset = 0
+		}
+	}
+	end := offset + listH
+	if end > n {
+		end = n
+	}
+	lines := make([]string, 0, end-offset+headerLines)
+	if header != "" {
+		lines = append(lines, header)
+	}
+	for i := offset; i < end; i++ {
+		lines = append(lines, m.renderCompactPost(visible[i], i == m.postIndex, width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// DetailView returns the full guild post card + threaded replies for the Miller reading pane.
+func (m GuildsModel) DetailView(width, height int) string {
+	if !m.ready {
+		return theme.Subtle.Render("  loading…")
+	}
+	visible := m.visiblePosts()
+	if len(visible) == 0 {
+		return theme.Subtle.Render("  no posts")
+	}
+	if m.postIndex >= len(visible) {
+		return theme.Subtle.Render("  select a post")
+	}
+	p := visible[m.postIndex]
+	_, bookmarked := m.bookmarkedPostIDs[p.ID]
+	_, watched := m.watchedPostIDs[p.ID]
+
+	postSelected := m.threadReplyIndex < 0
+	card := RenderPost(p, postSelected, bookmarked, watched, width, m.location(), m.timeDisplayFormat, 0)
+
+	var parts []string
+	startLines := []int{0}
+	lineCount := lipgloss.Height(card)
+	parts = append(parts, card)
+
+	if m.threadLoading {
+		parts = append(parts, theme.Subtle.Render("  loading replies…"))
+	} else {
+		for i, node := range m.threadFlatTree {
+			rendered := m.renderDetailReply(node, i == m.threadReplyIndex, width)
+			startLines = append(startLines, lineCount)
+			lineCount += lipgloss.Height(rendered)
+			parts = append(parts, rendered)
+		}
+	}
+	if m.panel.IsActive() {
+		parts = append(parts, m.panel.View())
+	}
+
+	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
+	if lineCount <= height {
+		return fullContent
+	}
+
+	selectedItem := m.threadReplyIndex + 1
+	offset := 0
+	if selectedItem >= 0 && selectedItem < len(startLines) {
+		offset = startLines[selectedItem]
+	}
+	if offset+height > lineCount {
+		offset = lineCount - height
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	allLines := strings.Split(fullContent, "\n")
+	end := offset + height
+	if end > len(allLines) {
+		end = len(allLines)
+	}
+	return strings.Join(allLines[offset:end], "\n")
 }

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -814,7 +814,7 @@ func (m GuildsModel) renderMemberItem(mem model.GuildMember, selected bool) stri
 func (m GuildsModel) renderPostItem(p model.Post, selected bool) string {
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
 	_, watched := m.watchedPostIDs[p.ID]
-	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat)
+	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat, postMaxBodyLines)
 }
 
 func (m GuildsModel) refreshContent() GuildsModel {

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -44,6 +44,7 @@ type SharedConfigMsg struct {
 	Timezone       string
 	ImageViewer    string
 	OwnGuildSlug   string
+	LayoutName     string // "tabs" or "miller"; used by settings screen to show current value
 }
 
 // URLProvider is implemented by screens that can expose URLs from their
@@ -68,6 +69,7 @@ type SaveSettingsMsg struct {
 	MaxThreadDepth int
 	Timezone       string
 	ImageViewer    string
+	LayoutName     string // "tabs" or "miller"
 }
 
 // BookmarkedMsg is sent back to the bookmarks screen after a successful CreateBookmark

--- a/internal/ui/screens/miller_pager.go
+++ b/internal/ui/screens/miller_pager.go
@@ -1,0 +1,105 @@
+package screens
+
+import "strings"
+
+// millerPageNav computes the new replyIndex and scrollOffset after a single j/k
+// keypress in a Miller-layout detail pane (or PostDetail in tabs mode).
+//
+// Pager behaviour: scroll one line at a time within the current item; only advance
+// to the next item once the current item's trailing edge becomes visible (delta>0),
+// or retreat once the leading edge becomes visible (delta<0).
+//
+//   - replyStarts[i] is the start line of reply i within the full content.
+//   - replyHeights[i] is the rendered height of reply i.
+//   - replyIndex == -1 means the post itself is selected; 0+ indexes into the reply slice.
+func millerPageNav(delta, paneH, postH int, replyStarts, replyHeights []int, replyIndex, scrollOffset int) (newReplyIndex, newScrollOffset int) {
+	newReplyIndex = replyIndex
+	newScrollOffset = scrollOffset
+
+	totalLines := postH
+	if n := len(replyStarts); n > 0 {
+		totalLines = replyStarts[n-1] + replyHeights[n-1]
+	}
+
+	clamp := func(v int) int {
+		if v < 0 {
+			return 0
+		}
+		if max := totalLines - paneH; v > max {
+			if max < 0 {
+				return 0
+			}
+			return max
+		}
+		return v
+	}
+
+	if delta > 0 {
+		if replyIndex == -1 {
+			viewBottom := scrollOffset + paneH - 1
+			if viewBottom >= postH-1 && len(replyStarts) > 0 {
+				newReplyIndex = 0
+				newScrollOffset = clamp(replyStarts[0])
+			} else {
+				newScrollOffset = clamp(scrollOffset + 1)
+			}
+		} else {
+			replyBottom := replyStarts[replyIndex] + replyHeights[replyIndex] - 1
+			viewBottom := scrollOffset + paneH - 1
+			if replyBottom > viewBottom {
+				newScrollOffset = clamp(scrollOffset + 1)
+			} else if replyIndex < len(replyStarts)-1 {
+				newReplyIndex = replyIndex + 1
+				newScrollOffset = clamp(replyStarts[newReplyIndex])
+			}
+		}
+	} else {
+		if replyIndex == -1 {
+			newScrollOffset = clamp(scrollOffset - 1)
+		} else {
+			replyTop := replyStarts[replyIndex]
+			if replyTop < scrollOffset {
+				newScrollOffset = clamp(scrollOffset - 1)
+			} else {
+				newReplyIndex = replyIndex - 1
+				var prevStart, prevH int
+				if newReplyIndex == -1 {
+					prevStart = 0
+					prevH = postH
+				} else {
+					prevStart = replyStarts[newReplyIndex]
+					prevH = replyHeights[newReplyIndex]
+				}
+				if prevH <= paneH {
+					newScrollOffset = clamp(prevStart)
+				} else {
+					newScrollOffset = clamp(prevStart + prevH - paneH)
+				}
+			}
+		}
+	}
+	return newReplyIndex, newScrollOffset
+}
+
+// sliceContent clips fullContent to a height-line window starting at offset.
+// If lineCount fits within height, the full content is returned unchanged.
+func sliceContent(fullContent string, offset, height, lineCount int) string {
+	if lineCount <= height {
+		return fullContent
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset+height > lineCount {
+		offset = lineCount - height
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	lines := strings.Split(fullContent, "\n")
+	end := offset + height
+	if end > len(lines) {
+		end = len(lines)
+	}
+	return strings.Join(lines[offset:end], "\n")
+}

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -520,71 +520,22 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 			}
 			return m, nil
 		case "up", "k":
-			if m.selectedReply >= 0 {
-				// Reply is selected — scroll through it first (pager behaviour).
-				replyTop := m.replyOffsets[m.selectedReply]
-				if replyTop < m.viewport.YOffset {
-					// Reply top is above the visible area — scroll up.
-					m.viewport.ScrollUp(1)
-				} else {
-					// Reply top is visible — move to previous item.
-					m.selectedReply--
-					m = m.refreshContent()
-					// Mirror the down-scroll behaviour: snap the previous item
-					// fully into view if it fits the viewport; otherwise leave
-					// the viewport in place and let the user scroll through it
-					// line-by-line.
-					var prevStart, prevHeight int
-					if m.selectedReply == -1 {
-						prevStart = 0
-						prevHeight = m.postHeight
-					} else {
-						prevStart = m.replyOffsets[m.selectedReply]
-						prevHeight = m.replyHeights[m.selectedReply]
-					}
-					if prevHeight <= m.viewport.Height {
-						// Item fits — snap it fully into view (mirrors down behaviour).
-						m = m.ensureSelectedVisible()
-					} else {
-						// Item is taller than the viewport — align its bottom to the
-						// viewport bottom so the selection highlight is visible and
-						// the user can scroll up through it line-by-line.
-						itemEnd := prevStart + prevHeight - 1
-						m.viewport.SetYOffset(itemEnd - m.viewport.Height + 1)
-					}
-				}
-			} else {
-				// Post is selected — scroll viewport up (pager behaviour).
-				m.viewport.ScrollUp(1)
+			newReply, newOffset := millerPageNav(-1, m.viewport.Height, m.postHeight,
+				m.replyOffsets, m.replyHeights, m.selectedReply, m.viewport.YOffset)
+			if newReply != m.selectedReply {
+				m.selectedReply = newReply
+				m = m.refreshContent()
 			}
+			m.viewport.SetYOffset(newOffset)
 			return m, nil
 		case "down", "j":
-			if m.selectedReply == -1 {
-				// Post is selected — scroll through it first, then advance to replies.
-				viewBottom := m.viewport.YOffset + m.viewport.Height - 1
-				if viewBottom >= m.postHeight-1 && len(m.replies) > 0 {
-					// Post bottom is visible — jump to first reply.
-					m.selectedReply = 0
-					m = m.refreshContent()
-					m = m.ensureSelectedVisible()
-				} else {
-					m.viewport.ScrollDown(1)
-				}
-			} else {
-				// Reply is selected — scroll through it first (pager behaviour).
-				replyH := m.replyHeights[m.selectedReply]
-				replyBottom := m.replyOffsets[m.selectedReply] + replyH - 1
-				viewBottom := m.viewport.YOffset + m.viewport.Height - 1
-				if replyBottom > viewBottom {
-					// Reply bottom is below the visible area — scroll down.
-					m.viewport.ScrollDown(1)
-				} else if m.selectedReply < len(m.flatTree)-1 {
-					// Reply bottom is visible — advance to next reply.
-					m.selectedReply++
-					m = m.refreshContent()
-					m = m.ensureSelectedVisible()
-				}
+			newReply, newOffset := millerPageNav(+1, m.viewport.Height, m.postHeight,
+				m.replyOffsets, m.replyHeights, m.selectedReply, m.viewport.YOffset)
+			if newReply != m.selectedReply {
+				m.selectedReply = newReply
+				m = m.refreshContent()
 			}
+			m.viewport.SetYOffset(newOffset)
 			return m, nil
 		}
 	}

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -17,7 +17,9 @@ const postMaxBodyLines = 4
 // selected controls the border colour (active vs inactive).
 // bookmarked adds a [★] badge; watched adds a [◉] badge — both in the header.
 // width is the full terminal width; loc and timeFormat control the timestamp display.
-func RenderPost(p model.Post, selected bool, bookmarked bool, watched bool, width int, loc *time.Location, timeFormat string) string {
+// maxBodyLines caps body text at that many lines (postMaxBodyLines for list views,
+// 0 for the reading pane where the full content should be shown).
+func RenderPost(p model.Post, selected bool, bookmarked bool, watched bool, width int, loc *time.Location, timeFormat string, maxBodyLines int) string {
 	innerWidth := width - 4
 
 	left := lipgloss.JoinHorizontal(lipgloss.Top,
@@ -66,9 +68,9 @@ func RenderPost(p model.Post, selected bool, bookmarked bool, watched bool, widt
 	if innerWidth > 0 {
 		rendered := markdown.Render(p.Content, innerWidth)
 		lines := strings.Split(rendered, "\n")
-		if len(lines) > postMaxBodyLines {
-			body = strings.Join(lines[:postMaxBodyLines], "\n")
-			more := len(lines) - postMaxBodyLines
+		if maxBodyLines > 0 && len(lines) > maxBodyLines {
+			body = strings.Join(lines[:maxBodyLines], "\n")
+			more := len(lines) - maxBodyLines
 			body += "\n" + theme.Subtle.Render(fmt.Sprintf("  ▼ %d more lines", more))
 		} else {
 			body = rendered

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -95,6 +95,7 @@ func RenderPost(p model.Post, selected bool, bookmarked bool, watched bool, widt
 		boxStyle = boxStyle.Width(width - 2)
 	}
 
+	body = strings.TrimRight(body, "\n")
 	rows := []string{header}
 	if badges != "" {
 		rows = append(rows, badges)
@@ -102,7 +103,10 @@ func RenderPost(p model.Post, selected bool, bookmarked bool, watched bool, widt
 	if p.Title != "" {
 		rows = append(rows, theme.Highlight.Render(p.Title))
 	}
-	rows = append(rows, body, fmt.Sprintf("\n%s", topics))
+	rows = append(rows, body)
+	if topics != "" {
+		rows = append(rows, "\n"+topics)
+	}
 	return boxStyle.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
 }
 

--- a/internal/ui/screens/screens_test.go
+++ b/internal/ui/screens/screens_test.go
@@ -1361,7 +1361,7 @@ func TestJournal_SetFetching_ClearedBySetNotes(t *testing.T) {
 
 func TestRenderPost_WatchIconPresent(t *testing.T) {
 	p := model.Post{ID: "p1", AuthorUsername: "user", Content: "hello", CreatedAt: time.Now()}
-	out := screens.RenderPost(p, false, false, true, 80, time.UTC, "datetime")
+	out := screens.RenderPost(p, false, false, true, 80, time.UTC, "datetime", 4)
 	if !strings.Contains(out, "◉") {
 		t.Errorf("expected ◉ watch icon in output, got: %q", out)
 	}
@@ -1369,7 +1369,7 @@ func TestRenderPost_WatchIconPresent(t *testing.T) {
 
 func TestRenderPost_WatchIconAbsentWhenNotWatched(t *testing.T) {
 	p := model.Post{ID: "p1", AuthorUsername: "user", Content: "hello", CreatedAt: time.Now()}
-	out := screens.RenderPost(p, false, false, false, 80, time.UTC, "datetime")
+	out := screens.RenderPost(p, false, false, false, 80, time.UTC, "datetime", 4)
 	if strings.Contains(out, "◉") {
 		t.Errorf("expected no ◉ watch icon in output, got: %q", out)
 	}
@@ -1377,7 +1377,7 @@ func TestRenderPost_WatchIconAbsentWhenNotWatched(t *testing.T) {
 
 func TestRenderPost_BookmarkAndWatchIconsStack(t *testing.T) {
 	p := model.Post{ID: "p1", AuthorUsername: "user", Content: "hello", CreatedAt: time.Now()}
-	out := screens.RenderPost(p, false, true, true, 80, time.UTC, "datetime")
+	out := screens.RenderPost(p, false, true, true, 80, time.UTC, "datetime", 4)
 	if !strings.Contains(out, "★") {
 		t.Errorf("expected ★ bookmark icon in output")
 	}

--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -166,6 +166,24 @@ var settingsGroups = []settingsGroup{
 					return m
 				},
 			},
+			{
+				label: "layout", kind: "enum",
+				options: []string{"tabs", "miller"},
+				getEnum: func(m SettingsModel) string {
+					if m.layoutName == "miller" {
+						return "miller"
+					}
+					return "tabs"
+				},
+				cycle: func(m SettingsModel, delta int) SettingsModel {
+					cur := m.layoutName
+					if cur == "" {
+						cur = "tabs"
+					}
+					m.layoutName = cycleStringEnum(cur, []string{"tabs", "miller"}, delta)
+					return m
+				},
+			},
 		},
 	},
 	{
@@ -192,6 +210,8 @@ type SettingsModel struct {
 	originalTimezone       string         // last saved baseline
 	imageViewer            string         // live local config value ("terminal" or "browser")
 	originalImageViewer    string         // last saved baseline
+	layoutName             string         // live local config value ("tabs" or "miller")
+	originalLayoutName     string         // last saved baseline
 	cursor                 int
 	width                  int
 	height                 int
@@ -214,7 +234,7 @@ func (m SettingsModel) SetSettings(s model.Settings) SettingsModel {
 }
 
 // SetSaved marks the current settings as saved and advances the baseline.
-func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, imageViewer string) SettingsModel {
+func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, imageViewer, layoutName string) SettingsModel {
 	m.saved = true
 	m.err = nil
 	m.original = m.settings
@@ -226,6 +246,8 @@ func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, i
 	m.originalTimezone = timezone
 	m.imageViewer = imageViewer
 	m.originalImageViewer = imageViewer
+	m.layoutName = layoutName
+	m.originalLayoutName = layoutName
 	return m
 }
 
@@ -241,7 +263,8 @@ func (m SettingsModel) IsDirty() bool {
 		m.wanderLust != m.originalWanderLust ||
 		m.maxThreadDepth != m.originalMaxThreadDepth ||
 		m.timezone != m.originalTimezone ||
-		m.imageViewer != m.originalImageViewer
+		m.imageViewer != m.originalImageViewer ||
+		m.layoutName != m.originalLayoutName
 }
 
 // settingsEqual compares only the editable scalar fields.
@@ -325,6 +348,8 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			}
 			m.imageViewer = iv
 			m.originalImageViewer = iv
+			m.layoutName = msg.LayoutName
+			m.originalLayoutName = msg.LayoutName
 		}
 		return m, nil
 
@@ -374,8 +399,9 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				td := m.maxThreadDepth
 				tz := m.timezone
 				iv := m.imageViewer
+				ln := m.layoutName
 				return m, func() tea.Msg {
-					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv}
+					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, LayoutName: ln}
 				}
 			}
 			return m, nil
@@ -387,6 +413,7 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			m.maxThreadDepth = m.originalMaxThreadDepth
 			m.timezone = m.originalTimezone
 			m.imageViewer = m.originalImageViewer
+			m.layoutName = m.originalLayoutName
 			m.saved = false
 			m.err = nil
 			return m, nil

--- a/internal/ui/screens/settings_test.go
+++ b/internal/ui/screens/settings_test.go
@@ -250,7 +250,7 @@ func TestSettings_Esc_ClearsError(t *testing.T) {
 func TestSettings_SetSaved_ClearsError(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m = m.SetError(testErr)
-	m = m.SetSaved(false, 3, "UTC", "terminal")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "tabs")
 	if m.err != nil {
 		t.Error("SetSaved should clear error")
 	}
@@ -262,7 +262,7 @@ func TestSettings_SetSaved_AdvancesBaseline(t *testing.T) {
 	if !m.IsDirty() {
 		t.Error("should be dirty after change")
 	}
-	m = m.SetSaved(false, 3, "UTC", "terminal")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "tabs")
 	if m.IsDirty() {
 		t.Error("after SetSaved, should not be dirty")
 	}
@@ -387,7 +387,7 @@ func TestSettings_View_DirtyFooterHint(t *testing.T) {
 
 func TestSettings_View_SavedMessage(t *testing.T) {
 	m := initSettings(defaultSettings())
-	m = m.SetSaved(false, 3, "UTC", "terminal")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "tabs")
 	view := m.View()
 	if !containsSubstring(view, "saved!") {
 		t.Error("View should show 'saved!' when saved=true")
@@ -416,7 +416,7 @@ func TestSettings_WanderGroup_Visible(t *testing.T) {
 func TestSettings_WanderToggle(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
-	m.cursor = 11 // wander mode item (index shifted by added image viewer item)
+	m.cursor = 12 // wander mode item (index shifted by added layout item)
 	m, _ = m.Update(keyMsg("enter"))
 	if m.wanderLust {
 		t.Error("toggling wander mode should flip wanderLust to false")
@@ -458,7 +458,7 @@ func TestSettings_WanderSetSaved(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
 	m.originalWanderLust = false // dirty
-	m = m.SetSaved(true, 3, "UTC", "terminal")
+	m = m.SetSaved(true, 3, "UTC", "terminal", "tabs")
 	if m.originalWanderLust != true {
 		t.Error("SetSaved should update originalWanderLust to the saved value")
 	}

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -418,7 +418,7 @@ func (m TopicsModel) renderTopicItem(index int) string {
 func (m TopicsModel) renderPostItem(p model.Post, selected bool) string {
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
 	_, watched := m.watchedPostIDs[p.ID]
-	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat)
+	return RenderPost(p, selected, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat, postMaxBodyLines)
 }
 
 func (m TopicsModel) refreshContent() TopicsModel {

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -36,7 +36,11 @@ type TopicThreadRepliesMsg struct {
 	Replies []model.Reply
 }
 
-type TopicThreadNavMsg struct{ Delta int }
+type TopicThreadNavMsg struct {
+	Delta      int
+	PaneHeight int
+	PaneWidth  int
+}
 
 // Internal view state for the Topics screen
 type topicsView int
@@ -67,11 +71,12 @@ type TopicsModel struct {
 	loaded      bool
 
 	// Miller 3-pane thread state
-	threadPostID    string
-	threadReplies   []model.Reply
-	threadFlatTree  []replyNode
-	threadReplyIndex int
-	threadLoading   bool
+	threadPostID       string
+	threadReplies      []model.Reply
+	threadFlatTree     []replyNode
+	threadReplyIndex   int
+	threadScrollOffset int
+	threadLoading      bool
 
 	// Shared
 	viewport    viewport.Model
@@ -225,20 +230,15 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 			m.threadReplies = msg.Replies
 			m.threadFlatTree = buildReplyTree(msg.Replies, 3)
 			m.threadReplyIndex = -1
+			m.threadScrollOffset = 0
 			m.threadLoading = false
 		}
 		return m, nil
 
 	case TopicThreadNavMsg:
-		max := len(m.threadFlatTree) - 1
-		next := m.threadReplyIndex + msg.Delta
-		if next < -1 {
-			next = -1
+		if msg.PaneHeight > 0 && msg.PaneWidth > 0 {
+			m = m.pageThreadNav(msg.Delta, msg.PaneHeight, msg.PaneWidth)
 		}
-		if next > max {
-			next = max
-		}
-		m.threadReplyIndex = next
 		return m, nil
 
 	case tea.WindowSizeMsg:
@@ -572,6 +572,7 @@ func (m TopicsModel) currentDetailCmd() (TopicsModel, tea.Cmd) {
 	m.threadReplies = nil
 	m.threadFlatTree = nil
 	m.threadReplyIndex = -1
+	m.threadScrollOffset = 0
 	return m, func() tea.Msg { return LoadTopicThreadMsg{PostID: postID} }
 }
 
@@ -679,6 +680,35 @@ func (m TopicsModel) CompactListView(width, height int) string {
 	return strings.Join(lines, "\n")
 }
 
+// pageThreadNav implements pager-style scrolling for the Miller detail pane.
+func (m TopicsModel) pageThreadNav(delta, paneH, paneW int) TopicsModel {
+	visible := m.visiblePosts()
+	if m.postIndex >= len(visible) {
+		return m
+	}
+	p := visible[m.postIndex]
+	_, bookmarked := m.bookmarkedPostIDs[p.ID]
+	_, watched := m.watchedPostIDs[p.ID]
+
+	postCard := RenderPost(p, false, bookmarked, watched, paneW, m.location(), m.timeDisplayFormat, 0)
+	postH := lipgloss.Height(postCard)
+
+	replyStarts := make([]int, len(m.threadFlatTree))
+	replyHeights := make([]int, len(m.threadFlatTree))
+	pos := postH
+	for i, node := range m.threadFlatTree {
+		replyStarts[i] = pos
+		rendered := m.renderDetailReply(node, false, paneW)
+		replyHeights[i] = lipgloss.Height(rendered)
+		pos += replyHeights[i]
+	}
+
+	m.threadReplyIndex, m.threadScrollOffset = millerPageNav(
+		delta, paneH, postH, replyStarts, replyHeights, m.threadReplyIndex, m.threadScrollOffset,
+	)
+	return m
+}
+
 // DetailView returns the full topic post card + threaded replies for the Miller reading pane.
 func (m TopicsModel) DetailView(width, height int) string {
 	if !m.ready {
@@ -715,27 +745,7 @@ func (m TopicsModel) DetailView(width, height int) string {
 	}
 
 	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
-	if lineCount <= height {
-		return fullContent
-	}
-
-	selectedItem := m.threadReplyIndex + 1
-	offset := 0
-	if selectedItem >= 0 && selectedItem < len(startLines) {
-		offset = startLines[selectedItem]
-	}
-	if offset+height > lineCount {
-		offset = lineCount - height
-	}
-	if offset < 0 {
-		offset = 0
-	}
-	allLines := strings.Split(fullContent, "\n")
-	end := offset + height
-	if end > len(allLines) {
-		end = len(allLines)
-	}
-	return strings.Join(allLines[offset:end], "\n")
+	return sliceContent(fullContent, m.threadScrollOffset, height, lineCount)
 }
 
 // --- Helpers ---

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/ragnar/cyber-tui/internal/model"
+	"github.com/ragnar/cyber-tui/internal/ui/markdown"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
@@ -27,6 +28,15 @@ type RefreshTopicPostsMsg struct{ Slug string }
 type ShowTopicPostMsg struct{ Post model.Post }
 
 type LoadMoreTopicsMsg struct{ Cursor string }
+
+type LoadTopicThreadMsg struct{ PostID string }
+
+type TopicThreadRepliesMsg struct {
+	PostID  string
+	Replies []model.Reply
+}
+
+type TopicThreadNavMsg struct{ Delta int }
 
 // Internal view state for the Topics screen
 type topicsView int
@@ -56,6 +66,13 @@ type TopicsModel struct {
 	refreshing  bool
 	loaded      bool
 
+	// Miller 3-pane thread state
+	threadPostID    string
+	threadReplies   []model.Reply
+	threadFlatTree  []replyNode
+	threadReplyIndex int
+	threadLoading   bool
+
 	// Shared
 	viewport    viewport.Model
 	itemOffsets []int
@@ -73,7 +90,7 @@ type TopicsModel struct {
 }
 
 func NewTopicsModel() TopicsModel {
-	return TopicsModel{}
+	return TopicsModel{threadReplyIndex: -1}
 }
 
 func (m TopicsModel) visiblePosts() []model.Post {
@@ -203,6 +220,27 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case TopicThreadRepliesMsg:
+		if msg.PostID == m.threadPostID {
+			m.threadReplies = msg.Replies
+			m.threadFlatTree = buildReplyTree(msg.Replies, 3)
+			m.threadReplyIndex = -1
+			m.threadLoading = false
+		}
+		return m, nil
+
+	case TopicThreadNavMsg:
+		max := len(m.threadFlatTree) - 1
+		next := m.threadReplyIndex + msg.Delta
+		if next < -1 {
+			next = -1
+		}
+		if next > max {
+			next = max
+		}
+		m.threadReplyIndex = next
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -226,11 +264,19 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 					m = m.refreshContent()
 					m = m.ensureSelectedVisible()
 				}
-			} else {
+			} else if m.view == viewTopicPosts {
 				if m.postIndex > 0 {
 					m.postIndex--
 					m = m.refreshContent()
 					m = m.ensureSelectedVisible()
+					var detailCmd tea.Cmd
+					m, detailCmd = m.currentDetailCmd()
+					return m, detailCmd
+				} else if !m.loading && !m.refreshing {
+					slug := m.activeTopic
+					m.refreshing = true
+					m = m.refreshContent()
+					return m, func() tea.Msg { return RefreshTopicPostsMsg{Slug: slug} }
 				}
 			}
 			return m, nil
@@ -249,11 +295,14 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 						return LoadMoreTopicsMsg{Cursor: m.topicsNextCursor}
 					}
 				}
-			} else {
+			} else if m.view == viewTopicPosts {
 				if m.postIndex < len(m.visiblePosts())-1 {
 					m.postIndex++
 					m = m.refreshContent()
 					m = m.ensureSelectedVisible()
+					var detailCmd tea.Cmd
+					m, detailCmd = m.currentDetailCmd()
+					return m, detailCmd
 				} else if !m.exhausted && !m.loading {
 					m.loading = true
 					m = m.refreshContent()
@@ -498,6 +547,195 @@ func (m TopicsModel) GetFocusedURLs() []string {
 	}
 	p := visible[m.postIndex]
 	return append(extractURLs(p.Content), attachmentURLs(p.Attachments)...)
+}
+
+// IsViewingTopicPosts reports whether the topic post list is currently shown (3-pane applies).
+func (m TopicsModel) IsViewingTopicPosts() bool { return m.view == viewTopicPosts }
+
+// IsAtTop reports whether the first post is selected.
+func (m TopicsModel) IsAtTop() bool { return m.postIndex == 0 }
+
+// PostCount returns the number of currently visible topic posts.
+func (m TopicsModel) PostCount() int { return len(m.visiblePosts()) }
+
+func (m TopicsModel) currentDetailCmd() (TopicsModel, tea.Cmd) {
+	visible := m.visiblePosts()
+	if m.postIndex >= len(visible) {
+		return m, nil
+	}
+	postID := visible[m.postIndex].ID
+	if postID == m.threadPostID {
+		return m, nil
+	}
+	m.threadPostID = postID
+	m.threadLoading = true
+	m.threadReplies = nil
+	m.threadFlatTree = nil
+	m.threadReplyIndex = -1
+	return m, func() tea.Msg { return LoadTopicThreadMsg{PostID: postID} }
+}
+
+// CurrentDetailCmd is exported so app.go can trigger the initial detail load when topic posts first arrive.
+func (m TopicsModel) CurrentDetailCmd() (TopicsModel, tea.Cmd) {
+	return m.currentDetailCmd()
+}
+
+func (m TopicsModel) renderDetailReply(node replyNode, selected bool, width int) string {
+	indentW := node.Depth * 3
+	cardWidth := width - 2 - indentW
+	if cardWidth < 4 {
+		cardWidth = 4
+	}
+	innerWidth := cardWidth - 2
+	if innerWidth < 1 {
+		innerWidth = 1
+	}
+	header := theme.Highlight.Render("@" + node.Reply.AuthorUsername)
+	if node.ParentUsername != "" {
+		header += theme.Subtle.Render("  ↩ @" + node.ParentUsername)
+	}
+	header += theme.Subtle.Render("  " + displayTime(node.Reply.CreatedAt, m.location(), m.timeDisplayFormat, false))
+	body := strings.TrimRight(markdown.Render(node.Reply.Content, innerWidth), "\n")
+	boxStyle := theme.Border
+	if selected {
+		boxStyle = theme.ActiveBorder
+	}
+	if cardWidth > 0 {
+		boxStyle = boxStyle.Width(cardWidth)
+	}
+	card := boxStyle.Render(lipgloss.JoinVertical(lipgloss.Left, header, body))
+	if indentW > 0 {
+		return lipgloss.NewStyle().MarginLeft(indentW).Render(card)
+	}
+	return card
+}
+
+func (m TopicsModel) renderCompactPost(p model.Post, selected bool, width int) string {
+	username := "@" + p.AuthorUsername
+	var preview string
+	if p.Title != "" {
+		preview = p.Title
+	} else {
+		preview = strings.TrimSpace(strings.SplitN(p.Content, "\n", 2)[0])
+	}
+	const sep = "  "
+	var indicatorAndName string
+	if selected {
+		indicatorAndName = theme.Highlight.Render("▶ " + username)
+	} else {
+		indicatorAndName = theme.Subtle.Render("  ") + theme.Base.Render(username)
+	}
+	prefixWidth := 2 + lipgloss.Width(username) + len(sep)
+	remaining := width - prefixWidth
+	if remaining > 1 {
+		preview = ansiTruncate(preview, remaining)
+	} else {
+		preview = ""
+	}
+	return indicatorAndName + theme.Subtle.Render(sep+preview)
+}
+
+// CompactListView returns the compact single-line topic post list for the Miller list pane.
+func (m TopicsModel) CompactListView(width, height int) string {
+	if !m.ready || m.fetching {
+		return theme.Subtle.Render("  loading…")
+	}
+	visible := m.visiblePosts()
+	if len(visible) == 0 {
+		return theme.Subtle.Render("  no posts")
+	}
+	headerLines := 0
+	var header string
+	if m.refreshing {
+		header = theme.Subtle.Render("  fetching new posts...")
+		headerLines = 1
+	}
+	n := len(visible)
+	listH := height - headerLines
+	if listH < 1 {
+		listH = 1
+	}
+	offset := m.postIndex - listH + 1
+	if offset < 0 {
+		offset = 0
+	}
+	if offset+listH > n {
+		offset = n - listH
+		if offset < 0 {
+			offset = 0
+		}
+	}
+	end := offset + listH
+	if end > n {
+		end = n
+	}
+	lines := make([]string, 0, end-offset+headerLines)
+	if header != "" {
+		lines = append(lines, header)
+	}
+	for i := offset; i < end; i++ {
+		lines = append(lines, m.renderCompactPost(visible[i], i == m.postIndex, width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// DetailView returns the full topic post card + threaded replies for the Miller reading pane.
+func (m TopicsModel) DetailView(width, height int) string {
+	if !m.ready {
+		return theme.Subtle.Render("  loading…")
+	}
+	visible := m.visiblePosts()
+	if len(visible) == 0 {
+		return theme.Subtle.Render("  no posts")
+	}
+	if m.postIndex >= len(visible) {
+		return theme.Subtle.Render("  select a post")
+	}
+	p := visible[m.postIndex]
+	_, bookmarked := m.bookmarkedPostIDs[p.ID]
+	_, watched := m.watchedPostIDs[p.ID]
+
+	postSelected := m.threadReplyIndex < 0
+	card := RenderPost(p, postSelected, bookmarked, watched, width, m.location(), m.timeDisplayFormat, 0)
+
+	var parts []string
+	startLines := []int{0}
+	lineCount := lipgloss.Height(card)
+	parts = append(parts, card)
+
+	if m.threadLoading {
+		parts = append(parts, theme.Subtle.Render("  loading replies…"))
+	} else {
+		for i, node := range m.threadFlatTree {
+			rendered := m.renderDetailReply(node, i == m.threadReplyIndex, width)
+			startLines = append(startLines, lineCount)
+			lineCount += lipgloss.Height(rendered)
+			parts = append(parts, rendered)
+		}
+	}
+
+	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
+	if lineCount <= height {
+		return fullContent
+	}
+
+	selectedItem := m.threadReplyIndex + 1
+	offset := 0
+	if selectedItem >= 0 && selectedItem < len(startLines) {
+		offset = startLines[selectedItem]
+	}
+	if offset+height > lineCount {
+		offset = lineCount - height
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	allLines := strings.Split(fullContent, "\n")
+	end := offset + height
+	if end > len(allLines) {
+		end = len(allLines)
+	}
+	return strings.Join(allLines[offset:end], "\n")
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary

- **Miller Columns layout** — new 3-pane reading experience (nav sidebar / compact post list / detail pane with threaded replies) available for Feed, Guilds, and Topics. Toggle via Settings. Replaces the single-screen tabs view when enabled.
- **Logo animation** — random scramble/unscramble effect every 30s on the idle screen.
- **Notification auto-refresh** — notification list reloads automatically when the background poll detects new items.
- **Feed tab lazy reload** — pressing the feed tab key no longer fires a redundant API fetch when the feed is already loaded. Matches the existing `IsLoaded()` guard pattern used by Bookmarks, Guilds, and Topics.

## Miller layout details

- Left pane: navigation menu (22 chars)
- Middle pane: compact single-line post list with sticky scroll
- Right pane: full post card + threaded replies tree with pager-style line scrolling
- Auto-fills the compact list column on first load to ensure it is never sparsely populated
- Guilds and Topics show their own post lists in Miller when a guild/topic is selected

## Test plan

- [x] Enable Miller layout in Settings, verify 3-pane view renders for Feed, Guilds, Topics
- [x] Navigate between posts with j/k — detail pane updates with correct replies
- [x] Switch between layouts (Settings toggle) — existing data preserved, no blank flash
- [x] Press feed tab key after feed is loaded — no spinner, existing posts shown instantly
- [x] Scroll to top of feed — refresh fires as before
- [x] Logo animation plays on idle screen
- [x] New notification arrives — notification list refreshes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)