### PR TITLE
feat: show active guild/topic name in Miller posts column header

### DIFF
--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -51,7 +51,7 @@ func (l MillerLayout) View(a App) string {
 		listW := millerListWidth
 		detailW := contentW - listW - 1
 
-		listHdr := l.renderColumnHeader("posts", a.focus == focusList, listW)
+		listHdr := l.renderColumnHeader("posts (◆ "+a.guilds.ActiveGuildName()+")", a.focus == focusList, listW)
 		detailHdr := l.renderColumnHeader("thread", a.focus == focusDetail, detailW)
 		hdrRow = lipgloss.JoinHorizontal(lipgloss.Top, navHdr, colSep, listHdr, colSep, detailHdr)
 
@@ -65,7 +65,7 @@ func (l MillerLayout) View(a App) string {
 		listW := millerListWidth
 		detailW := contentW - listW - 1
 
-		listHdr := l.renderColumnHeader("posts", a.focus == focusList, listW)
+		listHdr := l.renderColumnHeader("posts (# "+a.topics.ActiveTopicName()+")", a.focus == focusList, listW)
 		detailHdr := l.renderColumnHeader("thread", a.focus == focusDetail, detailW)
 		hdrRow = lipgloss.JoinHorizontal(lipgloss.Top, navHdr, colSep, listHdr, colSep, detailHdr)
 

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -976,6 +976,14 @@ func (m GuildsModel) GetFocusedURLs() []string {
 // IsViewingGuildPosts reports whether the guild post list is currently shown (3-pane applies).
 func (m GuildsModel) IsViewingGuildPosts() bool { return m.view == viewGuildPosts }
 
+// ActiveGuildName returns the display name of the active guild, falling back to the slug if detail has not yet loaded.
+func (m GuildsModel) ActiveGuildName() string {
+	if m.guildDetailLoaded {
+		return m.activeGuildDetail.Name
+	}
+	return m.activeGuild
+}
+
 // IsAtTop reports whether the first post is selected (used to suppress pull-to-refresh in Miller).
 func (m GuildsModel) IsAtTop() bool { return m.postIndex == 0 }
 

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -552,6 +552,9 @@ func (m TopicsModel) GetFocusedURLs() []string {
 // IsViewingTopicPosts reports whether the topic post list is currently shown (3-pane applies).
 func (m TopicsModel) IsViewingTopicPosts() bool { return m.view == viewTopicPosts }
 
+// ActiveTopicName returns the slug of the currently active topic.
+func (m TopicsModel) ActiveTopicName() string { return m.activeTopic }
+
 // IsAtTop reports whether the first post is selected.
 func (m TopicsModel) IsAtTop() bool { return m.postIndex == 0 }
 


### PR DESCRIPTION
## Summary

- Adds `ActiveGuildName()` to `GuildsModel` — returns full guild name once detail is loaded, falls back to slug
- Adds `ActiveTopicName()` to `TopicsModel` — returns the active topic slug
- Miller layout header now reads `posts (◆ GuildName)` when on Guilds and `posts (# topicslug)` when on Topics, giving users context about which guild or topic they're browsing

## Test plan

- [x] Open Miller layout on the Guilds screen, drill into a guild's post list — confirm header shows `posts (◆ <guild name>)`
- [x] Open Miller layout on the Topics screen, drill into a topic — confirm header shows `posts (# <topic>)`
- [x] Verify header falls back to guild slug before detail has loaded
- [x] Confirm no regression on Feed tab Miller header (still shows plain `posts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)