### PR TITLE
fix: preserve notification pagination state and fix badge count

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -144,7 +144,8 @@ type App struct {
 	pendingReplyID string
 
 	// polledUnreadCount is the single source of truth for the tab badge unread count.
-	// It is synced from: initial/page load, 60-second poll, m/M key, and enter on a notification.
+	// It is synced from: 60-second server poll, m/M key, and enter on a notification.
+	// Never overwrite with the local list count — the server count is always authoritative.
 	polledUnreadCount int
 
 	// settings holds the user's preferences fetched from GET /v1/settings on login.
@@ -2412,11 +2413,9 @@ func (a App) handleNotifications(msg tea.Msg) (App, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case notifsLoadedMsg:
 		a.notifications = a.notifications.SetNotifs(msg.notifs, msg.cursor)
-		a.polledUnreadCount = a.notifications.UnreadCount()
 		return a, nil, true
 	case notifsPageMsg:
 		a.notifications = a.notifications.AppendNotifs(msg.notifs, msg.cursor)
-		a.polledUnreadCount = a.notifications.UnreadCount()
 		return a, nil, true
 	case screens.RefreshNotifsMsg:
 		return a, a.loadNotifsCmd(), true
@@ -2470,7 +2469,7 @@ func (a App) handleNotifications(msg tea.Msg) (App, tea.Cmd, bool) {
 	case unreadCountMsg:
 		prev := a.polledUnreadCount
 		a.polledUnreadCount = msg.count
-		if msg.count > prev {
+		if msg.count > prev && !a.notifications.HasPaginated() {
 			return a, a.loadNotifsCmd(), true
 		}
 		return a, nil, true

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -176,8 +176,11 @@ func navigateTabBy(a App, delta int) (App, tea.Cmd) {
 	case screenProfile:
 		return a, a.loadProfileCmd()
 	case screenNotifications:
-		a.notifications = a.notifications.SetFetching()
-		return a, a.loadNotifsCmd()
+		if !a.notifications.HasPaginated() {
+			a.notifications = a.notifications.SetFetching()
+			return a, a.loadNotifsCmd()
+		}
+		return a, nil
 	case screenSettings:
 		return a, nil
 	case screenBookmarks:

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -114,8 +114,11 @@ func (l TabsLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 		if a.active != screenLogin {
 			a.cmail = a.cmail.CancelSubscription()
 			a.active = screenNotifications
-			a.notifications = a.notifications.SetFetching()
-			return a, a.loadNotifsCmd(), true
+			if !a.notifications.HasPaginated() {
+				a.notifications = a.notifications.SetFetching()
+				return a, a.loadNotifsCmd(), true
+			}
+			return a, nil, true
 		}
 	case "3":
 		if a.active != screenLogin {

--- a/internal/ui/screens/notifications.go
+++ b/internal/ui/screens/notifications.go
@@ -50,6 +50,7 @@ type NotificationsModel struct {
 	refreshing     bool
 	exhausted      bool
 	nextCursor     string
+	hasPaginated   bool
 	showUnreadOnly bool
 	err            error
 	relaxed        bool
@@ -80,6 +81,7 @@ func (m NotificationsModel) SetNotifs(notifs []model.Notification, cursor string
 	m.loading = false
 	m.fetching = false
 	m.refreshing = false
+	m.hasPaginated = false
 	m.selectedIndex = 0
 	if m.ready {
 		m = m.refreshContent()
@@ -92,6 +94,7 @@ func (m NotificationsModel) AppendNotifs(notifs []model.Notification, cursor str
 	m.notifs = append(m.notifs, notifs...)
 	m.nextCursor = cursor
 	m.exhausted = cursor == ""
+	m.hasPaginated = true
 	m.loading = false
 	m.fetching = false
 	if m.ready {
@@ -133,6 +136,9 @@ func (m NotificationsModel) SetLocation(loc *time.Location) NotificationsModel {
 
 // ShowUnreadOnly reports whether the screen is currently filtering to unread-only.
 func (m NotificationsModel) ShowUnreadOnly() bool { return m.showUnreadOnly }
+
+// HasPaginated reports whether the user has loaded pages beyond the first.
+func (m NotificationsModel) HasPaginated() bool { return m.hasPaginated }
 
 // UnreadCount returns the number of unread notifications in the current page.
 func (m NotificationsModel) UnreadCount() int {


### PR DESCRIPTION
## Summary

- **Pagination state preserved**: tab switch (key `2`) and left/right arrow navigation no longer reload the first page when the user has paginated past it. Both call sites (`layout.go`, `layout_tabs.go`) are guarded by `HasPaginated()` on `NotificationsModel`.
- **Poll no longer resets list**: the background poll's `unreadCountMsg` handler applies the same guard — if the user has paginated, new notifications only update the badge, they don't discard loaded pages.
- **Badge flash and reload loop fixed**: `polledUnreadCount` was overwritten with the local list count after every page load, causing it to fall below the server count and trigger a reload on every poll tick (and a visible 127→20→127 flash). Removed both `a.polledUnreadCount = a.notifications.UnreadCount()` assignments from `notifsLoadedMsg` and `notifsPageMsg`. The badge is now managed exclusively by the 60-second server poll, optimistic mark-read decrements, and mark-all-read.

## Test plan

- [ ] Login — badge shows server-side unread count
- [ ] Navigate to Notifications — badge does not drop to 20
- [ ] Page down past the first page — badge stays at server count (does not increment 20 → 40 → …)
- [ ] Navigate away and back (key `2`, left/right arrow) — list and scroll position preserved
- [ ] Wait for poll tick — no badge flash, no list reset
- [ ] Press `r` to refresh — list reloads from page 1, pagination state resets
- [ ] Mark a notification read — badge decrements by 1
- [ ] All tests pass: `go test ./...`, `go vet ./...`, `staticcheck ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)