### PR TITLE
fix: Miller layout auto-fill and thread depth fixes

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -861,6 +861,26 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.layoutName)
 		a.broadcastConfig()
 		a.refreshViewports()
+		if _, isMiller := a.layout.(MillerLayout); isMiller {
+			compactH := a.height - 2
+			var cmds []tea.Cmd
+			if cursor := a.feed.NextCursor(); cursor != "" && a.feed.PostCount() < compactH {
+				cmds = append(cmds, a.loadFeedPageCmd(cursor))
+			}
+			if a.guilds.IsViewingGuildPosts() {
+				if cursor := a.guilds.PostsNextCursor(); cursor != "" && a.guilds.PostCount() < compactH {
+					cmds = append(cmds, a.loadGuildPostsPageCmd(a.guilds.ActiveGuild(), cursor))
+				}
+			}
+			if a.topics.IsViewingTopicPosts() {
+				if cursor := a.topics.PostsNextCursor(); cursor != "" && a.topics.PostCount() < compactH {
+					cmds = append(cmds, a.loadTopicPostsPageCmd(a.topics.ActiveTopicName(), cursor))
+				}
+			}
+			if len(cmds) > 0 {
+				return a, tea.Batch(cmds...), true
+			}
+		}
 		return a, nil, true
 
 	case wanderTickMsg:

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -97,6 +97,7 @@ type FeedModel struct {
 	detailReplyIndex int         // -1 = post selected; 0+ = index into detailFlatTree
 	detailScrollOffset int       // raw line offset for pager scrolling in the detail pane
 	detailLoading    bool
+	maxThreadDepth   int
 }
 
 func NewFeedModel() FeedModel {
@@ -317,6 +318,12 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 				m = m.refreshContent()
 			}
 		}
+		if msg.MaxThreadDepth != m.maxThreadDepth {
+			m.maxThreadDepth = msg.MaxThreadDepth
+			if len(m.detailReplies) > 0 {
+				m.detailFlatTree = buildReplyTree(m.detailReplies, m.effectiveMaxDepth())
+			}
+		}
 		return m, nil
 
 	case BookmarkedIDsMsg:
@@ -338,7 +345,7 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		if m.selectedIndex < len(visible) && visible[m.selectedIndex].ID == msg.PostID {
 			m.detailPostID = msg.PostID
 			m.detailReplies = msg.Replies
-			m.detailFlatTree = buildReplyTree(msg.Replies, 3)
+			m.detailFlatTree = buildReplyTree(msg.Replies, m.effectiveMaxDepth())
 			m.detailReplyIndex = -1
 			m.detailScrollOffset = 0
 			m.detailLoading = false
@@ -700,6 +707,16 @@ func (m FeedModel) IsAtTop() bool { return m.selectedIndex == 0 }
 
 // PostCount returns the number of currently visible posts (respects NSFW filter).
 func (m FeedModel) PostCount() int { return len(m.visiblePosts()) }
+
+// NextCursor returns the pagination cursor for the next page of feed posts.
+func (m FeedModel) NextCursor() string { return m.nextCursor }
+
+func (m FeedModel) effectiveMaxDepth() int {
+	if m.maxThreadDepth <= 0 {
+		return 3
+	}
+	return m.maxThreadDepth
+}
 
 // ansiTruncate truncates s to at most maxWidth terminal columns, appending "…" if truncated.
 // Operates on plain text (no ANSI codes in post titles or raw content first lines).

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -131,6 +131,7 @@ type GuildsModel struct {
 
 	// Miller reading pane: replies for the currently selected guild post.
 	threadPostID       string
+	maxThreadDepth     int
 	threadReplies      []model.Reply
 	threadFlatTree     []replyNode
 	threadReplyIndex   int
@@ -353,6 +354,12 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 		if m.ready {
 			m = m.refreshContent()
 		}
+		if msg.MaxThreadDepth != m.maxThreadDepth {
+			m.maxThreadDepth = msg.MaxThreadDepth
+			if len(m.threadReplies) > 0 {
+				m.threadFlatTree = buildReplyTree(m.threadReplies, m.effectiveMaxDepth())
+			}
+		}
 		return m, nil
 
 	case BookmarkedIDsMsg:
@@ -374,7 +381,7 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 		if m.postIndex < len(visible) && visible[m.postIndex].ID == msg.PostID {
 			m.threadPostID = msg.PostID
 			m.threadReplies = msg.Replies
-			m.threadFlatTree = buildReplyTree(msg.Replies, 3)
+			m.threadFlatTree = buildReplyTree(msg.Replies, m.effectiveMaxDepth())
 			m.threadReplyIndex = -1
 			m.threadScrollOffset = 0
 			m.threadLoading = false
@@ -1004,6 +1011,16 @@ func (m GuildsModel) IsAtTop() bool { return m.postIndex == 0 }
 
 // PostCount returns the number of currently visible guild posts.
 func (m GuildsModel) PostCount() int { return len(m.visiblePosts()) }
+
+// PostsNextCursor returns the pagination cursor for the next page of guild posts.
+func (m GuildsModel) PostsNextCursor() string { return m.nextCursor }
+
+func (m GuildsModel) effectiveMaxDepth() int {
+	if m.maxThreadDepth <= 0 {
+		return 3
+	}
+	return m.maxThreadDepth
+}
 
 // currentDetailCmd clears the detail pane immediately and starts a debounce timer.
 // The API fetch only fires if the selection hasn't changed by the time the timer expires,

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -79,6 +79,7 @@ type TopicsModel struct {
 
 	// Miller 3-pane thread state
 	threadPostID       string
+	maxThreadDepth     int
 	threadReplies      []model.Reply
 	threadFlatTree     []replyNode
 	threadReplyIndex   int
@@ -216,6 +217,12 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 		if m.ready {
 			m = m.refreshContent()
 		}
+		if msg.MaxThreadDepth != m.maxThreadDepth {
+			m.maxThreadDepth = msg.MaxThreadDepth
+			if len(m.threadReplies) > 0 {
+				m.threadFlatTree = buildReplyTree(m.threadReplies, m.effectiveMaxDepth())
+			}
+		}
 		return m, nil
 
 	case BookmarkedIDsMsg:
@@ -235,7 +242,7 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 	case TopicThreadRepliesMsg:
 		if msg.PostID == m.threadPostID {
 			m.threadReplies = msg.Replies
-			m.threadFlatTree = buildReplyTree(msg.Replies, 3)
+			m.threadFlatTree = buildReplyTree(msg.Replies, m.effectiveMaxDepth())
 			m.threadReplyIndex = -1
 			m.threadScrollOffset = 0
 			m.threadLoading = false
@@ -575,6 +582,16 @@ func (m TopicsModel) IsAtTop() bool { return m.postIndex == 0 }
 
 // PostCount returns the number of currently visible topic posts.
 func (m TopicsModel) PostCount() int { return len(m.visiblePosts()) }
+
+// PostsNextCursor returns the pagination cursor for the next page of topic posts.
+func (m TopicsModel) PostsNextCursor() string { return m.nextCursor }
+
+func (m TopicsModel) effectiveMaxDepth() int {
+	if m.maxThreadDepth <= 0 {
+		return 3
+	}
+	return m.maxThreadDepth
+}
 
 // currentDetailCmd clears the detail pane immediately and starts a debounce timer.
 // The API fetch only fires if the selection hasn't changed by the time the timer expires,


### PR DESCRIPTION
## Summary

- **Auto-fill on layout switch**: switching from Tabs → Miller now triggers page fetches to fill the compact list column; previously `settingsSavedMsg` called `refreshViewports()` and returned without checking whether enough posts were loaded to fill the screen
- **Thread depth in Miller preview pane**: the preview/detail pane now respects the user's configured Max Thread Depth setting; `FeedModel`, `GuildsModel`, and `TopicsModel` were calling `buildReplyTree` with a hardcoded depth of `3` instead of reading from `SharedConfigMsg`, now follows the same pattern as `PostDetailModel`
- **Earlier commits on this branch**: auto-fill on initial Miller load for guilds/topics, debounced reply loading indicator, reply debounce

## Test plan

- [x] In Tabs layout with multiple pages loaded, open Settings → change Layout to Miller → compact list should immediately start filling beyond the first page
- [x] Repeat for guild posts and topic posts
- [x] Set Max Thread Depth to a value other than 3 (e.g. 1 or 5), select a post with deep replies in Miller preview pane → nesting should match the setting
- [x] Change Max Thread Depth while a thread is visible → preview pane should update immediately
- [x] `go test ./... && go vet ./... && staticcheck ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)