### PR TITLE
fix: remove layout setting and default to tabs-only

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -268,10 +268,7 @@ func (a App) WithSavedSession(s config.Config) App {
 	return a
 }
 
-func layoutFromName(name string) Layout {
-	if name == "miller" {
-		return MillerLayout{}
-	}
+func layoutFromName(_ string) Layout {
 	return TabsLayout{}
 }
 

--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -166,24 +166,6 @@ var settingsGroups = []settingsGroup{
 					return m
 				},
 			},
-			{
-				label: "layout", kind: "enum",
-				options: []string{"tabs", "miller"},
-				getEnum: func(m SettingsModel) string {
-					if m.layoutName == "miller" {
-						return "miller"
-					}
-					return "tabs"
-				},
-				cycle: func(m SettingsModel, delta int) SettingsModel {
-					cur := m.layoutName
-					if cur == "" {
-						cur = "tabs"
-					}
-					m.layoutName = cycleStringEnum(cur, []string{"tabs", "miller"}, delta)
-					return m
-				},
-			},
 		},
 	},
 	{

--- a/internal/ui/screens/settings_test.go
+++ b/internal/ui/screens/settings_test.go
@@ -416,7 +416,7 @@ func TestSettings_WanderGroup_Visible(t *testing.T) {
 func TestSettings_WanderToggle(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
-	m.cursor = 12 // wander mode item (index shifted by added layout item)
+	m.cursor = 11 // wander mode item
 	m, _ = m.Update(keyMsg("enter"))
 	if m.wanderLust {
 		t.Error("toggling wander mode should flip wanderLust to false")


### PR DESCRIPTION
## Summary

- Removes the layout enum from the settings screen — Miller is no longer user-selectable
- `layoutFromName` now always returns `TabsLayout`, so any existing config with `"layout":"miller"` silently falls back to tabs without requiring a config migration
- Corrects the wander mode cursor index in tests (was off by one due to the removed item)

## Test plan

- [ ] All tests pass
- [ ] Settings screen no longer shows a layout option
- [ ] App with `"layout":"miller"` in config starts on the tabs layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)