### PR TITLE
feat: Miller layout improvements for guilds and topics

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1181,6 +1181,12 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.guilds = a.guilds.SetGuildPosts(msg.posts, msg.cursor)
 		var detailCmd tea.Cmd
 		a.guilds, detailCmd = a.guilds.CurrentDetailCmd()
+		if _, isMiller := a.layout.(MillerLayout); isMiller && msg.cursor != "" {
+			compactH := a.height - 2
+			if a.guilds.PostCount() < compactH {
+				return a, tea.Batch(detailCmd, a.loadGuildPostsPageCmd(msg.slug, msg.cursor)), true
+			}
+		}
 		if detailCmd != nil {
 			return a, detailCmd, true
 		}
@@ -1205,6 +1211,12 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 			return a, nil, true
 		}
 		a.guilds = a.guilds.AppendGuildPosts(msg.posts, msg.cursor)
+		if _, isMiller := a.layout.(MillerLayout); isMiller && msg.cursor != "" {
+			compactH := a.height - 2
+			if a.guilds.PostCount() < compactH {
+				return a, a.loadGuildPostsPageCmd(msg.slug, msg.cursor), true
+			}
+		}
 		return a, nil, true
 
 	case screens.RefreshGuildPostsMsg:
@@ -1296,6 +1308,12 @@ func (a App) handleTopics(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.topics = a.topics.SetTopicPosts(msg.posts, msg.cursor)
 		var detailCmd tea.Cmd
 		a.topics, detailCmd = a.topics.CurrentDetailCmd()
+		if _, isMiller := a.layout.(MillerLayout); isMiller && msg.cursor != "" {
+			compactH := a.height - 2
+			if a.topics.PostCount() < compactH {
+				return a, tea.Batch(detailCmd, a.loadTopicPostsPageCmd(a.topics.ActiveTopicName(), msg.cursor)), true
+			}
+		}
 		if detailCmd != nil {
 			return a, detailCmd, true
 		}
@@ -1317,6 +1335,12 @@ func (a App) handleTopics(msg tea.Msg) (App, tea.Cmd, bool) {
 
 	case topicPostsPageMsg:
 		a.topics = a.topics.AppendTopicPosts(msg.posts, msg.cursor)
+		if _, isMiller := a.layout.(MillerLayout); isMiller && msg.cursor != "" {
+			compactH := a.height - 2
+			if a.topics.PostCount() < compactH {
+				return a, a.loadTopicPostsPageCmd(a.topics.ActiveTopicName(), msg.cursor), true
+			}
+		}
 		return a, nil, true
 
 	case screens.RefreshTopicPostsMsg:
@@ -1608,6 +1632,7 @@ func (a *App) refreshViewports() {
 	a.notifications, _ = a.notifications.Update(msg)
 	a.bookmarks, _ = a.bookmarks.Update(msg)
 	a.topics, _ = a.topics.Update(msg)
+	a.guilds, _ = a.guilds.Update(msg)
 	a.journal, _ = a.journal.Update(msg)
 }
 

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -348,6 +348,7 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 	case FeedDetailDebounceMsg:
 		visible := m.visiblePosts()
 		if m.selectedIndex < len(visible) && visible[m.selectedIndex].ID == msg.PostID {
+			m.detailLoading = true
 			return m, func() tea.Msg { return LoadFeedDetailMsg{PostID: msg.PostID} }
 		}
 		return m, nil
@@ -599,7 +600,7 @@ func (m FeedModel) currentDetailCmd() (FeedModel, tea.Cmd) {
 		return m, nil
 	}
 	m.detailPostID = postID
-	m.detailLoading = true
+	m.detailLoading = false
 	m.detailReplies = nil
 	m.detailFlatTree = nil
 	m.detailReplyIndex = -1

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -349,7 +349,7 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		visible := m.visiblePosts()
 		if m.selectedIndex < len(visible) && visible[m.selectedIndex].ID == msg.PostID {
 			m.detailLoading = true
-			return m, func() tea.Msg { return LoadFeedDetailMsg{PostID: msg.PostID} }
+			return m, func() tea.Msg { return LoadFeedDetailMsg(msg) }
 		}
 		return m, nil
 

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -385,7 +385,7 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 		visible := m.visiblePosts()
 		if m.postIndex < len(visible) && visible[m.postIndex].ID == msg.PostID {
 			m.threadLoading = true
-			return m, func() tea.Msg { return LoadGuildThreadMsg{PostID: msg.PostID} }
+			return m, func() tea.Msg { return LoadGuildThreadMsg(msg) }
 		}
 		return m, nil
 

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -70,6 +70,13 @@ type GuildThreadNavMsg struct {
 	PaneWidth  int
 }
 
+// GuildThreadDebounceMsg is the delayed message emitted after guildThreadDebounceDelay
+// when the selected post changes. The fetch only proceeds if PostID still matches
+// the current selection, dropping stale ticks from rapid navigation.
+type GuildThreadDebounceMsg struct{ PostID string }
+
+const guildThreadDebounceDelay = time.Second
+
 // guildsConfirm tracks whether a join/leave confirmation prompt is active.
 type guildsConfirm int
 
@@ -371,6 +378,14 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 			m.threadReplyIndex = -1
 			m.threadScrollOffset = 0
 			m.threadLoading = false
+		}
+		return m, nil
+
+	case GuildThreadDebounceMsg:
+		visible := m.visiblePosts()
+		if m.postIndex < len(visible) && visible[m.postIndex].ID == msg.PostID {
+			m.threadLoading = true
+			return m, func() tea.Msg { return LoadGuildThreadMsg{PostID: msg.PostID} }
 		}
 		return m, nil
 
@@ -990,7 +1005,32 @@ func (m GuildsModel) IsAtTop() bool { return m.postIndex == 0 }
 // PostCount returns the number of currently visible guild posts.
 func (m GuildsModel) PostCount() int { return len(m.visiblePosts()) }
 
+// currentDetailCmd clears the detail pane immediately and starts a debounce timer.
+// The API fetch only fires if the selection hasn't changed by the time the timer expires,
+// avoiding a flood of calls when the user scrolls quickly through the post list.
 func (m GuildsModel) currentDetailCmd() (GuildsModel, tea.Cmd) {
+	visible := m.visiblePosts()
+	if m.postIndex >= len(visible) {
+		return m, nil
+	}
+	postID := visible[m.postIndex].ID
+	if postID == m.threadPostID {
+		return m, nil
+	}
+	m.threadPostID = postID
+	m.threadLoading = false
+	m.threadReplies = nil
+	m.threadFlatTree = nil
+	m.threadReplyIndex = -1
+	m.threadScrollOffset = 0
+	return m, tea.Tick(guildThreadDebounceDelay, func(time.Time) tea.Msg {
+		return GuildThreadDebounceMsg{PostID: postID}
+	})
+}
+
+// CurrentDetailCmd is exported so app.go can trigger the initial detail load when guild posts first arrive.
+// Loads immediately without debounce.
+func (m GuildsModel) CurrentDetailCmd() (GuildsModel, tea.Cmd) {
 	visible := m.visiblePosts()
 	if m.postIndex >= len(visible) {
 		return m, nil
@@ -1006,11 +1046,6 @@ func (m GuildsModel) currentDetailCmd() (GuildsModel, tea.Cmd) {
 	m.threadReplyIndex = -1
 	m.threadScrollOffset = 0
 	return m, func() tea.Msg { return LoadGuildThreadMsg{PostID: postID} }
-}
-
-// CurrentDetailCmd is exported so app.go can trigger the initial detail load when guild posts first arrive.
-func (m GuildsModel) CurrentDetailCmd() (GuildsModel, tea.Cmd) {
-	return m.currentDetailCmd()
 }
 
 func (m GuildsModel) renderDetailReply(node replyNode, selected bool, width int) string {

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -36,6 +36,13 @@ type TopicThreadRepliesMsg struct {
 	Replies []model.Reply
 }
 
+// TopicThreadDebounceMsg is the delayed message emitted after topicThreadDebounceDelay
+// when the selected post changes. The fetch only proceeds if PostID still matches
+// the current selection, dropping stale ticks from rapid navigation.
+type TopicThreadDebounceMsg struct{ PostID string }
+
+const topicThreadDebounceDelay = time.Second
+
 type TopicThreadNavMsg struct {
 	Delta      int
 	PaneHeight int
@@ -232,6 +239,14 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 			m.threadReplyIndex = -1
 			m.threadScrollOffset = 0
 			m.threadLoading = false
+		}
+		return m, nil
+
+	case TopicThreadDebounceMsg:
+		visible := m.visiblePosts()
+		if m.postIndex < len(visible) && visible[m.postIndex].ID == msg.PostID {
+			m.threadLoading = true
+			return m, func() tea.Msg { return LoadTopicThreadMsg{PostID: msg.PostID} }
 		}
 		return m, nil
 
@@ -561,7 +576,32 @@ func (m TopicsModel) IsAtTop() bool { return m.postIndex == 0 }
 // PostCount returns the number of currently visible topic posts.
 func (m TopicsModel) PostCount() int { return len(m.visiblePosts()) }
 
+// currentDetailCmd clears the detail pane immediately and starts a debounce timer.
+// The API fetch only fires if the selection hasn't changed by the time the timer expires,
+// avoiding a flood of calls when the user scrolls quickly through the post list.
 func (m TopicsModel) currentDetailCmd() (TopicsModel, tea.Cmd) {
+	visible := m.visiblePosts()
+	if m.postIndex >= len(visible) {
+		return m, nil
+	}
+	postID := visible[m.postIndex].ID
+	if postID == m.threadPostID {
+		return m, nil
+	}
+	m.threadPostID = postID
+	m.threadLoading = false
+	m.threadReplies = nil
+	m.threadFlatTree = nil
+	m.threadReplyIndex = -1
+	m.threadScrollOffset = 0
+	return m, tea.Tick(topicThreadDebounceDelay, func(time.Time) tea.Msg {
+		return TopicThreadDebounceMsg{PostID: postID}
+	})
+}
+
+// CurrentDetailCmd is exported so app.go can trigger the initial detail load when topic posts first arrive.
+// Loads immediately without debounce.
+func (m TopicsModel) CurrentDetailCmd() (TopicsModel, tea.Cmd) {
 	visible := m.visiblePosts()
 	if m.postIndex >= len(visible) {
 		return m, nil
@@ -577,11 +617,6 @@ func (m TopicsModel) currentDetailCmd() (TopicsModel, tea.Cmd) {
 	m.threadReplyIndex = -1
 	m.threadScrollOffset = 0
 	return m, func() tea.Msg { return LoadTopicThreadMsg{PostID: postID} }
-}
-
-// CurrentDetailCmd is exported so app.go can trigger the initial detail load when topic posts first arrive.
-func (m TopicsModel) CurrentDetailCmd() (TopicsModel, tea.Cmd) {
-	return m.currentDetailCmd()
 }
 
 func (m TopicsModel) renderDetailReply(node replyNode, selected bool, width int) string {

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -246,7 +246,7 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 		visible := m.visiblePosts()
 		if m.postIndex < len(visible) && visible[m.postIndex].ID == msg.PostID {
 			m.threadLoading = true
-			return m, func() tea.Msg { return LoadTopicThreadMsg{PostID: msg.PostID} }
+			return m, func() tea.Msg { return LoadTopicThreadMsg(msg) }
 		}
 		return m, nil
 


### PR DESCRIPTION
## Summary

- **fix:** Defer the "loading replies…" indicator in the Miller preview pane until the 1-second debounce fires — previously it flashed immediately on every keypress during fast navigation. Guilds and Topics gain the same reply-loading debounce that Feed already had (`GuildThreadDebounceMsg` / `TopicThreadDebounceMsg`). `CurrentDetailCmd()` on both screens remains an immediate load for the initial page arrival.
- **feat:** Auto-fill the Miller compact list on load for Guilds and Topics, mirroring the existing Feed behaviour. After each page arrives, if the post count is still less than the column height (`a.height - 2`) and a cursor is available, the next page is fetched automatically.
- **fix:** `a.guilds` was missing from `refreshViewports()`, causing the guilds viewport to retain Miller's inflated content height after switching to the Tabs layout, leaving the post list not filling the screen.

## Test plan

- [x] In Miller layout, navigate quickly through a guild or topic post list — "loading replies…" must not appear until the selection is held for ~1 second
- [x] Enter a guild or topic in Miller layout with more posts than fit one API page — compact list should auto-fill the column without manual scrolling
- [x] Switch from Miller to Tabs while a guild is open — post list must fill the Tabs viewport correctly (no blank space at bottom)
- [x] Confirm Tabs layout is unaffected by the fill-screen logic (guard is `isMiller` only)
- [x] `go test ./...`, `go vet ./...`, `staticcheck ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)