### PR TITLE
feat: replace numeric tab shortcuts with leader-key navigation

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -451,7 +451,7 @@ Direct messages (C-Mail) with live Firebase RTDB integration.
 - `waitForDM(sub)` is a Bubble Tea `Cmd` that blocks on the subscription channel and returns each incoming message as a `tea.Msg`
 - Other person's messages left-aligned; my messages right-aligned (driven by `currentUser` field)
 - `j`/`k` navigate conversation list in list mode; Enter opens detail mode; Enter sends a message; `↑`/`↓` scroll history in detail mode
-- **Starting a conversation:** pressing `c` on any highlighted post, reply, notification, or read-only profile emits `StartConversationMsg{Username}` (defined in `messages.go`); App calls `StartConversation(username)` via REST, then switches to C-Mail and opens the returned conversation in detail mode; self-DMs are dropped in the App handler
+- **Starting a conversation:** pressing `c` on any highlighted post, reply, notification, or read-only profile emits `StartConversationMsg{Username}` (defined in `messages.go`); App calls `StartConversation(username)` via REST, then switches to C-Mail and opens the returned conversation in detail mode; self-DMs are dropped in the App handler. Distinct from `g m` (see "Keyboard Shortcuts" → Global): `c` targets the specific highlighted user, `g m` just opens the C-Mail tab's conversation list — the in-app hint for `c` reads "message" rather than "c-mail" to keep the two from being conflated
 - **Scroll-to-load history:** reaching the top of the loaded messages via `↑` fetches the next older page (`GetMessages(convID, 50, before)`, `before` = oldest loaded message's timestamp) and prepends it via `PrependMessages`, preserving scroll offset; guarded by `loadingHistory`/`historyExhausted` fields, reset on conversation open. A failed fetch resets `loadingHistory` (so a retry is possible) and sets `err`, which `renderMessages()` surfaces as "couldn't load messages" when the list is still empty.
 - **Live-stream reconnect:** when `dmStreamClosedMsg` fires for the still-active conversation (idToken expiry, an idle-read timeout, a terminal `auth_revoked`/`cancel` event, or a network error — see `internal/rtdb`), `reconnectConvCmd` calls `api.Client.RefreshSession()` then re-subscribes; on failure it retries with backoff (`reconnectDelay`/`reconnectBackoffSchedule` in `reconnect.go`, shared with `chatrooms.go`: `1s, 2s, 4s, 8s, 15s`, 6 attempts total) via `scheduleReconnectRetryCmd`/`tea.Tick`, tracked by `m.reconnecting`/`m.reconnectAttempt`/`m.reconnectFailed`. Success emits `CMailReconnectedMsg`, which App turns into a "reconnected to live chat" toast, and clears the retry state. While retrying, `View()` shows `(live updates lost, reconnecting… N/6)` in the header; once attempts are exhausted, `(live updates lost)` persists until the user leaves and re-enters — independent of `renderMessages()`'s empty-list error path, so it's visible even with history already loaded. `cancelDMSub()` (called on navigation away) cancels any in-flight retry sequence via `m.reconnectCancel`. A stale close event (from an abandoned conversation) is a no-op.
 - **Slash commands:** normal commands (`/me`, `/dice`, etc.) are expanded server-side; `/help` posts nothing, so `SendMessage`'s reply text is routed through app.go's `cmailCommandReplyMsg` into `AppendSystemMessage`, which injects a local-only `model.Message{IsSystem: true}` rendered via `renderSystemNotice`. `/me`-style messages carry an undocumented `isAction` field (`model.Message.IsAction`, confirmed live for CIRC, parsed defensively here) rendered via `renderActionLine` as classic IRC `* username body *`
@@ -679,6 +679,15 @@ All screens implement Bubble Tea's `Model` interface. `ComposeModel` is embedded
 
 ### Global
 
+Two navigation schemes reach the same 11 screens — pick whichever is faster
+for a given target. Both are derived from the single `menuTabs` slice in
+`internal/ui/layout.go`, so TabsLayout and MillerLayout can never disagree
+about what a given key does (a bug that existed before this scheme and was
+fixed alongside it).
+
+**Numeric aliases** — quick access to the first 9 screens by position on the
+tab bar:
+
 | Key | Action |
 |---|---|
 | `1` | Feed |
@@ -690,15 +699,56 @@ All screens implement Bubble Tea's `Model` interface. `ComposeModel` is embedded
 | `7` | Guilds |
 | `8` | Topics |
 | `9` | Profile |
-| `←` / `→` | Cycle tabs left / right (includes Search and Settings, which have no number key) |
+
+**Leader key** — `g` ("go to") arms a pending state; the very next keypress
+resolves against a mnemonic map to jump directly to any of the 11 screens,
+including Search and Settings which have no numeric alias. An unmapped
+follow-up key silently cancels the pending state rather than doing anything.
+The mnemonic letter is shown highlighted inline within each tab's label on
+the tab bar / nav sidebar as a hint:
+
+| Chord | Screen | Chord | Screen |
+|---|---|---|---|
+| `g f` | Feed | `g g` | Guilds |
+| `g n` | Notifications | `g t` | Topics |
+| `g m` | C-Mail | `g p` | Profile |
+| `g i` | CIRC | `g s` | Search |
+| `g j` | Journal | `g e` | Settings |
+| `g b` | Bookmarks | | |
+
+Only plain letters are used — no `alt+`, function keys, or `ctrl+`/`shift+`
+combinations — since those are caught inconsistently by terminal emulators,
+window managers, or (for `ctrl+`/`shift+` on non-letter keys) aren't
+reliably distinguishable without the Kitty keyboard protocol. `g` isn't
+bound to anything on its own, so there's no ambiguity or timeout to manage.
+
+**Search is hidden from the tab bar / nav sidebar and from `←`/`→` (and
+MillerLayout's `j`/`k`) cycling** — `menuTabs`' `search` entry has
+`hidden: true` (`internal/ui/layout.go`), so `visibleTabs()` (what actually
+renders and what cycling iterates over) skips it, the same treatment
+`screenPostDetail` already had. It's an explicit-entry-only destination:
+the only ways in are `g s` and `/`, and both always land in a focused query
+box (`SearchModel.FocusQuery()`) regardless of whatever state Search was
+last left in — unlike cycling, which for every other screen intentionally
+just resumes wherever it was left. `screenForMnemonic` and the help modal's
+leader-key legend still list `g s` normally; only the rendered tab
+list/cycling exclude it.
+
+Other global keys:
+
+| Key | Action |
+|---|---|
+| `←` / `→` | Cycle tabs left / right (does not include Search, which is hidden — see above) |
 | `/` | Search — jumps to the Search screen with the query box focused. No-op while any screen's compose input is focused (so `/dice`, `/me`, etc. still type normally in CIRC/C-Mail) |
 | `v` | Toggle dense / relaxed display |
 | `?` | Help modal |
 | `t` | Theme picker |
-| `z` | Timezone picker |
 | `o` | Open URLs/images from the focused item (direct-open if one, picker if several) — no-op while any screen's compose input is focused |
 | `ctrl+o` | Same as `o`, but reaches the handler even while a compose input is focused — the only way to open links in CIRC/C-Mail, since their input is focused for the entire detail view, not just a transient compose sub-mode |
 | `q` / `ctrl+c` | Quit |
+
+Timezone is set from the Settings screen's own field (`tab`/`shift+tab` to
+cycle), not a global shortcut.
 
 ### Login
 
@@ -749,15 +799,29 @@ All screens implement Bubble Tea's `Model` interface. `ComposeModel` is embedded
 | `w` | Watch / unwatch the thread (root post focused only; no-op on replies) |
 | `esc` | Back to feed |
 
-### Compose (embedded)
+### Compose
+
+**Reply/inline compose** (`ComposeModel` — replies, guild/topic threads,
+CIRC/C-Mail messages): `enter` inserts a paragraph break (`\n\n`) rather than
+submitting — most terminals can't distinguish `shift+enter` from `enter`
+without the Kitty keyboard protocol, so there's no separate hard-line-break
+key.
 
 | Key | Action |
 |---|---|
 | `enter` | Insert paragraph break |
-| `tab` | Cycle focus: compose → title → topics → compose (Feed only) |
-| `alt+enter` / `ctrl+s` | Submit |
-| `alt+p` | Toggle public flag (Feed compose only) |
-| `alt+s` | Toggle NSFW flag (Feed compose only) |
+| `ctrl+s` | Submit |
+| `esc` | Cancel |
+
+**New post panel** (`PostComposePanel` — Feed's `n`, guild/topic new-thread):
+a single panel with title, slug, body, topics, and public/NSFW checkbox
+fields.
+
+| Key | Action |
+|---|---|
+| `tab` / `shift+tab` | Cycle fields: title → slug → body → topics → public → NSFW |
+| `space` | Toggle the focused checkbox field (public / NSFW) |
+| `ctrl+s` | Submit (validates the slug field first; invalid slug refocuses it with an inline error) |
 | `esc` | Cancel |
 
 ### Notifications
@@ -769,7 +833,7 @@ All screens implement Bubble Tea's `Model` interface. `ComposeModel` is embedded
 | `enter` | Jump to referenced post/reply |
 | `m` | Mark selected as read |
 | `M` | Mark all as read |
-| `1` | Toggle unread-only filter |
+| `u` | Toggle unread-only filter |
 | `c` | Start C-Mail conversation with notification actor |
 
 ### C-Mail

--- a/docs/02-menu-bar-navigation.md
+++ b/docs/02-menu-bar-navigation.md
@@ -4,26 +4,48 @@
 
 Replaces the original `[1] label` tab bar with a proper fixed menu bar. Active tab is highlighted as a filled block. Left/right arrow keys navigate between tabs. Status bar is anchored to the bottom of the terminal.
 
+The app has grown from 4 tabs to 11, which outgrew a plain `1`-`9` numbering
+scheme (see `docs/00-project-reference.md`'s "Keyboard Shortcuts" section
+for the full current inventory). Navigation now combines two schemes, both
+derived from the same `menuTabs` slice so they can't drift apart:
+
+- **Numeric aliases** (`1`-`9`) for the first 9 tabs, by position.
+- **Leader key** (`g` + a mnemonic letter, e.g. `g f` for Feed) reaches all
+  11 screens, including the two with no numeric alias (Search, Settings).
+
+Search is further set apart from the other 10: it's a **hidden,
+explicit-entry-only destination** — not shown on the tab bar/sidebar and not
+part of `←`/`→` (or MillerLayout's `j`/`k`) cycling at all. The only ways in
+are `g s` and `/`, and both always land in a focused query box regardless of
+whatever state Search was last left in. This avoids a state the screen
+doesn't actually handle: landing on Search unfocused (which arrow-cycling
+used to be able to do) left the query box unreachable, since query-mode is
+only ever supposed to be entered focused.
+
 ---
 
 ## Menu Bar
 
-- Single fixed line at the top of the screen
+- Single fixed line at the top of the screen (TabsLayout) or a vertical
+  sidebar (MillerLayout) — both render from `visibleTabs()` (`menuTabs`
+  minus any entry marked `hidden` — currently just Search)
 - Active tab: filled dim-green background, bright green bold text
 - Inactive tabs: muted text, no background
+- Each tab's mnemonic letter (the second key of its `g`-chord) is rendered
+  highlighted in cyan inline within the label itself — e.g. `feed`'s `f`,
+  `c-mail`'s `m` — so the leader-key hint is visible without opening the
+  help modal (`?`)
 - All tabs are the same height — no layout jumping on tab change
 
 ## Navigation
 
 | Key | Action |
 |---|---|
-| `←` / `→` | Cycle through tabs |
-| `1` | Jump to Feed |
-| `2` | Jump to Rooms |
-| `3` | Jump to Mail |
-| `4` | Jump to Profile |
+| `←` / `→` | Cycle through the 10 visible tabs (TabsLayout, `focusMenu`) — Search is hidden and excluded, see above |
+| `1`-`9` | Jump directly to one of the first 9 tabs — see the numeric table in `docs/00-project-reference.md` |
+| `g` + letter | Jump directly to any of the 11 screens via its mnemonic, including Search — see the chord table in `docs/00-project-reference.md` |
 
-Arrow keys are blocked from tab navigation when a text input is focused (Chatrooms, Mail) so cursor movement works normally in those screens.
+Arrow keys and the numeric/leader jumps are blocked from tab navigation when a text input is focused (CIRC, C-Mail, Search's query box, compose panels) so typing works normally in those screens.
 
 ## Status Bar
 
@@ -35,8 +57,10 @@ Anchored to the bottom of the terminal at all times. Resizes correctly with the 
 
 **`theme.ChromeHeight`** — shared constant (`= 3`: tab bar + separator + status bar) used by all screens to calculate their viewport height. Eliminates magic numbers.
 
-**`focusTarget`** — type on `App` (`focusMenu` / `focusList`) gates which component consumes arrow keys. `focusList` is reserved for future list navigation (e.g. scrollable feed items).
+**`focusTarget`** — type on `App` (`focusMenu` / `focusList` / `focusDetail`) gates which component consumes arrow keys.
 
-**`InputFocused() bool`** — method on `ChatroomsModel` and `DMsModel`, queried by the app before consuming left/right keys.
+**`HasFocusedInput(a App) bool`** — method on `Layout` (implemented per layout, delegating to each screen's own `InputFocused()`/`ComposeActive()`), queried by the app before consuming keys that would otherwise navigate.
 
-**`menuTabs` var** — single source of truth for tab order, shared by the renderer and the key handler.
+**`menuTabs` var** (`internal/ui/layout.go`) — single source of truth for tab order, label, leader-key mnemonic, and (via the `hidden` field) whether an entry is part of the visible/cyclable tab set. `screenForNumber` and `screenForMnemonic` both derive from the full slice (so Search stays reachable by mnemonic); `visibleTabs()` filters out `hidden` entries for rendering and cycling. `activateScreen` is the shared jump-to-screen implementation both the numeric and leader-key paths call, so the two layouts and both navigation schemes can never disagree about what a given key does. `navigateTabBy` (arrow/j-k cycling) is a no-op while `screenSearch` is active, the same treatment `screenPostDetail` gets — neither is part of the rotation.
+
+**`leaderPending` field on `App`** — armed by the `g` key in `handleKeys` (`internal/ui/app.go`); the next keypress resolves against `screenForMnemonic` or silently cancels. No timeout is needed since `g` has no other binding of its own, so there's no ambiguity to resolve.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -111,6 +111,11 @@ type App struct {
 	// helpModal state — open with '?', close with any key.
 	helpModalOpen bool
 
+	// leaderPending is armed by the "g" ("go to") leader key and resolved by
+	// the very next keypress against screenForMnemonic — e.g. "g" then "f"
+	// jumps to Feed. An unmapped follow-up key silently cancels it.
+	leaderPending bool
+
 	// urlPicker state — open with 'o' when multiple URLs are available.
 	urlPickerOpen   bool
 	urlPickerItems  []string
@@ -510,6 +515,34 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		if m.String() != "ctrl+o" {
 			return a, nil, false // fall through to delegateUpdate
+		}
+	}
+	// "g" arms the leader key; the very next keypress resolves against
+	// screenForMnemonic regardless of what it is (even another global key
+	// like "t" or "q"), so it must be checked ahead of the switch below.
+	if a.leaderPending {
+		a.leaderPending = false
+		if a.active != screenLogin {
+			if s, ok := screenForMnemonic(m.String()); ok {
+				var cmd tea.Cmd
+				a, cmd = activateScreen(a, s)
+				if s == screenSearch {
+					// activateScreen leaves Search in whatever state it was
+					// last left in (correct for arrow-cycling, which no
+					// longer reaches Search at all) — "g s" is a deliberate
+					// "go to Search" action like '/', so it must always focus
+					// the query box the same way '/' already does below.
+					a.search = a.search.FocusQuery()
+				}
+				return a, cmd, true
+			}
+		}
+		return a, nil, true
+	}
+	if m.String() == "g" {
+		if a.active != screenLogin {
+			a.leaderPending = true
+			return a, nil, true
 		}
 	}
 	switch m.String() {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -95,8 +95,9 @@ func TestNavigateTab_RightFromGuilds_GoesToTopics(t *testing.T) {
 func TestNavigateTab_CyclesAllTabsRight(t *testing.T) {
 	a := loggedInApp()
 	a.active = screenFeed
-	// menuTabs order: feed, notifications, c-mail, circ, journal, bookmarks, guilds, topics, profile, search, settings
-	expected := []screen{screenNotifications, screenCMail, screenChatrooms, screenJournal, screenBookmarks, screenGuilds, screenTopics, screenProfile, screenSearch, screenSettings, screenFeed}
+	// visibleTabs order: feed, notifications, c-mail, circ, journal, bookmarks, guilds, topics, profile, settings
+	// (search is hidden — reachable only via "g s"/"/", never by cycling; see navigateTabBy)
+	expected := []screen{screenNotifications, screenCMail, screenChatrooms, screenJournal, screenBookmarks, screenGuilds, screenTopics, screenProfile, screenSettings, screenFeed}
 	for i, want := range expected {
 		a.navigateTab(+1)
 		if a.active != want {
@@ -108,13 +109,43 @@ func TestNavigateTab_CyclesAllTabsRight(t *testing.T) {
 func TestNavigateTab_CyclesAllTabsLeft(t *testing.T) {
 	a := loggedInApp()
 	a.active = screenFeed
-	// menuTabs order: feed, notifications, c-mail, circ, journal, bookmarks, guilds, topics, profile, search, settings
-	expected := []screen{screenSettings, screenSearch, screenProfile, screenTopics, screenGuilds, screenBookmarks, screenJournal, screenChatrooms, screenCMail, screenNotifications, screenFeed}
+	// visibleTabs order: feed, notifications, c-mail, circ, journal, bookmarks, guilds, topics, profile, settings
+	// (search is hidden — reachable only via "g s"/"/", never by cycling; see navigateTabBy)
+	expected := []screen{screenSettings, screenProfile, screenTopics, screenGuilds, screenBookmarks, screenJournal, screenChatrooms, screenCMail, screenNotifications, screenFeed}
 	for i, want := range expected {
 		a.navigateTab(-1)
 		if a.active != want {
 			t.Errorf("step %d: expected %v, got %v", i+1, want, a.active)
 		}
+	}
+}
+
+// TestNavigateTab_ProfileToSettings_SkipsSearch confirms Search — hidden
+// from the tab rotation — is never landed on while cycling: Profile is the
+// last visible tab before Settings in menuTabs order, with Search sitting
+// between them but excluded.
+func TestNavigateTab_ProfileToSettings_SkipsSearch(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenProfile
+	a.navigateTab(+1)
+	if a.active != screenSettings {
+		t.Errorf("expected screenSettings (skipping hidden screenSearch), got %v", a.active)
+	}
+}
+
+// TestNavigateTab_NoOpWhileOnSearch confirms arrow-key/j-k cycling can't
+// move off Search either, now that it's a hidden, explicit-entry-only
+// destination — the same treatment screenPostDetail already got.
+func TestNavigateTab_NoOpWhileOnSearch(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenSearch
+	a.navigateTab(+1)
+	if a.active != screenSearch {
+		t.Errorf("expected navigateTab to no-op while on screenSearch, got %v", a.active)
+	}
+	a.navigateTab(-1)
+	if a.active != screenSearch {
+		t.Errorf("expected navigateTab to no-op while on screenSearch, got %v", a.active)
 	}
 }
 
@@ -155,6 +186,123 @@ func TestActiveScreenHasFocusedInput_ChatroomsDefault(t *testing.T) {
 	// This test guards against regressions where input starts focused unexpectedly
 	if a.chatrooms.InputFocused() {
 		t.Error("chatrooms input should not be focused before a room is selected")
+	}
+}
+
+// --- leader key ("g" + mnemonic) ---
+
+func TestHandleKeys_Leader_G_ArmsAndConsumes(t *testing.T) {
+	a := loggedInApp()
+	a2, cmd, consumed := a.handleKeys(keyMsg("g"))
+	if !consumed {
+		t.Fatal("expected 'g' to be consumed")
+	}
+	if !a2.leaderPending {
+		t.Error("expected leaderPending to be armed after 'g'")
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd from arming the leader key")
+	}
+}
+
+func TestHandleKeys_Leader_G_LoginScreen_NoOp(t *testing.T) {
+	a := newTestApp() // active == screenLogin
+	a2, _, consumed := a.handleKeys(keyMsg("g"))
+	if consumed {
+		t.Error("'g' on login screen should not be consumed")
+	}
+	if a2.leaderPending {
+		t.Error("leaderPending should not arm on login screen")
+	}
+}
+
+func TestHandleKeys_Leader_MappedChord_Navigates(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenProfile
+	a2, _, consumed := a.handleKeys(keyMsg("g"))
+	if !consumed || !a2.leaderPending {
+		t.Fatal("setup: expected 'g' to arm the leader key")
+	}
+	a3, _, consumed := a2.handleKeys(keyMsg("j")) // g j -> Journal
+	if !consumed {
+		t.Fatal("expected the leader chord's second key to be consumed")
+	}
+	if a3.leaderPending {
+		t.Error("expected leaderPending to be cleared after resolving")
+	}
+	if a3.active != screenJournal {
+		t.Errorf("expected screenJournal, got %v", a3.active)
+	}
+}
+
+func TestHandleKeys_Leader_UnmappedChord_CancelsSilently(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenProfile
+	a2, _, _ := a.handleKeys(keyMsg("g"))
+	a3, cmd, consumed := a2.handleKeys(keyMsg("z")) // not a mnemonic
+	if !consumed {
+		t.Fatal("expected the cancelling key to still be consumed (swallowed)")
+	}
+	if a3.leaderPending {
+		t.Error("expected leaderPending to be cleared")
+	}
+	if a3.active != screenProfile {
+		t.Errorf("expected no navigation to occur, still screenProfile, got %v", a3.active)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd when the chord doesn't resolve")
+	}
+}
+
+func TestHandleKeys_Leader_DoubleG_GoesToGuilds(t *testing.T) {
+	a := loggedInApp()
+	a2, _, _ := a.handleKeys(keyMsg("g"))
+	a3, _, consumed := a2.handleKeys(keyMsg("g")) // g g -> Guilds
+	if !consumed {
+		t.Fatal("expected second 'g' to be consumed")
+	}
+	if a3.active != screenGuilds {
+		t.Errorf("expected screenGuilds, got %v", a3.active)
+	}
+}
+
+func TestHandleKeys_Leader_NotArmed_WhileInputFocused(t *testing.T) {
+	a := setupChatroomsDetailWithURL(loggedInApp())
+	if !a.chatrooms.InputFocused() {
+		t.Fatal("setup: expected chatrooms input focused in detail mode")
+	}
+	a2, _, consumed := a.handleKeys(keyMsg("g"))
+	if consumed {
+		t.Error("expected 'g' to NOT be consumed while chatrooms input is focused — it must still type into the compose box")
+	}
+	if a2.leaderPending {
+		t.Error("leaderPending should not arm while a text input is focused")
+	}
+}
+
+func TestHandleKeys_Leader_NumericAliasAndLeaderAgree(t *testing.T) {
+	// "1" through "9" and their equivalent "g"+mnemonic chord must land on
+	// the same screen in both layouts — the drift this feature fixes.
+	for i, tab := range menuTabs[:9] {
+		num := string(rune('1' + i))
+		for _, layout := range []Layout{TabsLayout{}, MillerLayout{}} {
+			a := loggedInApp()
+			a.layout = layout
+			a.active = screenProfile
+			a2, _, _ := a.handleKeys(keyMsg(num))
+			if a2.active != tab.s {
+				t.Errorf("layout %T: key %q: expected %v, got %v", layout, num, tab.s, a2.active)
+			}
+
+			b := loggedInApp()
+			b.layout = layout
+			b.active = screenProfile
+			b2, _, _ := b.handleKeys(keyMsg("g"))
+			b3, _, _ := b2.handleKeys(keyMsg(string(tab.mnemonic)))
+			if b3.active != tab.s {
+				t.Errorf("layout %T: chord \"g %c\": expected %v, got %v", layout, tab.mnemonic, tab.s, b3.active)
+			}
+		}
 	}
 }
 
@@ -408,27 +556,55 @@ func TestSearch_EscToLeave_ReturnsToOriginScreen(t *testing.T) {
 	}
 }
 
-// TestNavigateTab_IntoSearch_SetsSearchReturn reproduces a reported bug:
-// tab-cycling into Search (rather than pressing '/') left searchReturn at
-// its zero value (screenLogin), so Esc from Search would drop an
-// authenticated user on the login screen. navigateTabBy must record the
-// origin screen itself, since it's a second entry point into Search that
-// bypasses the '/' handler's searchReturn assignment.
-func TestNavigateTab_IntoSearch_SetsSearchReturn(t *testing.T) {
+// TestHandleKeys_Leader_G_S_FocusesQueryAndSetsSearchReturn reproduces the
+// reported bug: "g s" switched to screenSearch but never called
+// FocusQuery(), unlike '/' — landing on Search unfocused but still in
+// searchViewQuery is a state the screen doesn't actually handle (see the
+// comment on search.go's Update), so there was no way to type a query.
+// "g s" is a deliberate "go to Search" action, same intent as '/', so it
+// must behave identically: focused query box and searchReturn recorded.
+func TestHandleKeys_Leader_G_S_FocusesQueryAndSetsSearchReturn(t *testing.T) {
 	a := loggedInApp()
 	a.active = screenProfile
-	a.navigateTab(+1)
-	if a.active != screenSearch {
-		t.Fatalf("setup: expected screenSearch, got %v", a.active)
+	a2, _, _ := a.handleKeys(keyMsg("g"))
+	a3, _, consumed := a2.handleKeys(keyMsg("s"))
+	if !consumed {
+		t.Fatal("expected \"g s\" to be consumed")
 	}
-	if a.searchReturn != screenProfile {
-		t.Fatalf("expected searchReturn = screenProfile, got %v", a.searchReturn)
+	if a3.active != screenSearch {
+		t.Fatalf("expected screenSearch, got %v", a3.active)
+	}
+	if a3.searchReturn != screenProfile {
+		t.Errorf("expected searchReturn = screenProfile, got %v", a3.searchReturn)
+	}
+	if !a3.search.InputFocused() {
+		t.Error("expected the query box to be focused after \"g s\", same as '/'")
 	}
 
-	m, _ := a.Update(screens.LeaveSearchMsg{})
-	a2 := m.(App)
-	if a2.active != screenProfile {
-		t.Errorf("expected esc to return to screenProfile (origin), got %v", a2.active)
+	m, _ := a3.Update(screens.LeaveSearchMsg{})
+	a4 := m.(App)
+	if a4.active != screenProfile {
+		t.Errorf("expected esc to return to screenProfile (origin), got %v", a4.active)
+	}
+}
+
+// TestHandleKeys_Leader_G_S_FocusesQuery_EvenAfterStalePreviewState confirms
+// "g s" resets to a focused query box even when Search was previously left
+// mid-browse (a drilled-into preview, query blurred) — not just on a fresh
+// SearchModel where the query happens to start focused.
+func TestHandleKeys_Leader_G_S_FocusesQuery_EvenAfterStalePreviewState(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenSearch
+	a.search = a.search.SetPreview(model.SearchPreview{}, "old query")
+	if a.search.InputFocused() {
+		t.Fatal("setup: expected SetPreview to leave the query box blurred")
+	}
+	a.active = screenFeed
+
+	a2, _, _ := a.handleKeys(keyMsg("g"))
+	a3, _, _ := a2.handleKeys(keyMsg("s"))
+	if !a3.search.InputFocused() {
+		t.Error("expected \"g s\" to focus the query box even after a stale preview state")
 	}
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -51,22 +52,51 @@ type CompactComposer interface {
 	ComposeView(width int) string // panel rendered at the given spanning width
 }
 
-// menuTabs is the ordered list of navigable screens.
-var menuTabs = []struct {
-	label string
-	s     screen
-}{
-	{"feed", screenFeed},
-	{"notifications", screenNotifications},
-	{"c-mail", screenCMail},
-	{"circ", screenChatrooms},
-	{"journal", screenJournal},
-	{"bookmarks", screenBookmarks},
-	{"guilds", screenGuilds},
-	{"topics", screenTopics},
-	{"profile", screenProfile},
-	{"search", screenSearch},
-	{"settings", screenSettings},
+// navTab is one entry in menuTabs.
+type navTab struct {
+	label    string
+	mnemonic rune
+	s        screen
+	// hidden excludes this entry from the rendered tab bar/nav sidebar and
+	// from arrow-key cycling (see visibleTabs, navigateTabBy) while keeping
+	// it reachable via its mnemonic leader chord and listed in the help
+	// modal's leader legend (leaderRows). Used for Search: it's an
+	// explicit-entry-only destination ("g s" or "/"), not a tab you park on
+	// or arrow past while browsing — see docs/02-menu-bar-navigation.md.
+	hidden bool
+}
+
+// menuTabs is the ordered list of navigable screens — the single source of
+// truth for tab-bar rendering, the "1"-"9" numeric aliases (the first 9
+// entries, by index), and the "g"+mnemonic leader-key chords (all entries,
+// via their mnemonic rune). Keeping all three derived from this one slice is
+// what keeps TabsLayout and MillerLayout from drifting apart. mnemonic must
+// be a rune that appears in label, since the tab bar renders it highlighted
+// inline within the label text.
+var menuTabs = []navTab{
+	{label: "feed", mnemonic: 'f', s: screenFeed},
+	{label: "notifications", mnemonic: 'n', s: screenNotifications},
+	{label: "c-mail", mnemonic: 'm', s: screenCMail},
+	{label: "circ", mnemonic: 'i', s: screenChatrooms},
+	{label: "journal", mnemonic: 'j', s: screenJournal},
+	{label: "bookmarks", mnemonic: 'b', s: screenBookmarks},
+	{label: "guilds", mnemonic: 'g', s: screenGuilds},
+	{label: "topics", mnemonic: 't', s: screenTopics},
+	{label: "profile", mnemonic: 'p', s: screenProfile},
+	{label: "search", mnemonic: 's', s: screenSearch, hidden: true},
+	{label: "settings", mnemonic: 'e', s: screenSettings},
+}
+
+// visibleTabs returns the menuTabs entries shown on the tab bar/nav sidebar
+// and reachable by arrow-key cycling — i.e. everything except hidden entries.
+func visibleTabs() []navTab {
+	out := make([]navTab, 0, len(menuTabs))
+	for _, t := range menuTabs {
+		if !t.hidden {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 var renderedVersionLine = theme.Subtle.Render("version " + version.Version + " (" + version.Commit + ")")
@@ -147,9 +177,12 @@ func themeIndex(name string) int {
 	return 0
 }
 
-// tabIndexOf returns the index of a.active within menuTabs, defaulting to 0.
+// tabIndexOf returns the index of a.active within visibleTabs, defaulting to
+// 0. a.active won't normally be a hidden screen (Search) here, since
+// navigateTabBy — the only caller — is a no-op while Search is active; if it
+// ever is, this defaults to 0 (Feed) same as any other not-found screen.
 func tabIndexOf(a App) int {
-	for i, t := range menuTabs {
+	for i, t := range visibleTabs() {
 		if t.s == a.active {
 			return i
 		}
@@ -157,9 +190,66 @@ func tabIndexOf(a App) int {
 	return 0
 }
 
-// navigateTabBy computes the App state and load command for moving delta steps
-// through menuTabs from the current active screen.
-func navigateTabBy(a App, delta int) (App, tea.Cmd) {
+// screenForNumber resolves a "1"-"9" key to its menuTabs entry, by index.
+// Only the first 9 of menuTabs' 11 entries have a numeric alias; Search and
+// Settings are reachable only via the "g"+mnemonic leader chord (see
+// screenForMnemonic) or, for Search, "/".
+func screenForNumber(key string) (screen, bool) {
+	if len(key) != 1 || key[0] < '1' || key[0] > '9' {
+		return 0, false
+	}
+	idx := int(key[0] - '1')
+	if idx >= len(menuTabs) {
+		return 0, false
+	}
+	return menuTabs[idx].s, true
+}
+
+// screenForMnemonic resolves the second keystroke of a "g"-prefixed leader
+// chord (e.g. "g f" for Feed) to its menuTabs entry. Derived from menuTabs
+// so it can never drift from what's shown highlighted on the tab bar.
+func screenForMnemonic(key string) (screen, bool) {
+	if len(key) != 1 {
+		return 0, false
+	}
+	for _, t := range menuTabs {
+		if rune(key[0]) == t.mnemonic {
+			return t.s, true
+		}
+	}
+	return 0, false
+}
+
+// splitMnemonic locates mnemonic within label and returns it split into three
+// parts (before, the mnemonic character itself, after) so a renderer can
+// style the mnemonic distinctly as an inline "go to" hint. If mnemonic isn't
+// found, ch is empty and before holds the full label.
+func splitMnemonic(label string, mnemonic rune) (before, ch, after string) {
+	idx := strings.IndexRune(label, mnemonic)
+	if idx < 0 {
+		return label, "", ""
+	}
+	n := utf8.RuneLen(mnemonic)
+	return label[:idx], label[idx : idx+n], label[idx+n:]
+}
+
+// leaderRows formats every "g"+mnemonic chord as a help-modal row via row
+// (see TabsLayout/MillerLayout's renderHelpModal), derived from menuTabs so
+// the help text can never drift from what the leader key actually does.
+func leaderRows(row func(key, desc string) string) []string {
+	rows := make([]string, 0, len(menuTabs))
+	for _, t := range menuTabs {
+		rows = append(rows, row("g "+string(t.mnemonic), t.label))
+	}
+	return rows
+}
+
+// activateScreen switches directly to screen s (as opposed to navigateTabBy's
+// relative cycling), cancelling any live subscription being left behind and
+// running the same lazy-load-on-entry side effects as cycling would. Used by
+// the "1"-"9" numeric aliases and the "g"+mnemonic leader chords in both
+// layouts, so a direct jump behaves identically to arriving via cycling.
+func activateScreen(a App, s screen) (App, tea.Cmd) {
 	if a.active == screenCMail {
 		a.cmail = a.cmail.CancelSubscription()
 	}
@@ -167,8 +257,7 @@ func navigateTabBy(a App, delta int) (App, tea.Cmd) {
 		a.chatrooms = a.chatrooms.CancelSubscription()
 	}
 	prev := a.active
-	idx := (tabIndexOf(a) + delta + len(menuTabs)) % len(menuTabs)
-	a.active = menuTabs[idx].s
+	a.active = s
 	if a.active == screenSearch && prev != screenSearch {
 		a.searchReturn = prev
 	}
@@ -216,10 +305,24 @@ func navigateTabBy(a App, delta int) (App, tea.Cmd) {
 		return a, a.loadJournalCmd()
 	case screenSearch:
 		// No auto-fetch: Search only has meaning once a query is submitted.
-		// Cycling in just shows whatever state it was last left in.
+		// Jumping in just shows whatever state it was last left in.
 		return a, nil
 	}
 	return a, nil
+}
+
+// navigateTabBy computes the App state and load command for moving delta
+// steps through visibleTabs from the current active screen. A no-op while
+// Search is active: it's a hidden, explicit-entry-only destination (reached
+// via "g s" or "/", see handleKeys in app.go), not part of the cyclable tab
+// rotation — the same reason screenPostDetail was never part of it either.
+func navigateTabBy(a App, delta int) (App, tea.Cmd) {
+	if a.active == screenSearch {
+		return a, nil
+	}
+	tabs := visibleTabs()
+	idx := (tabIndexOf(a) + delta + len(tabs)) % len(tabs)
+	return activateScreen(a, tabs[idx].s)
 }
 
 // delegateScreenUpdate routes a message to the currently active screen model.

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -164,98 +164,26 @@ func (l MillerLayout) View(a App) string {
 
 func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 	if a.focus == focusMenu {
+		if a.active == screenLogin {
+			return a, nil, false
+		}
+		if s, ok := screenForNumber(msg.String()); ok {
+			var cmd tea.Cmd
+			a, cmd = activateScreen(a, s)
+			return a, cmd, true
+		}
 		switch msg.String() {
 		case "j", "down":
-			if a.active != screenLogin {
-				var cmd tea.Cmd
-				a, cmd = navigateTabBy(a, +1)
-				return a, cmd, true
-			}
+			var cmd tea.Cmd
+			a, cmd = navigateTabBy(a, +1)
+			return a, cmd, true
 		case "k", "up":
-			if a.active != screenLogin {
-				var cmd tea.Cmd
-				a, cmd = navigateTabBy(a, -1)
-				return a, cmd, true
-			}
+			var cmd tea.Cmd
+			a, cmd = navigateTabBy(a, -1)
+			return a, cmd, true
 		case "l", "right", "enter":
-			if a.active != screenLogin {
-				a.focus = focusList
-				return a, nil, true
-			}
-		case "1":
-			if a.active != screenLogin {
-				a.cmail = a.cmail.CancelSubscription()
-				a.active = screenFeed
-				if !a.feed.IsLoaded() {
-					a.feed = a.feed.SetFetching()
-					return a, a.loadFeedCmd(), true
-				}
-				return a, nil, true
-			}
-		case "2":
-			if a.active != screenLogin {
-				a.cmail = a.cmail.CancelSubscription()
-				a.active = screenNotifications
-				if !a.notifications.HasPaginated() {
-					a.notifications = a.notifications.SetFetching()
-					return a, a.loadNotifsCmd(), true
-				}
-				return a, nil, true
-			}
-		case "3":
-			if a.active != screenLogin {
-				a.active = screenCMail
-				return a, a.loadConvsCmd(), true
-			}
-		case "4":
-			if a.active != screenLogin {
-				a.cmail = a.cmail.CancelSubscription()
-				a.active = screenJournal
-				a.journal = a.journal.SetFetching()
-				return a, a.loadJournalCmd(), true
-			}
-		case "5":
-			if a.active != screenLogin {
-				a.cmail = a.cmail.CancelSubscription()
-				a.active = screenBookmarks
-				if !a.bookmarks.IsLoaded() {
-					a.bookmarks = a.bookmarks.SetFetching()
-					return a, a.loadBookmarksCmd(""), true
-				}
-				return a, nil, true
-			}
-		case "6":
-			if a.active != screenLogin {
-				a.cmail = a.cmail.CancelSubscription()
-				a.active = screenGuilds
-				if !a.guilds.IsLoaded() {
-					a.guilds = a.guilds.SetFetching()
-					return a, a.loadGuildsCmd(""), true
-				}
-				return a, nil, true
-			}
-		case "7":
-			if a.active != screenLogin {
-				a.cmail = a.cmail.CancelSubscription()
-				a.active = screenTopics
-				if !a.topics.IsLoaded() {
-					a.topics = a.topics.SetFetching()
-					return a, a.loadTopicsCmd(), true
-				}
-				return a, nil, true
-			}
-		case "8":
-			if a.active != screenLogin {
-				a.cmail = a.cmail.CancelSubscription()
-				a.active = screenProfile
-				return a, a.loadProfileCmd(), true
-			}
-		case "9":
-			if a.active != screenLogin {
-				a.cmail = a.cmail.CancelSubscription()
-				a.active = screenSettings
-				return a, nil, true
-			}
+			a.focus = focusList
+			return a, nil, true
 		}
 		return a, nil, false
 	}
@@ -355,30 +283,34 @@ func (l MillerLayout) renderNav(a App) string {
 	navW := millerSidebarWidth - 1 // leave 1 col for the "│" separator
 
 	var rows []string
-	for _, t := range menuTabs {
-		label := t.label
+	for _, t := range visibleTabs() {
+		badge := ""
 		if t.s == screenNotifications && a.polledUnreadCount > 0 {
-			label = fmt.Sprintf("%s ●%d", label, a.polledUnreadCount)
+			badge = fmt.Sprintf(" ●%d", a.polledUnreadCount)
 		}
 		if t.s == screenCMail {
 			if n := a.cmail.TotalUnread(); n > 0 {
-				label = fmt.Sprintf("%s ●%d", label, n)
+				badge = fmt.Sprintf(" ●%d", n)
 			}
 		}
 		isActive := a.active == t.s &&
 			!(t.s == screenCMail && a.cmail.IsShowingDetail()) &&
 			!(t.s == screenChatrooms && a.chatrooms.IsShowingDetail())
-		var row string
+		marker := "  "
+		base := theme.Subtle
 		if isActive {
+			marker = "▶ "
 			if a.focus == focusMenu {
-				row = theme.Highlight.Width(navW).Render("▶ " + label)
-			} else {
-				row = theme.Subtle.Width(navW).Render("▶ " + label)
+				base = theme.Highlight
 			}
-		} else {
-			row = theme.Subtle.Width(navW).Render("  " + label)
 		}
-		rows = append(rows, row)
+		before, ch, after := splitMnemonic(t.label, t.mnemonic)
+		// No background is set on base/mnemonic here, so — unlike renderTabBar —
+		// wrapping the whole nested-ANSI string in one Width call is safe: the
+		// worst a lost style could do is leave trailing padding spaces
+		// uncolored, which is invisible.
+		text := base.Render(marker+before) + theme.NavMnemonic.Render(ch) + base.Render(after+badge)
+		rows = append(rows, lipgloss.NewStyle().Width(navW).Render(text))
 	}
 	return strings.Join(rows, "\n")
 }
@@ -483,7 +415,7 @@ func (l MillerLayout) renderNotification(a App) string {
 func (l MillerLayout) screenHints(a App) []hint {
 	switch a.focus {
 	case focusMenu:
-		return []hint{{"j/k", "nav"}, {"l/↵", "enter"}, {"1-9", "jump"}, {"?", "more"}}
+		return []hint{{"j/k", "nav"}, {"l/↵", "enter"}, {"1-9 / g+", "jump"}, {"?", "more"}}
 	case focusDetail:
 		return []hint{{"h/←", "list"}, {"j/k", "replies"}, {"↵", "thread"}, {"r", "reply"}}
 	default: // focusList
@@ -576,18 +508,21 @@ func (l MillerLayout) renderHelpModal(a App) string {
 		return lipgloss.JoinHorizontal(lipgloss.Top, k, theme.Subtle.Render(desc))
 	}
 
-	globalSection := lipgloss.JoinVertical(lipgloss.Left,
+	globalRows := append([]string{
 		sectionStyle.Render("global"),
 		row("j/k", "move nav · select section"),
 		row("l / enter", "enter content pane"),
 		row("h", "return to nav pane"),
 		row("1-9", "jump to section"),
+	}, leaderRows(row)...)
+	globalRows = append(globalRows,
 		row("/", "search"),
 		row("t", "theme"),
 		row("v", "density"),
 		row("o", "open url"),
 		row("q", "quit"),
 	)
+	globalSection := lipgloss.JoinVertical(lipgloss.Left, globalRows...)
 
 	body := lipgloss.JoinVertical(lipgloss.Left,
 		title,

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -96,100 +96,28 @@ func (l TabsLayout) View(a App) string {
 	return base
 }
 
-// HandleNav processes navigation key presses for the tabs layout:
-// number shortcuts 1–8 and left/right arrow tab cycling.
+// HandleNav processes navigation key presses for the tabs layout: the "1"-"9"
+// numeric aliases and left/right arrow tab cycling. The "g"+mnemonic leader
+// chords are handled globally in app.go's handleKeys, ahead of HandleNav,
+// since they apply identically regardless of which layout is active.
 func (l TabsLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
+	if a.active == screenLogin {
+		return a, nil, false
+	}
+	if s, ok := screenForNumber(msg.String()); ok {
+		var cmd tea.Cmd
+		a, cmd = activateScreen(a, s)
+		return a, cmd, true
+	}
 	switch msg.String() {
-	case "1":
-		if a.active != screenLogin {
-			a.cmail = a.cmail.CancelSubscription()
-			a.chatrooms = a.chatrooms.CancelSubscription()
-			a.active = screenFeed
-			if !a.feed.IsLoaded() {
-				a.feed = a.feed.SetFetching()
-				return a, a.loadFeedCmd(), true
-			}
-			return a, nil, true
-		}
-	case "2":
-		if a.active != screenLogin {
-			a.cmail = a.cmail.CancelSubscription()
-			a.chatrooms = a.chatrooms.CancelSubscription()
-			a.active = screenNotifications
-			if !a.notifications.HasPaginated() {
-				a.notifications = a.notifications.SetFetching()
-				return a, a.loadNotifsCmd(), true
-			}
-			return a, nil, true
-		}
-	case "3":
-		if a.active != screenLogin {
-			a.chatrooms = a.chatrooms.CancelSubscription()
-			a.active = screenCMail
-			return a, a.loadConvsCmd(), true
-		}
-	case "4":
-		if a.active != screenLogin {
-			a.cmail = a.cmail.CancelSubscription()
-			a.active = screenChatrooms
-			return a, a.loadRoomsCmd(), true
-		}
-	case "5":
-		if a.active != screenLogin {
-			a.cmail = a.cmail.CancelSubscription()
-			a.chatrooms = a.chatrooms.CancelSubscription()
-			a.active = screenJournal
-			a.journal = a.journal.SetFetching()
-			return a, a.loadJournalCmd(), true
-		}
-	case "6":
-		if a.active != screenLogin {
-			a.cmail = a.cmail.CancelSubscription()
-			a.chatrooms = a.chatrooms.CancelSubscription()
-			a.active = screenBookmarks
-			if !a.bookmarks.IsLoaded() {
-				a.bookmarks = a.bookmarks.SetFetching()
-				return a, a.loadBookmarksCmd(""), true
-			}
-			return a, nil, true
-		}
-	case "7":
-		if a.active != screenLogin {
-			a.cmail = a.cmail.CancelSubscription()
-			a.chatrooms = a.chatrooms.CancelSubscription()
-			a.active = screenGuilds
-			if !a.guilds.IsLoaded() {
-				a.guilds = a.guilds.SetFetching()
-				return a, a.loadGuildsCmd(""), true
-			}
-			return a, nil, true
-		}
-	case "8":
-		if a.active != screenLogin {
-			a.cmail = a.cmail.CancelSubscription()
-			a.chatrooms = a.chatrooms.CancelSubscription()
-			a.active = screenTopics
-			if !a.topics.IsLoaded() {
-				a.topics = a.topics.SetFetching()
-				return a, a.loadTopicsCmd(), true
-			}
-			return a, nil, true
-		}
-	case "9":
-		if a.active != screenLogin {
-			a.cmail = a.cmail.CancelSubscription()
-			a.chatrooms = a.chatrooms.CancelSubscription()
-			a.active = screenProfile
-			return a, a.loadProfileCmd(), true
-		}
 	case "left":
-		if a.active != screenLogin && a.active != screenPostDetail && a.focus == focusMenu {
+		if a.active != screenPostDetail && a.focus == focusMenu {
 			var cmd tea.Cmd
 			a, cmd = navigateTabBy(a, -1)
 			return a, cmd, true
 		}
 	case "right":
-		if a.active != screenLogin && a.active != screenPostDetail && a.focus == focusMenu {
+		if a.active != screenPostDetail && a.focus == focusMenu {
 			var cmd tea.Cmd
 			a, cmd = navigateTabBy(a, +1)
 			return a, cmd, true
@@ -231,24 +159,28 @@ func (l TabsLayout) ContentHeight(termHeight int) int { return termHeight }
 
 func (l TabsLayout) renderTabBar(a App) string {
 	var tabs string
-	for _, t := range menuTabs {
-		label := t.label
+	for _, t := range visibleTabs() {
+		badge := ""
 		if t.s == screenNotifications && a.polledUnreadCount > 0 {
-			label = fmt.Sprintf("%s (%d)", label, a.polledUnreadCount)
+			badge = fmt.Sprintf(" (%d)", a.polledUnreadCount)
 		}
 		if t.s == screenCMail {
 			if n := a.cmail.TotalUnread(); n > 0 {
-				label = fmt.Sprintf("%s (%d)", label, n)
+				badge = fmt.Sprintf(" (%d)", n)
 			}
 		}
 		isActive := a.active == t.s &&
 			!(t.s == screenCMail && a.cmail.IsShowingDetail()) &&
 			!(t.s == screenChatrooms && a.chatrooms.IsShowingDetail())
+		text, mnemonic := theme.TabText, theme.TabMnemonic
 		if isActive {
-			tabs += theme.ActiveTab.Render(label)
-		} else {
-			tabs += theme.Tab.Render(label)
+			text, mnemonic = theme.ActiveTabText, theme.ActiveTabMnemonic
 		}
+		before, ch, after := splitMnemonic(t.label, t.mnemonic)
+		// Each fragment is rendered independently (rather than wrapping the
+		// whole label in one .Padding style) so the active tab's background
+		// survives across the mnemonic's own ANSI reset — see TabText's doc.
+		tabs += text.Render("  "+before) + mnemonic.Render(ch) + text.Render(after+badge+"  ")
 	}
 	logo := lipgloss.NewStyle().
 		Background(theme.ColorGreen).
@@ -390,22 +322,22 @@ func (l TabsLayout) screenHints(a App) []hint {
 		if a.feed.ComposeActive() {
 			return []hint{{"tab", "cycle"}, {"space", "toggle"}, {"Ctrl+s", "send"}, {"Esc", "cancel"}}
 		}
-		return []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"r", "reply"}, {"n", "new"}, {"b", "bookmark"}, {"w", "watch"}, {"c", "c-mail"}, more}
+		return []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"r", "reply"}, {"n", "new"}, {"b", "bookmark"}, {"w", "watch"}, {"c", "message"}, more}
 	case screenPostDetail:
 		if a.postDetail.ComposeActive() {
 			return []hint{{"Ctrl+s", "send"}, {"Esc", "cancel"}}
 		}
-		return []hint{{"↑↓", "navigate"}, {"r", "reply"}, {"b", "bookmark"}, {"w", "watch"}, {"c", "c-mail"}, {"esc", "back"}, more}
+		return []hint{{"↑↓", "navigate"}, {"r", "reply"}, {"b", "bookmark"}, {"w", "watch"}, {"c", "message"}, {"esc", "back"}, more}
 	case screenProfile:
 		if a.profile.ComposeActive() {
 			return []hint{{"Ctrl+s", "save"}, {"Esc", "cancel"}, {"tab", "cycle"}}
 		}
 		if a.profile.IsReadOnly() {
-			return []hint{{"↑↓", "navigate"}, {"f", "follow"}, {"c", "c-mail"}, {"tab", "cycle"}, more}
+			return []hint{{"↑↓", "navigate"}, {"f", "follow"}, {"c", "message"}, {"tab", "cycle"}, more}
 		}
 		return []hint{{"↑↓", "navigate"}, {"e", "edit"}, {"tab", "cycle"}, more}
 	case screenNotifications:
-		return []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"m", "mark read"}, {"u", "toggle unread"}, {"c", "c-mail"}, more}
+		return []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"m", "mark read"}, {"u", "toggle unread"}, {"c", "message"}, more}
 	case screenJournal:
 		if a.journal.ComposeActive() {
 			return []hint{{"tab", "cycle"}, {"Ctrl+s", "save"}, {"Ctrl+p", "publish"}, {"Esc", "cancel"}}
@@ -498,9 +430,11 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		return lipgloss.JoinHorizontal(lipgloss.Top, k, theme.Subtle.Render(desc))
 	}
 
-	globalSection := lipgloss.JoinVertical(lipgloss.Left,
+	globalRows := append([]string{
 		sectionStyle.Render("global"),
 		row("1-9", "feed · notifs · c-mail · circ · journal · bookmarks · guilds · topics · profile"),
+	}, leaderRows(row)...)
+	globalRows = append(globalRows,
 		row("← →", "cycle tabs"),
 		row("/", "search"),
 		row("t", "theme"),
@@ -508,6 +442,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		row("o", "open url"),
 		row("q", "quit"),
 	)
+	globalSection := lipgloss.JoinVertical(lipgloss.Left, globalRows...)
 
 	section := func(title string, extra ...string) string {
 		parts := append([]string{sectionStyle.Render(title)}, hintRows(l.screenHints(a), row)...)
@@ -523,7 +458,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		} else {
 			localSection = section("feed",
 				row("p", "view profile"),
-				row("c", "start c-mail"),
+				row("c", "message"),
 				row("d", "delete own"),
 			)
 		}
@@ -534,7 +469,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 			localSection = section("post detail",
 				row("d", "delete own"),
 				row("p", "view profile"),
-				row("c", "start c-mail"),
+				row("c", "message"),
 			)
 		}
 	case screenProfile:
@@ -543,7 +478,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		} else if a.profile.IsReadOnly() {
 			localSection = section("profile",
 				row("enter", "open"),
-				row("c", "start c-mail"),
+				row("c", "message"),
 			)
 		} else {
 			localSection = section("profile (own)",
@@ -554,7 +489,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		localSection = section("notifications",
 			row("M", "mark all read"),
 			row("p", "view profile"),
-			row("c", "start c-mail"),
+			row("c", "message"),
 		)
 	case screenJournal:
 		if a.journal.ComposeActive() {

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// --- visibleTabs ---
+
+func TestVisibleTabs_ExcludesHiddenSearch(t *testing.T) {
+	for _, t2 := range visibleTabs() {
+		if t2.s == screenSearch {
+			t.Error("expected screenSearch to be excluded from visibleTabs")
+		}
+	}
+	if got, want := len(visibleTabs()), len(menuTabs)-1; got != want {
+		t.Errorf("expected %d visible tabs (menuTabs minus the one hidden entry), got %d", want, got)
+	}
+}
+
+// --- renderTabBar / renderNav: Search must not appear on either bar ---
+
+func TestRenderTabBar_DoesNotShowSearch(t *testing.T) {
+	a := loggedInApp()
+	a.width = 100
+	out := ansi.Strip(TabsLayout{}.renderTabBar(a))
+	if strings.Contains(out, "search") {
+		t.Errorf("expected the tab bar to omit the hidden Search entry, got: %q", out)
+	}
+}
+
+func TestRenderNav_DoesNotShowSearch(t *testing.T) {
+	a := loggedInApp()
+	out := ansi.Strip(MillerLayout{}.renderNav(a))
+	if strings.Contains(out, "search") {
+		t.Errorf("expected the nav sidebar to omit the hidden Search entry, got: %q", out)
+	}
+}
+
+// --- screenForNumber ---
+
+func TestScreenForNumber_1Through9_MatchMenuTabsOrder(t *testing.T) {
+	want := []screen{
+		screenFeed, screenNotifications, screenCMail, screenChatrooms,
+		screenJournal, screenBookmarks, screenGuilds, screenTopics, screenProfile,
+	}
+	for i, w := range want {
+		key := string(rune('1' + i))
+		got, ok := screenForNumber(key)
+		if !ok {
+			t.Errorf("key %q: expected ok=true", key)
+		}
+		if got != w {
+			t.Errorf("key %q: expected %v, got %v", key, w, got)
+		}
+	}
+}
+
+func TestScreenForNumber_SearchAndSettingsHaveNoNumericAlias(t *testing.T) {
+	// menuTabs' 10th and 11th entries (Search, Settings) are intentionally
+	// unreachable by number — only "0" or beyond "9" would reach them, and
+	// neither is a valid key here.
+	if _, ok := screenForNumber("0"); ok {
+		t.Error("\"0\" should not resolve to a screen")
+	}
+}
+
+func TestScreenForNumber_InvalidKeys(t *testing.T) {
+	for _, key := range []string{"", "a", "10", "g", "!"} {
+		if _, ok := screenForNumber(key); ok {
+			t.Errorf("key %q: expected ok=false", key)
+		}
+	}
+}
+
+// --- screenForMnemonic ---
+
+func TestScreenForMnemonic_AllElevenTabsReachable(t *testing.T) {
+	for _, tab := range menuTabs {
+		got, ok := screenForMnemonic(string(tab.mnemonic))
+		if !ok {
+			t.Errorf("mnemonic %q: expected ok=true", tab.mnemonic)
+		}
+		if got != tab.s {
+			t.Errorf("mnemonic %q: expected %v, got %v", tab.mnemonic, tab.s, got)
+		}
+	}
+}
+
+func TestScreenForMnemonic_UnmappedKeyCancels(t *testing.T) {
+	if _, ok := screenForMnemonic("z"); ok {
+		t.Error("\"z\" is not a mnemonic and should not resolve to a screen")
+	}
+}
+
+func TestScreenForMnemonic_MnemonicsAreUniqueAndPresentInLabel(t *testing.T) {
+	seen := make(map[rune]string)
+	for _, tab := range menuTabs {
+		if prev, ok := seen[tab.mnemonic]; ok {
+			t.Errorf("mnemonic %q used by both %q and %q", tab.mnemonic, prev, tab.label)
+		}
+		seen[tab.mnemonic] = tab.label
+		if _, ch, _ := splitMnemonic(tab.label, tab.mnemonic); ch == "" {
+			t.Errorf("mnemonic %q for %q does not appear in its own label", tab.mnemonic, tab.label)
+		}
+	}
+}
+
+// --- splitMnemonic ---
+
+func TestSplitMnemonic_Found(t *testing.T) {
+	before, ch, after := splitMnemonic("c-mail", 'm')
+	if before != "c-" || ch != "m" || after != "ail" {
+		t.Errorf("got (%q, %q, %q)", before, ch, after)
+	}
+}
+
+func TestSplitMnemonic_NotFound(t *testing.T) {
+	before, ch, after := splitMnemonic("feed", 'z')
+	if before != "feed" || ch != "" || after != "" {
+		t.Errorf("got (%q, %q, %q), want (\"feed\", \"\", \"\")", before, ch, after)
+	}
+}

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -75,6 +75,38 @@ var (
 			Bold(true).
 			Padding(0, 2)
 
+	// TabText/ActiveTabText and TabMnemonic/ActiveTabMnemonic are the
+	// no-padding building blocks renderTabBar uses to highlight a tab's
+	// leader-key mnemonic letter inline. Padding is added manually as literal
+	// spaces around the concatenated fragments (see renderTabBar) rather than
+	// via .Padding, because each fragment is rendered independently — nesting
+	// ANSI-styled spans inside a single .Padding call loses the background
+	// on any fragment after the first once its reset code fires.
+	TabText = lipgloss.NewStyle().
+		Foreground(ColorDimGreen)
+
+	TabMnemonic = lipgloss.NewStyle().
+			Foreground(ColorCyan).
+			Bold(true)
+
+	ActiveTabText = lipgloss.NewStyle().
+			Background(ColorDimGreen).
+			Foreground(ColorGreen).
+			Bold(true)
+
+	ActiveTabMnemonic = lipgloss.NewStyle().
+				Background(ColorDimGreen).
+				Foreground(ColorCyan).
+				Bold(true)
+
+	// NavMnemonic highlights a leader-key mnemonic letter within the Miller
+	// layout's vertical nav sidebar, where rows have no background to
+	// preserve, so a single foreground-only style suffices for both the
+	// active and inactive row states.
+	NavMnemonic = lipgloss.NewStyle().
+			Foreground(ColorCyan).
+			Bold(true)
+
 	SelectedRow = lipgloss.NewStyle().
 			Background(ColorDimGreen).
 			Foreground(ColorGreen).
@@ -182,6 +214,27 @@ func applyStyles() {
 		Foreground(ColorGreen).
 		Bold(true).
 		Padding(0, 2)
+
+	TabText = lipgloss.NewStyle().
+		Foreground(ColorDimGreen)
+
+	TabMnemonic = lipgloss.NewStyle().
+		Foreground(ColorCyan).
+		Bold(true)
+
+	ActiveTabText = lipgloss.NewStyle().
+		Background(ColorDimGreen).
+		Foreground(ColorGreen).
+		Bold(true)
+
+	ActiveTabMnemonic = lipgloss.NewStyle().
+		Background(ColorDimGreen).
+		Foreground(ColorCyan).
+		Bold(true)
+
+	NavMnemonic = lipgloss.NewStyle().
+		Foreground(ColorCyan).
+		Bold(true)
 
 	SelectedRow = lipgloss.NewStyle().
 		Background(ColorDimGreen).


### PR DESCRIPTION
## Summary

- 11 top-level tabs had outgrown `1`-`9`, and `TabsLayout`/`MillerLayout` had already drifted apart on what each number meant (key `4` opened CIRC in one, Journal in the other).
- Adds a `g`+mnemonic leader key (e.g. `g f` for Feed, `g m` for C-Mail, `g g` for Guilds) that reaches all 11 screens, using only plain letters so it's safe over SSH/tmux/any terminal.
- `1`-`9` stay as aliases for the first 9 screens, now derived from a single `menuTabs` source of truth instead of two hand-duplicated switch statements — the two layouts can no longer disagree.
- Each tab's mnemonic letter is highlighted inline on the tab bar / nav sidebar as a discoverability hint.
- Fixed 3 stale entries in the shortcuts doc found along the way (a `z` timezone shortcut that didn't exist, Notifications' unread toggle documented as `1` when it's `u`, nonexistent `alt+enter`/`alt+p`/`alt+s` compose bindings).

**Two follow-ups from testing the new scheme:**
- Search is now a hidden, explicit-entry-only destination — reachable only via `g s` or `/`, both of which always focus the query box. Previously `g s` (like arrow-cycling) could land on Search unfocused, which the screen doesn't actually handle since query-mode is only ever supposed to be entered focused.
- The `c` "message this user" shortcut (Feed, Post Detail, Notifications, read-only Profile) is reworded from `c-mail`/`start c-mail` to `message` in the status bar and help modal, since it now reads as if it opens the C-Mail screen — which is what `g m` actually does. `c` itself is unchanged and still useful (targets a specific user without navigating anywhere).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...` all clean
- [x] `go test ./...` passes, including new coverage for `screenForNumber`/`screenForMnemonic`/`visibleTabs`, the leader-key state machine (arm/resolve/cancel, login/input-focus guards, cross-layout parity), and the Search-focus fix (including after a stale preview state)
- [x] Manually rendered the tab bar / nav sidebar with color forced on to confirm the mnemonic highlight doesn't corrupt ANSI or leak backgrounds across fragments
- [x] Manual pass in a real terminal (both layout modes) recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)