### PR TITLE
fix: Miller layout column resize and compose panel UX

### DIFF
--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -41,6 +41,16 @@ type CompactListRenderer interface {
 	DetailView(width, height int) string
 }
 
+// CompactComposer is an optional extension of CompactListRenderer for screens that have
+// a compose panel. In Miller mode the layout pulls the panel out of DetailView and
+// renders it as a full-width row spanning the list and detail columns, making it clear
+// the user is composing a new post rather than a reply.
+type CompactComposer interface {
+	ComposeActive() bool
+	ComposeHeight() int           // total rows the panel occupies (for contentH budget)
+	ComposeView(width int) string // panel rendered at the given spanning width
+}
+
 // menuTabs is the ordered list of navigable screens.
 var menuTabs = []struct {
 	label string

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -65,7 +65,6 @@ func (l MillerLayout) View(a App) string {
 
 	contentH := a.height - 1 - millerHeaderHeight // full height minus bottom bar and column header
 	contentW := a.width - millerSidebarWidth
-	navPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderNav(a))
 
 	// Column header row — active column title in accent, others muted.
 	navHdr := l.renderColumnHeader("spaces", a.focus == focusMenu, millerSidebarWidth-1)
@@ -79,9 +78,16 @@ func (l MillerLayout) View(a App) string {
 		Render(a.logoText)
 	logoW := lipgloss.Width(logo)
 
-	var contentPane, hdrRow string
+	var contentPane, hdrRow, composeBar string
 	if r := l.activeCompactRenderer(a); r != nil {
 		listW, detailW := l.paneWidths(contentW)
+
+		// If compose panel is active, pull it out of DetailView and render it as a
+		// full-width bar spanning the list and detail columns (above the status bar).
+		if cc, ok := r.(CompactComposer); ok && cc.ComposeActive() {
+			contentH = max(0, contentH-cc.ComposeHeight())
+			composeBar = cc.ComposeView(contentW)
+		}
 
 		listHdr := l.renderColumnHeader(r.ListTitle(), a.focus == focusList, listW)
 		detailHdr := l.renderColumnHeader("thread", a.focus == focusDetail, detailW-logoW)
@@ -99,12 +105,21 @@ func (l MillerLayout) View(a App) string {
 		contentPane = lipgloss.NewStyle().Width(contentW).Height(contentH).MaxHeight(contentH).Render(l.renderContent(a))
 	}
 
+	// navPane and sep use the (possibly compose-reduced) contentH.
+	navPane := lipgloss.NewStyle().Height(contentH).MaxHeight(contentH).Render(l.renderNav(a))
 	sep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", contentH), "\n"))
-	base := lipgloss.JoinVertical(lipgloss.Left,
-		hdrRow,
-		lipgloss.JoinHorizontal(lipgloss.Top, navPane, sep, contentPane),
-		l.renderBottomBar(a),
-	)
+	mainRow := lipgloss.JoinHorizontal(lipgloss.Top, navPane, sep, contentPane)
+
+	var base string
+	if composeBar != "" {
+		panelH := lipgloss.Height(composeBar)
+		composeSep := theme.Subtle.Render(strings.TrimSuffix(strings.Repeat("│\n", panelH), "\n"))
+		sideBlank := lipgloss.NewStyle().Width(millerSidebarWidth - 1).Render("")
+		composeRow := lipgloss.JoinHorizontal(lipgloss.Top, sideBlank, composeSep, composeBar)
+		base = lipgloss.JoinVertical(lipgloss.Left, hdrRow, mainRow, composeRow, l.renderBottomBar(a))
+	} else {
+		base = lipgloss.JoinVertical(lipgloss.Left, hdrRow, mainRow, l.renderBottomBar(a))
+	}
 
 	if a.themePickerOpen {
 		return overlayCenter(base, l.renderThemePicker(a), a.width, a.height)
@@ -298,9 +313,6 @@ func (l MillerLayout) DelegateUpdate(msg tea.Msg, a App) (App, tea.Cmd) {
 }
 
 func (l MillerLayout) HasFocusedInput(a App) bool {
-	if a.focus == focusMenu {
-		return false
-	}
 	switch a.active {
 	case screenChatrooms:
 		return a.chatrooms.InputFocused()

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -13,20 +13,24 @@ import (
 )
 
 const millerSidebarWidth = 22  // nav pane (21 chars) + "│" separator (1 char)
-const millerListWidth = 52     // compact post list pane width in 3-pane Feed view
+const millerListMaxWidth = 70  // hard cap on the list pane; above this, excess goes to the detail pane
 const millerHeaderHeight = 1   // column title row at the top of the layout
 
 // MillerLayout renders a left navigation sidebar alongside the active screen.
 type MillerLayout struct{}
 
 // paneWidths returns the list and detail column widths for the given content area.
-// Both columns shrink proportionally as the terminal narrows, using the same ratio
-// as the preferred widths at a normal (120-col) terminal (52:45 ≈ 54:46). Add a
-// similar method to any future multi-pane layout to keep its collapsing logic
-// self-contained.
+// The detail pane is pinned at its preferred width (45); the list takes remaining
+// space and collapses first when narrowing. Above millerListMaxWidth the excess
+// goes to the detail pane. Add a similar method to any future multi-pane layout
+// to keep its collapsing logic self-contained.
 func (l MillerLayout) paneWidths(contentW int) (listW, detailW int) {
-	listW = min(millerListWidth, contentW*54/100)
-	detailW = max(0, contentW-listW-1)
+	const preferredDetailW = 45 // detail width at ~120-col terminal (98 contentW - 52 list - 1 sep)
+	detailW = min(preferredDetailW, max(0, contentW*46/100))
+	listW = min(millerListMaxWidth, max(0, contentW-detailW-1))
+	if listW == millerListMaxWidth {
+		detailW = max(0, contentW-listW-1)
+	}
 	return
 }
 

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -300,7 +300,9 @@ func (m FeedModel) ensureSelectedVisible() FeedModel {
 }
 
 // ComposeActive reports whether the new-post compose panel is open.
-func (m FeedModel) ComposeActive() bool { return m.panel.IsActive() }
+func (m FeedModel) ComposeActive() bool            { return m.panel.IsActive() }
+func (m FeedModel) ComposeHeight() int             { return m.panel.PanelHeight() }
+func (m FeedModel) ComposeView(width int) string   { return m.panel.SetWidth(width).View() }
 
 func (m FeedModel) Init() tea.Cmd { return nil }
 
@@ -847,10 +849,6 @@ func (m FeedModel) DetailView(width, height int) string {
 			parts = append(parts, rendered)
 		}
 	}
-	if m.panel.IsActive() {
-		parts = append(parts, m.panel.SetWidth(width).View())
-	}
-
 	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
 	return sliceContent(fullContent, m.detailScrollOffset, height, lineCount)
 }

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -848,7 +848,7 @@ func (m FeedModel) DetailView(width, height int) string {
 		}
 	}
 	if m.panel.IsActive() {
-		parts = append(parts, m.panel.View())
+		parts = append(parts, m.panel.SetWidth(width).View())
 	}
 
 	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -175,7 +175,9 @@ func (m GuildsModel) visiblePosts() []model.Post {
 }
 
 // ComposeActive reports whether the new-thread compose panel is open.
-func (m GuildsModel) ComposeActive() bool { return m.panel.IsActive() }
+func (m GuildsModel) ComposeActive() bool            { return m.panel.IsActive() }
+func (m GuildsModel) ComposeHeight() int             { return m.panel.PanelHeight() }
+func (m GuildsModel) ComposeView(width int) string   { return m.panel.SetWidth(width).View() }
 
 // ActiveGuild returns the slug of the guild whose posts are currently displayed, or "" when in list view.
 func (m GuildsModel) ActiveGuild() string { return m.activeGuild }
@@ -1230,10 +1232,6 @@ func (m GuildsModel) DetailView(width, height int) string {
 			parts = append(parts, rendered)
 		}
 	}
-	if m.panel.IsActive() {
-		parts = append(parts, m.panel.SetWidth(width).View())
-	}
-
 	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
 	return sliceContent(fullContent, m.threadScrollOffset, height, lineCount)
 }

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -1231,7 +1231,7 @@ func (m GuildsModel) DetailView(width, height int) string {
 		}
 	}
 	if m.panel.IsActive() {
-		parts = append(parts, m.panel.View())
+		parts = append(parts, m.panel.SetWidth(width).View())
 	}
 
 	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)


### PR DESCRIPTION
## Summary

Three related improvements to the Miller 3-pane layout:

- **List collapses first on resize**: Detail pane is now anchored at its preferred width (45 chars); the list pane flexes to absorb width changes first. When narrowing, the list column shrinks before the detail — the reverse of the previous behaviour. Above `millerListMaxWidth` (70 chars) excess space goes to the detail pane.

- **Compose panel spans full content width**: The new-post compose panel no longer appears inside the detail (preview) column where it looks like a reply. It now renders as a dedicated row spanning the list + detail columns above the status bar. Introduces `CompactComposer` optional interface (`ComposeActive`, `ComposeHeight`, `ComposeView`) implemented by Feed and Guilds.

- **Compose panel keyboard fix**: Removed `a.focus == focusMenu` early-return guard from `MillerLayout.HasFocusedInput`. With the spanning compose bar visible regardless of which Miller pane has focus, the old guard caused global shortcuts (e.g. `t` for theme) to fire through while compose was active. Now compose correctly captures all keys.

## Files changed

- `internal/ui/layout.go` — new `CompactComposer` interface
- `internal/ui/layout_miller.go` — `paneWidths`, `View`, `HasFocusedInput`
- `internal/ui/screens/feed.go` — `ComposeHeight`, `ComposeView`, removed panel from `DetailView`
- `internal/ui/screens/guilds.go` — same pattern as feed

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] Resize terminal from wide → narrow in Miller feed view; list column should shrink first
- [x] Open new-post compose (`n`) in Miller feed; panel spans both columns, fits without overflow
- [x] Type any letter while compose is open; no global shortcuts should fire
- [x] Same compose test in Miller guilds view
- [x] Tabs layout compose still works (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)