### PR TITLE
fix: guard MillerLayout notification reload and add hasPaginated tests

### DIFF
--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -196,8 +196,11 @@ func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 			if a.active != screenLogin {
 				a.cmail = a.cmail.CancelSubscription()
 				a.active = screenNotifications
-				a.notifications = a.notifications.SetFetching()
-				return a, a.loadNotifsCmd(), true
+				if !a.notifications.HasPaginated() {
+					a.notifications = a.notifications.SetFetching()
+					return a, a.loadNotifsCmd(), true
+				}
+				return a, nil, true
 			}
 		case "3":
 			if a.active != screenLogin {

--- a/internal/ui/screens/notifications_test.go
+++ b/internal/ui/screens/notifications_test.go
@@ -975,6 +975,33 @@ func TestNotifs_UnreadCount(t *testing.T) {
 	}
 }
 
+func TestNotifs_HasPaginated_FalseByDefault(t *testing.T) {
+	m := initNotifs(nil)
+	if m.HasPaginated() {
+		t.Error("expected HasPaginated false after SetNotifs")
+	}
+}
+
+func TestNotifs_AppendNotifs_SetsPaginated(t *testing.T) {
+	notifs := []model.Notification{makeNotif("n1", "reply", "p1", false)}
+	m := initNotifs(notifs)
+	extra := []model.Notification{makeNotif("n2", "poke", "", false)}
+	m = m.AppendNotifs(extra, "cursor-next")
+	if !m.HasPaginated() {
+		t.Error("expected HasPaginated true after AppendNotifs")
+	}
+}
+
+func TestNotifs_SetNotifs_ClearsPaginated(t *testing.T) {
+	notifs := []model.Notification{makeNotif("n1", "reply", "p1", false)}
+	m := initNotifs(notifs)
+	m = m.AppendNotifs(notifs, "c")
+	m = m.SetNotifs(notifs, "")
+	if m.HasPaginated() {
+		t.Error("expected HasPaginated false after SetNotifs")
+	}
+}
+
 func TestNotifs_IsReady(t *testing.T) {
 	m := NewNotificationsModel()
 	if m.IsReady() {


### PR DESCRIPTION
## Summary

Follow-up to #34 based on post-merge code review.

- **MillerLayout case "2" unguarded**: MillerLayout.HandleNav had the same unconditional loadNotifsCmd() call that was fixed in TabsLayout.HandleNav in #34. Left/right arrow navigation already used navigateTabBy() (covered by #34), but the direct key 2 shortcut was a separate code path. Applied the same HasPaginated() guard.
- **Missing unit tests**: Added three tests to notifications_test.go for the hasPaginated state machine: false by default, set by AppendNotifs, cleared by SetNotifs.

Other review concerns investigated and confirmed non-issues:
- Badge is suppressed entirely when polledUnreadCount == 0 (no "0" badge visible at startup).
- showUnreadOnly toggle correctly clears hasPaginated via RefreshNotifsMsg -> SetNotifs().

## Test plan

- [x] All tests pass: go test ./..., go vet ./..., staticcheck ./...
- [ ] In Miller layout: paginate notifications, press 2 -- list and scroll position preserved
- [x] Three new TestNotifs_HasPaginated_* tests pass

Generated with [Claude Code](https://claude.com/claude-code)
