### PR TITLE
feat: settings save optimisation and Miller→Tabs navigation fix

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -856,6 +856,7 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.imageViewer = msg.imageViewer
 		a.layoutName = msg.layoutName
 		a.layout = layoutFromName(msg.layoutName)
+		a.focus = focusMenu
 		a.loc = config.ParseTimezoneLabel(msg.timezone)
 		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.layoutName)
 		a.broadcastConfig()

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -833,8 +833,10 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		iv := msg.ImageViewer
 		ln := msg.LayoutName
 		return a, func() tea.Msg {
-			if err := a.client.UpdateSettings(s); err != nil {
-				return actionErrMsg{err}
+			if msg.RemoteChanged {
+				if err := a.client.UpdateSettings(s); err != nil {
+					return actionErrMsg{err}
+				}
 			}
 			a.saveConfig(func(cfg *config.Config) {
 				cfg.WanderLust = wl

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -70,6 +70,7 @@ type SaveSettingsMsg struct {
 	Timezone       string
 	ImageViewer    string
 	LayoutName     string // "tabs" or "miller"
+	RemoteChanged  bool   // true when API-managed fields differ from the last saved baseline
 }
 
 // BookmarkedMsg is sent back to the bookmarks screen after a successful CreateBookmark

--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -400,8 +400,9 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				tz := m.timezone
 				iv := m.imageViewer
 				ln := m.layoutName
+				remoteChanged := !settingsEqual(m.settings, m.original)
 				return m, func() tea.Msg {
-					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, LayoutName: ln}
+					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, LayoutName: ln, RemoteChanged: remoteChanged}
 				}
 			}
 			return m, nil


### PR DESCRIPTION
## Summary

- **Skip API call for local-only settings**: When the user saves settings that only differ in TUI-local fields (layout, timezone, image viewer, thread depth, wander lust), the `UpdateSettings` API call is skipped — only `saveConfig` is called. Remote settings (notifications, NSFW filter, etc.) still trigger the API as before.
- **Fix Miller→Tabs navigation**: Switching from Miller to Tabs while focus was on `focusList` or `focusDetail` left the `focus` field in a state incompatible with Tabs layout, causing left/right tab navigation to silently fail. Focus is now reset to `focusMenu` on every layout change.

## Test plan

- [x] Change a **local-only setting** (e.g. layout, timezone) → Ctrl+S → no API round-trip; change takes effect
- [x] Change a **remote setting** (e.g. filter NSFW) → Ctrl+S → API call fires as before
- [x] In Miller layout, drill into list or detail pane → open Settings → switch to Tabs → left/right navigation works immediately
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)