### PR TITLE
fix: remediate 2026-07-24 security review findings

### DIFF
--- a/cmd/cyber-tui/main.go
+++ b/cmd/cyber-tui/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 
@@ -59,6 +60,10 @@ func main() {
 
 	// SSH server mode (experimental)
 	if cfg.SSHListenAddr != "" {
+		if err := validateSSHAddr(cfg.SSHListenAddr, cfg.AllowRemoteSSH); err != nil {
+			fmt.Fprintf(os.Stderr, "config: %v\n", err)
+			os.Exit(1)
+		}
 		keyPath := cfg.SSHHostKeyPath
 		if keyPath == "" {
 			keyPath = "./ssh_host_key"
@@ -116,5 +121,27 @@ func validateBaseURL(raw string, allowInsecure bool) error {
 			"Use https, or set allowInsecureApi: true for a non-loopback dev server", raw)
 	default:
 		return fmt.Errorf("apiBaseURL %q must use http or https", raw)
+	}
+}
+
+// validateSSHAddr rejects a non-loopback SSH listen address unless
+// allowRemote is set. SSH server mode performs no authentication, so an
+// address like ":2222" (all interfaces) would otherwise expose a full,
+// unauthenticated session to anyone who can reach it from a single
+// misconfigured field.
+func validateSSHAddr(addr string, allowRemote bool) error {
+	if addr == "" || allowRemote {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid sshListenAddr %q: %w", addr, err)
+	}
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return nil
+	default:
+		return fmt.Errorf("sshListenAddr %q binds a non-loopback address; SSH server mode is unauthenticated. "+
+			"Use a loopback address, or set allowRemoteSsh: true to expose it intentionally", addr)
 	}
 }

--- a/cmd/cyber-tui/main_test.go
+++ b/cmd/cyber-tui/main_test.go
@@ -23,3 +23,28 @@ func TestValidateBaseURL(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSSHAddr(t *testing.T) {
+	cases := []struct {
+		addr        string
+		allowRemote bool
+		wantErr     bool
+	}{
+		{"", false, false},
+		{":2222", false, true},
+		{"localhost:2222", false, false},
+		{"127.0.0.1:2222", false, false},
+		{"[::1]:2222", false, false},
+		{"0.0.0.0:2222", false, true},
+		{"evil.example.com:2222", false, true},
+		{":2222", true, false},
+		{"evil.example.com:2222", true, false},
+		{"not-a-valid-addr", false, true},
+	}
+	for _, c := range cases {
+		err := validateSSHAddr(c.addr, c.allowRemote)
+		if (err != nil) != c.wantErr {
+			t.Errorf("validateSSHAddr(%q, %v) err = %v, wantErr %v", c.addr, c.allowRemote, err, c.wantErr)
+		}
+	}
+}

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -638,6 +638,7 @@ Permissions: `0600` (owner read/write only)
 | `autoPassword` | string | — | Pre-fill password (plain text; not recommended) |
 | `sshListenAddr` | string | — | Enable SSH server mode (e.g. `":2222"`) |
 | `sshHostKeyPath` | string | — | Path to SSH host private key |
+| `allowRemoteSsh` | bool | `false` | Permit `sshListenAddr` to bind a non-loopback address. SSH server mode is unauthenticated, so this is off by default |
 | `wanderLust` | bool | `false` | Wander mode toggle; `true` = on, `false` = off |
 | `lastWandered` | string | `""` (= never) | ISO timestamp of last wander mode update |
 
@@ -966,3 +967,13 @@ Release tags follow semver: `git tag -a v0.1.0 -m "v0.1.0"`. The `--version` fla
 | **Profile navigation depth** | Navigating from a Following/Followers tab to another user's profile is single-level; ESC returns to the original `profileReturn` destination, not the intermediate profile |
 | **Feed position — deep pagination** | When returning to the Feed tab, the selected post is restored by ID from the fresh first-page load. If the post was reached via pagination it will not be in page 1 and the feed falls back to the top. Fix options: re-fetch pages sequentially until found (expensive), or skip the tab-switch reload (stale data). Neither is warranted for typical usage. |
 | **Ambiguous-width character stripping** | Unicode EAW = "A" characters (kaomoji symbols, `©`, `®`, `™`, Greek letters, etc.) are stripped at two points: (1) `stripAmbiguousRunes` in `shared.go` strips them from post/reply content before display; (2) `filterAmbiguousKeyMsg` in `shared.go` intercepts `tea.KeyRunes` messages before they reach any `textarea` or `textinput` component (compose, topics, profile fields, C-Mail, chatrooms). Their column width is undefined and varies by terminal/font, causing border overflow and cursor misalignment. Wide (CJK), halfwidth, and zero-width characters are unaffected. |
+
+---
+
+## Code & Security Reviews
+
+Periodic full-repository audits, tracked as dated snapshots so successive reviews can be diffed against each other. Findings are actioned separately (see each report's Actionable Recommendations table); this doc's Deferred/Known Limitations table above tracks accepted long-term gaps.
+
+| Date | Commit | Report |
+|---|---|---|
+| 2026-07-24 | `8835173` | [`docs/reviews/2026-07-24-code-security-review.md`](reviews/2026-07-24-code-security-review.md) |

--- a/docs/30-security-hardening.md
+++ b/docs/30-security-hardening.md
@@ -72,11 +72,67 @@ authentication remains out of scope.
 x/crypto, including the SSH server path, plus standard-library issues fixed in
 recent Go patch releases).
 
+## Follow-up — 2026-07-24 review remediation
+
+The 2026-07-24 code and security review (`docs/reviews/2026-07-24-code-security-review.md`)
+found five issues; this section records the fixes.
+
+### 7. Chat message sanitize-bypass (High)
+
+Section 1 above states `sanitize.Strings` is called at every wire-to-model
+converter — but five chat-related conversion paths in `internal/api/client.go`
+were missed: `GetRoomMessages`, `GetMessages`, `GetConversations`,
+`wireRTDBMessageToModel`, and `wireRTDBCircMessageToModel`. A sixth,
+`GetRooms`, was found missing the same call while fixing the others. All six
+now call `sanitize.Strings` before building the model value, matching every
+other converter in the file. As defense in depth, `internal/ui/screens/render.go`
+now also strips control characters from the sender username and action-line
+username directly at render time (`sanitize.Strip`), and `internal/ui/app.go`
+sanitizes server-generated slash-command reply text before displaying it as a
+system message — so a future field added to either path doesn't silently
+regress the same way.
+
+### 8. Unsanitized raw bytes in log output (Medium)
+
+`apiTimestamp.UnmarshalJSON`'s fallback log line used to write an
+unrecognized server value straight to stderr with `%s`. Changed to `%q`,
+which renders control/escape characters as safe Go-quoted text instead of
+passing them through raw.
+
+### 9. Redirect scheme downgrade (Low)
+
+`NewHTTPClient`'s `http.Client` now sets `CheckRedirect` to refuse any
+redirect whose target scheme is not `https` (replicating the standard
+10-redirect cap that Go's default `nil` `CheckRedirect` provides). Closes a
+gap where `validateBaseURL` only checked the configured `apiBaseURL` once at
+startup — a same-host HTTPS→HTTP redirect issued by a compromised or
+misconfigured host would otherwise still carry the bearer token, since Go
+only strips `Authorization` on a cross-host redirect, not a same-host scheme
+downgrade.
+
+### 10. `crypto/tls` toolchain CVE (Low)
+
+`govulncheck` flagged GO-2026-5856 (Encrypted Client Hello privacy leak) in
+the Go standard library at the toolchain version then in use. Toolchain
+bumped to `go1.26.5`, which CI picks up automatically via `setup-go`'s
+`go-version-file: go.mod`. Re-running `govulncheck` after the bump confirms
+the finding is gone.
+
+### 11. SSH server mode — opt-in gate for non-loopback binds
+
+SSH server mode remains unauthenticated by design (see §4) — that isn't
+changing. What changed: binding `sshListenAddr` to anything but a loopback
+address now requires the new `allowRemoteSsh` config flag, mirroring the
+`allowInsecureApi` pattern in §5, so a single misconfigured `sshListenAddr`
+(e.g. `":2222"`, which binds all interfaces) can't expose an unauthenticated
+session to the network by itself.
+
 ## New configuration field
 
 | Field | Type | Default | Purpose |
 |---|---|---|---|
 | `allowInsecureApi` | bool | `false` | Permit a plain `http://` `apiBaseURL` to a non-loopback host. Off by default. |
+| `allowRemoteSsh` | bool | `false` | Permit `sshListenAddr` to bind a non-loopback address. SSH server mode is unauthenticated. Off by default. |
 
 ## Verification
 
@@ -95,3 +151,10 @@ Targeted tests added by this work:
 - `internal/rtdb`: rejection of host-injecting `aud` claims.
 - `internal/ssh`: surfaced listen error.
 - `cmd/cyber-tui`: `validateBaseURL` scheme rules.
+
+Targeted tests added by the 2026-07-24 follow-up (§7-11):
+
+- `internal/api`: control-character stripping for `GetRoomMessages`, `GetMessages`,
+  `GetConversations`, `GetRooms`, and the RTDB SSE `SubscribeDMs`/`SubscribeRoom`
+  paths; `NewHTTPClient` refusing a redirect to a non-https URL.
+- `cmd/cyber-tui`: `validateSSHAddr` loopback/non-loopback/opt-in rules.

--- a/docs/reviews/2026-07-24-code-security-review.md
+++ b/docs/reviews/2026-07-24-code-security-review.md
@@ -1,0 +1,178 @@
+# Code & Security Review — 2026-07-24
+
+**Reviewed commit:** `8835173` (main) · **Baseline for future comparisons — first review in this series.**
+
+Scope: full repository (80 Go files, ~32,400 lines). Automated tooling was re-run fresh rather than trusted from CI history. Manual review focused on trust boundaries: authentication/token handling, the experimental SSH host mode, untrusted-content rendering, outbound network calls, and OS command execution — informed by `docs/30-security-hardening.md`, the prior hardening pass this review checks for drift against.
+
+---
+
+## Executive Summary
+
+| Severity | Count |
+|---|---|
+| High | 1 |
+| Medium | 1 |
+| Low | 5 |
+| Informational | 3 |
+
+(3 Low + 2 Informational under Security Findings; 2 Low + 1 Informational under Code Quality Findings.)
+
+The standout finding is **High**: chat messages (C-Mail DMs and cIRC chatrooms) bypass the app's central sanitization layer on four separate code paths, contradicting an invariant `docs/30-security-hardening.md` explicitly documents as universal ("`sanitize.Strings` is called at every wire-to-model converter... so all server text is sanitized at the API boundary before it can reach any screen"). This is a real regression against a documented guarantee, not a newly-discovered design gap — it should be the first thing fixed.
+
+Everything else is contained: `go vet` and `staticcheck` are clean, all tests pass, and `govulncheck` surfaces one stdlib finding tied to the local Go toolchain version rather than the app's own code or dependencies. No SQL/command injection, no `InsecureSkipVerify`, no secrets in the repo, no unbounded resource consumption paths found.
+
+---
+
+## Security Findings
+
+### HIGH — Chat message sender usernames and system replies bypass `sanitize.Strings`
+
+**Files:**
+- `internal/api/client.go:1496-1523` (`GetRoomMessages` — REST cIRC history)
+- `internal/api/client.go:1611-1632` (`wireRTDBMessageToModel`, `wireRTDBCircMessageToModel` — RTDB SSE live messages)
+- `internal/api/client.go:1636-1656` (`GetConversations` — C-Mail conversation list)
+- `internal/api/client.go:1658-1684` (`GetMessages` — REST C-Mail history)
+- `internal/ui/app.go:762, 798` (server-generated command reply text from `SendRoomMessage`/`SendMessage`, e.g. `/help` output — called at `app.go:2484, 2504` — passed to `AppendSystemMessage` unsanitized)
+- `internal/ui/screens/render.go:344, 346` (`renderChatMessages` — renders `msg.From.Username` directly via `theme.Highlight.Render`, not through `markdown.Render`)
+
+**The problem:** Every other wire-to-model conversion in `client.go` — posts, users, replies, notifications, guilds, notes (14 call sites) — calls `sanitize.Strings(&w)` before constructing the model value. The five chat-message conversion paths above do not. `msg.Body` gets a compensating strip at render time because `renderChatMessages` (`render.go:358`) passes it through `markdown.Render`, which calls `sanitize.Strip` internally — so message bodies are actually protected by accident, not by the documented boundary control. `msg.From.Username`, however, is rendered directly (`render.go:344,346`) with no sanitization at either layer, and the conversation-list "other user" username (`cmail.go:592`) has the same gap via `GetConversations`.
+
+**Failure scenario:** A user sets their cyberspace.online display name/username to a string containing ANSI/OSC escape sequences (e.g. an OSC 52 clipboard-write sequence, or a cursor/title-manipulation sequence), then DMs the victim or posts in a shared cIRC room. The instant the victim's client renders the header line for that message — no click, no link-open required — the escape sequence executes in the victim's terminal. Depending on terminal emulator, this ranges from cosmetic (spoofed title) to data-exfiltration-adjacent (clipboard write) or a trigger for terminal-emulator-specific escape-sequence bugs.
+
+**Recommendation:** Add `sanitize.Strings(&w)` (or equivalent per-field `sanitize.Strip`) to all five conversion sites listed above, matching the existing pattern used everywhere else in the file. As defense in depth, also route `msg.From.Username` through `sanitize.Strip` (or `markdown.Render`) at the render layer in `render.go`, so the guarantee doesn't depend solely on the API boundary being remembered for every new field. Add a regression test asserting sanitize coverage for these five paths specifically, since `internal/sanitize` currently sits at 100% coverage but that only proves the package itself works — it doesn't prove every call site uses it.
+
+---
+
+### MEDIUM — `apiTimestamp.UnmarshalJSON` logs unrecognized raw server bytes unconditionally, unsanitized
+
+**File:** `internal/api/client.go:132` (also `client.go:716`, `parseTime`)
+
+**The problem:** When a timestamp field on a `/v1/search` hit doesn't match any recognized shape, the raw bytes are logged via `log.Printf("api: apiTimestamp: unrecognized value, leaving empty: %s", b)` — unconditionally (not gated behind `isDebug()`), and before any sanitization. `b` is attacker-influenced (the comment at `client.go:80-90` notes this field is already observed to serialize inconsistently on live search hits).
+
+**Failure scenario:** A crafted timestamp value containing terminal escape sequences reaches this log line and is written to stderr. In local TUI mode, stderr typically isn't the alt-screen the user is actively viewing, which limits impact; in SSH server mode (`internal/ssh/server.go`), stderr is the *host operator's* terminal, not the connecting client's — so this is a narrow but real vector for injecting sequences into the SSH host operator's own session via a value the operator never directly requested.
+
+**Recommendation:** Sanitize `b` (or truncate/hex-encode it) before logging, at both this call site and `client.go:716`.
+
+---
+
+### LOW — `apiBaseURL` scheme downgrade via same-host redirect is not defended
+
+**Files:** `internal/api/client.go:592-648` (`doRequest`), `cmd/cyber-tui/main.go:99-120` (`validateBaseURL`)
+
+**The problem:** `validateBaseURL` correctly rejects a configured `http://` `apiBaseURL` to a non-loopback host, preventing the bearer token from being sent in cleartext by misconfiguration. `HTTPClient`'s underlying `http.Client` (`client.go:550`, `Timeout: 15s` only) uses no custom `CheckRedirect`. Go's default client strips `Authorization` on a cross-*host* redirect, but does **not** strip it on a same-host scheme downgrade (`https://api.example.com` → `http://api.example.com`). If the configured HTTPS host is ever compromised, DNS-hijacked, or misconfigured to issue such a redirect, the token would still be attached.
+
+**Recommendation:** Set an explicit `CheckRedirect` on `HTTPClient`'s `http.Client` that refuses to follow any redirect whose scheme is `http`, closing the gap `validateBaseURL` otherwise only checks once at startup. Low priority — requires the trusted host itself to misbehave — but cheap to fix.
+
+---
+
+### LOW — `govulncheck`: stdlib `crypto/tls` ECH privacy leak (GO-2026-5856) in the active Go toolchain
+
+**Scope:** Go toolchain, not app code or a direct/indirect dependency.
+
+`govulncheck ./...` (fresh run against the locally installed `go1.26.4`) reports:
+
+```
+Vulnerability #1: GO-2026-5856
+  Invoking Encrypted Client Hello privacy leak in crypto/tls
+  Found in: crypto/tls@go1.26.4
+  Fixed in: crypto/tls@go1.26.5
+  Example traces: internal/rtdb/client.go (Put → http.Client.Do → tls handshake)
+```
+
+`go.mod` pins `toolchain go1.25.12` (`go.mod:5`), older than the `go1.26.4` used for this scan — so this specific finding's applicability depends on which Go version actually builds CI/release binaries, not what's pinned in `go.mod`. `docs/30-security-hardening.md §6` records the toolchain being pinned specifically to clear a prior `govulncheck` finding, so this pattern (govulncheck flags a toolchain-level CVE, project bumps `toolchain`) has precedent.
+
+**Recommendation:** Confirm the Go version used by `.github/workflows/ci.yml` and `release.yml`, and bump the `toolchain` directive to `go1.26.5+` (or the fixed patch of whichever minor line is in use). Exploitability is low in practice — ECH is opt-in and this app doesn't appear to configure it — but the fix is a one-line toolchain bump.
+
+---
+
+### LOW — SSH host mode remains unauthenticated by design (unchanged since `docs/30-security-hardening.md`)
+
+**Files:** `internal/ssh/server.go`, `cmd/cyber-tui/main.go:60-73`
+
+No change from the prior hardening pass: any client that can reach the listening address gets a full session, no SSH auth is performed. This is clearly documented in three places (doc comment on `Serve`, a runtime stderr warning on startup, and `docs/30-security-hardening.md §4`), and per-connection API clients plus `WithEphemeralSession()` correctly prevent cross-session credential leakage and host-config writes — the isolation guarantees from the prior review still hold. Rated Low here only because it's already flagged and gated, not because the underlying exposure is small; **do not enable `sshListenAddr` on anything but a trusted/loopback network.**
+
+**Recommendation:** No action required unless multi-user SSH auth becomes a real requirement — tracked as a known, accepted limitation. Consider adding a startup check that refuses to bind a non-loopback address without an explicit opt-in flag, mirroring the `allowInsecureApi` pattern, so the unauthenticated exposure requires two deliberate config choices instead of one.
+
+---
+
+### INFORMATIONAL — Image attachment fetch has no host allowlist (potential SSRF surface, contingent on server behavior)
+
+**File:** `internal/ui/imgview/fetch.go`
+
+`Fetch` downloads whatever URL is in an attachment's `Src` field with no restriction to an expected CDN domain. Size caps (10 MiB) and pixel caps (~52MP) are in place, which mitigate resource-exhaustion, but not the SSRF class: if the API can ever be induced to return an attacker-controlled `Src` (e.g. via an unvalidated user-submitted URL field), the client would fetch it, potentially reaching internal/loopback addresses from the *viewer's* machine. This is speculative — it depends on server-side behavior this review didn't verify — logged for awareness, not as a confirmed exploit.
+
+**Recommendation:** If attachment URLs are always same-origin CDN URLs by server-side construction, this is a non-issue; worth a one-line confirmation from the API side. If not, add a host allowlist in `Fetch`.
+
+---
+
+### INFORMATIONAL — RTDB auth token passed as a URL query parameter
+
+**File:** `internal/rtdb/client.go:311-323` (`buildURL`)
+
+This is Firebase's own REST/SSE convention (`?auth=<token>`), not an app-level choice, so it's not actionable here — but it means the token appears in full URLs, which would be captured by any logging proxy, browser history equivalent, or crash reporter sitting between the client and Firebase. No such intermediary currently exists in this codebase. Noted for awareness if one is ever added.
+
+---
+
+## Code Quality Findings
+
+### LOW — `internal/ui/imgview` undocumented in `docs/00-project-reference.md`
+
+The project reference's Package Reference section (`docs/00-project-reference.md`, `## Package Reference`) lists `cmd/cyber-tui`, `internal/model`, `internal/api`, `internal/config`, `internal/rtdb`, `internal/ssh`, `internal/ui`, `internal/ui/screens`, `internal/ui/theme` — but not `internal/ui/imgview` (7 files) or `internal/ui/markdown`/`internal/ui/urlutil`, all of which exist on disk and are exercised by the app (image viewer support, markdown rendering, URL extraction/opening). Per this project's own Definition of Done, `docs/00-project-reference.md` is supposed to reflect every package. **Recommendation:** add a Package Reference entry for each.
+
+### LOW — Several UI screen files are large, `guilds.go` most notably
+
+Line counts in `internal/ui/screens`: `guilds.go` 1239, `profile.go` 1112, `feed.go` 897, `journal.go` 881, `topics.go` 811, `postdetail.go` 807, `cmail.go` 775, `search.go` 770. `guilds.go` in particular is ~63% larger than the next-largest non-test file. This isn't a defect, but it's worth a look for extraction opportunities (e.g. splitting list-rendering, key-handling, and update logic into separate files per screen, a pattern already used elsewhere in the codebase) before it grows further — consistent with this project's own "no monoliths" coding rule.
+
+### INFORMATIONAL — Test coverage is uneven, concentrated away from the UI layer
+
+```
+internal/sanitize        100.0%
+internal/ui/theme        100.0%
+internal/rtdb              86.4%
+internal/config            81.4%
+internal/ui/urlutil        80.0%
+internal/api                68.2%
+internal/ssh                68.8%
+internal/ui/markdown        73.4%
+internal/ui/imgview         76.4%
+internal/ui/screens         49.2%
+internal/ui (root)          21.0%
+cmd/cyber-tui                19.3%
+cmd/apifetch                  0.0%  (dev tool, not shipped)
+internal/model               no test files
+internal/ui/markdown/cmd      0.0%  (dev tool, not shipped)
+```
+
+Core logic packages (`sanitize`, `rtdb`, `config`, `api`) are well covered. `internal/ui` (root — the Bubble Tea message hub in `app.go`) and `internal/ui/screens` are lower, which is common for TUI update/view code but is also exactly the layer where the sanitization-bypass finding above lived undetected. Not a call to chase a coverage number, but worth adding targeted tests for wire-to-model sanitization coverage specifically (see the High finding's recommendation) rather than broad coverage growth.
+
+---
+
+## Automated Tooling Results
+
+All run fresh against commit `8835173` on 2026-07-24, Go `go1.26.4` (windows/amd64):
+
+| Tool | Result |
+|---|---|
+| `go build ./...` | ✅ Pass |
+| `go vet ./...` | ✅ Pass, no output |
+| `staticcheck ./...` | ✅ Pass, no output |
+| `go test ./... -cover` | ✅ All packages pass (see coverage table above) |
+| `govulncheck ./...` | ⚠️ 1 finding — GO-2026-5856, stdlib `crypto/tls`, see LOW finding above. Exit code 3 (vulnerabilities found in code paths actually called). 2 additional advisories noted for imported/required packages the code doesn't call into (not detailed here; re-run with `-show verbose` if a full accounting is needed). |
+
+CI (`.github/workflows/ci.yml`) already runs `go test`, `go vet`, and `staticcheck` on every PR to `dev`/`main`, and a `vulncheck` job runs `govulncheck`. These results should match CI's next run modulo the toolchain-version caveat noted in the govulncheck finding above.
+
+---
+
+## Actionable Recommendations
+
+| Priority | Area | Finding | Recommended Action | Effort |
+|---|---|---|---|---|
+| 1 | Security | Chat sanitize bypass (High) | Add `sanitize.Strings`/`sanitize.Strip` to the 5 identified chat message/conversation conversion sites and the render-layer username path | Small — mirrors existing pattern, ~1-2 hrs incl. tests |
+| 2 | Security | Unsanitized raw-bytes log line (Medium) | Sanitize or truncate `b`/`s` before `log.Printf` at `client.go:132,716` | Trivial |
+| 3 | Security | Redirect scheme-downgrade gap (Low) | Add `CheckRedirect` refusing `http` targets on `HTTPClient`'s `http.Client` | Small |
+| 4 | Dependencies | `crypto/tls` ECH CVE in active toolchain (Low) | Confirm CI's Go version; bump `toolchain` directive to a patched release | Trivial |
+| 5 | Docs | `imgview`/`markdown`/`urlutil` missing from project reference (Low) | Add Package Reference entries per Definition of Done | Small |
+| 6 | Code quality | `guilds.go` size (Low) | Evaluate splitting into per-concern files, matching patterns elsewhere in `screens/` | Medium |
+| 7 | Test coverage | Low coverage in `internal/ui`/`internal/ui/screens` (Informational) | Prioritize targeted sanitize-coverage tests over broad coverage growth | Small–Medium |
+| — | SSH mode | Unauthenticated by design (Low, unchanged) | No action required; consider a non-loopback opt-in flag if this mode sees more use | Small, optional |
+| — | Attachments | Possible SSRF via unrestricted `Src` (Informational) | Confirm server-side URL construction; add host allowlist if not server-controlled | Small, pending confirmation |

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ragnar/cyber-tui
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.26.5
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -129,7 +130,7 @@ func (t *apiTimestamp) UnmarshalJSON(b []byte) error {
 			return nil
 		}
 	}
-	log.Printf("api: apiTimestamp: unrecognized value, leaving empty: %s", b)
+	log.Printf("api: apiTimestamp: unrecognized value, leaving empty: %q", b)
 	*t = ""
 	return nil
 }
@@ -546,9 +547,28 @@ func (c *HTTPClient) applyRefresh(idToken, rtdbToken, rtdbUrl string) {
 // NewHTTPClient creates a production HTTPClient with a 15-second timeout.
 func NewHTTPClient(baseURL string) *HTTPClient {
 	return &HTTPClient{
-		baseURL:    baseURL,
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout:       15 * time.Second,
+			CheckRedirect: refuseInsecureRedirect,
+		},
 	}
+}
+
+// refuseInsecureRedirect stops the bearer-token-bearing Authorization header
+// from following a redirect to a non-https URL. validateBaseURL only checks
+// the configured apiBaseURL once at startup; without this, a same-host
+// scheme downgrade (https -> http) issued by the server itself would still
+// carry the token, since Go's default client only strips Authorization on a
+// cross-host redirect, not a same-host scheme change.
+func refuseInsecureRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("api: stopped after 10 redirects")
+	}
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("api: refusing redirect to non-https URL: %s", req.URL)
+	}
+	return nil
 }
 
 // NewHTTPClientForTesting creates an HTTPClient with a custom http.Client.
@@ -1482,6 +1502,7 @@ func (c *HTTPClient) GetRooms() ([]model.Room, error) {
 	}
 	out := make([]model.Room, len(wire))
 	for i, w := range wire {
+		sanitize.Strings(&w)
 		out[i] = model.Room{
 			ID:            w.ID,
 			Slug:          w.Slug,
@@ -1510,16 +1531,22 @@ func (c *HTTPClient) GetRoomMessages(roomID string, limit int, before int64) ([]
 	}
 	out := make([]model.Message, len(wire))
 	for i, w := range wire {
-		out[i] = model.Message{
-			ID:          w.ID,
-			From:        model.User{ID: w.UserID, Username: w.Username},
-			Body:        w.Content,
-			CreatedAt:   time.UnixMilli(w.Timestamp),
-			IsChatAdmin: w.IsChatAdmin,
-			IsAction:    w.IsAction,
-		}
+		out[i] = wireCircMessageToModel(w)
 	}
 	return out, nil
+}
+
+// wireCircMessageToModel converts a REST cIRC chatroom message to the model type.
+func wireCircMessageToModel(w wireCircMessage) model.Message {
+	sanitize.Strings(&w)
+	return model.Message{
+		ID:          w.ID,
+		From:        model.User{ID: w.UserID, Username: w.Username},
+		Body:        w.Content,
+		CreatedAt:   time.UnixMilli(w.Timestamp),
+		IsChatAdmin: w.IsChatAdmin,
+		IsAction:    w.IsAction,
+	}
 }
 
 // SendRoomMessage sends a message to a chatroom via POST /v1/circ/:roomId.
@@ -1610,6 +1637,7 @@ func (c *HTTPClient) rtdbOrErr() (*rtdb.Client, error) {
 
 // wireRTDBMessageToModel converts a Firebase DM message to the model type.
 func wireRTDBMessageToModel(id string, wm wireRTDBMessage) model.Message {
+	sanitize.Strings(&wm)
 	return model.Message{
 		ID:        id,
 		From:      model.User{ID: wm.SenderID, Username: wm.SenderUsername},
@@ -1621,6 +1649,7 @@ func wireRTDBMessageToModel(id string, wm wireRTDBMessage) model.Message {
 
 // wireRTDBCircMessageToModel converts a Firebase CIRC chatroom message to the model type.
 func wireRTDBCircMessageToModel(id string, wm wireRTDBCircMessage) model.Message {
+	sanitize.Strings(&wm)
 	return model.Message{
 		ID:          id,
 		From:        model.User{ID: wm.UserID, Username: wm.Username},
@@ -1644,6 +1673,7 @@ func (c *HTTPClient) GetConversations() ([]model.Conversation, error) {
 	}
 	out := make([]model.Conversation, len(wire))
 	for i, w := range wire {
+		sanitize.Strings(&w)
 		out[i] = model.Conversation{
 			ID:            w.ConversationID,
 			Participants:  []model.User{{ID: w.OtherUser.UserID, Username: w.OtherUser.Username}},
@@ -1672,15 +1702,21 @@ func (c *HTTPClient) GetMessages(conversationID string, limit int, before int64)
 	}
 	out := make([]model.Message, len(wire))
 	for i, w := range wire {
-		out[i] = model.Message{
-			ID:        w.ID,
-			From:      model.User{ID: w.SenderID, Username: w.SenderUsername},
-			Body:      w.Content,
-			CreatedAt: time.UnixMilli(w.Timestamp),
-			IsAction:  w.IsAction,
-		}
+		out[i] = wireCMailMessageToModel(w)
 	}
 	return out, nil
+}
+
+// wireCMailMessageToModel converts a REST C-Mail message to the model type.
+func wireCMailMessageToModel(w wireCMailMessage) model.Message {
+	sanitize.Strings(&w)
+	return model.Message{
+		ID:        w.ID,
+		From:      model.User{ID: w.SenderID, Username: w.SenderUsername},
+		Body:      w.Content,
+		CreatedAt: time.UnixMilli(w.Timestamp),
+		IsAction:  w.IsAction,
+	}
 }
 
 // SendMessage sends a C-Mail message via POST /v1/cmail/:id. Returns the

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -151,6 +151,29 @@ func TestHTTPLogin_BadCredentials(t *testing.T) {
 	}
 }
 
+// TestHTTPClient_RefusesInsecureRedirect guards against a regression of the
+// 2026-07-24 review's redirect-scheme-downgrade finding: NewHTTPClient must
+// refuse to follow a redirect to a non-https URL, so a compromised or
+// misconfigured API host can't strip the bearer token down to cleartext via
+// a same-host scheme downgrade. Uses api.NewHTTPClient directly (not the
+// newClient test helper, which injects a raw *http.Client via
+// NewHTTPClientForTesting and bypasses the CheckRedirect wiring under test).
+func TestHTTPClient_RefusesInsecureRedirect(t *testing.T) {
+	redirectSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://example-should-not-be-followed.invalid/v1/feed", http.StatusFound)
+	}))
+	defer redirectSrv.Close()
+
+	c := api.NewHTTPClient(redirectSrv.URL)
+	_, _, err := c.GetFeed("")
+	if err == nil {
+		t.Fatal("expected error refusing insecure redirect, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing redirect") {
+		t.Errorf("error = %v, want it to mention refusing redirect", err)
+	}
+}
+
 func TestHTTPGetFeed_ParsesPosts(t *testing.T) {
 	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeOK(t, w, []map[string]any{
@@ -659,6 +682,39 @@ func TestHTTPSubscribeDMs_SkipsSnapshotDeliversMessages(t *testing.T) {
 	}
 }
 
+// TestHTTPSubscribeDMs_SanitizesControlChars guards against a regression of
+// the sanitize-bypass finding in the 2026-07-24 security review: live DM
+// messages arriving over RTDB SSE must have control characters stripped from
+// sender username and body, just like every REST-sourced field.
+func TestHTTPSubscribeDMs_SanitizesControlChars(t *testing.T) {
+	c, _ := newClientWithRTDB(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeSSEEvent(w, "put", `{"path":"/msg1","data":{"senderId":"u2","senderUsername":"evil\u001b[31m","content":"hi\u001b[0m","timestamp":1700000001000}}`)
+	}))
+
+	ch, cancel, err := c.SubscribeDMs(context.Background(), "conv1")
+	if err != nil {
+		t.Fatalf("SubscribeDMs error: %v", err)
+	}
+	defer cancel()
+
+	select {
+	case msg, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before delivering message")
+		}
+		if strings.ContainsRune(msg.From.Username, 0x1b) {
+			t.Errorf("msg.From.Username contains unstripped ESC: %q", msg.From.Username)
+		}
+		if strings.ContainsRune(msg.Body, 0x1b) {
+			t.Errorf("msg.Body contains unstripped ESC: %q", msg.Body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
 // TestHTTPSubscribeDMs_CancelClosesChannel verifies that calling cancel stops the stream.
 func TestHTTPSubscribeDMs_CancelClosesChannel(t *testing.T) {
 	c, _ := newClientWithRTDB(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -743,6 +799,37 @@ func TestHTTPSubscribeRoom_AuthRevokedClosesChannel(t *testing.T) {
 	}
 }
 
+// TestHTTPSubscribeRoom_SanitizesControlChars mirrors
+// TestHTTPSubscribeDMs_SanitizesControlChars for cIRC rooms.
+func TestHTTPSubscribeRoom_SanitizesControlChars(t *testing.T) {
+	c, _ := newClientWithRTDB(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeSSEEvent(w, "put", `{"path":"/msg1","data":{"userId":"u2","username":"evil\u001b[31m","content":"hi\u001b[0m","timestamp":1700000001000}}`)
+	}))
+
+	ch, cancel, err := c.SubscribeRoom(context.Background(), "zion")
+	if err != nil {
+		t.Fatalf("SubscribeRoom error: %v", err)
+	}
+	defer cancel()
+
+	select {
+	case msg, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before delivering message")
+		}
+		if strings.ContainsRune(msg.From.Username, 0x1b) {
+			t.Errorf("msg.From.Username contains unstripped ESC: %q", msg.From.Username)
+		}
+		if strings.ContainsRune(msg.Body, 0x1b) {
+			t.Errorf("msg.Body contains unstripped ESC: %q", msg.Body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
 // --- C-Mail REST tests ---
 
 func TestHTTPGetConversations_ParsesList(t *testing.T) {
@@ -779,6 +866,53 @@ func TestHTTPGetConversations_ParsesList(t *testing.T) {
 	}
 	if convs[0].LastMessage != "we need to talk" {
 		t.Errorf("LastMessage = %q, want 'we need to talk'", convs[0].LastMessage)
+	}
+}
+
+// TestHTTPGetConversations_SanitizesControlChars guards against a regression
+// of the 2026-07-24 review's sanitize-bypass finding for the C-Mail
+// conversation list (other-user username and last-message preview).
+func TestHTTPGetConversations_SanitizesControlChars(t *testing.T) {
+	c := newClient(t, authHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, []map[string]any{
+			{
+				"conversationId": "c1",
+				"otherUser":      map[string]any{"userId": "u2", "username": "evil\u001b[31m"},
+				"lastMessage":    "hi\u001b[0m",
+				"lastMessageAt":  1700000000000,
+				"unreadCount":    0,
+			},
+		})
+	})))
+	c.LoginWithRefreshToken("tok")
+	convs, err := c.GetConversations()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.ContainsRune(convs[0].Participants[0].Username, 0x1b) {
+		t.Errorf("Participants[0].Username contains unstripped ESC: %q", convs[0].Participants[0].Username)
+	}
+	if strings.ContainsRune(convs[0].LastMessage, 0x1b) {
+		t.Errorf("LastMessage contains unstripped ESC: %q", convs[0].LastMessage)
+	}
+}
+
+// TestHTTPGetRooms_SanitizesControlChars guards against the same sanitize-bypass
+// class the 2026-07-24 review found in chat messages, applied here to room
+// name/slug — GetRooms was found missing sanitize.Strings during the fix.
+func TestHTTPGetRooms_SanitizesControlChars(t *testing.T) {
+	c := newClient(t, authHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, []map[string]any{
+			{"id": "r1", "slug": "general", "name": "evil\u001b[31m", "lastMessageAt": 1700000000000, "sortOrder": 0},
+		})
+	})))
+	c.LoginWithRefreshToken("tok")
+	rooms, err := c.GetRooms()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.ContainsRune(rooms[0].Name, 0x1b) {
+		t.Errorf("Name contains unstripped ESC: %q", rooms[0].Name)
 	}
 }
 
@@ -847,6 +981,27 @@ func TestHTTPGetRoomMessages_ParsesIsAction(t *testing.T) {
 	}
 }
 
+// TestHTTPGetRoomMessages_SanitizesControlChars guards against a regression
+// of the 2026-07-24 review's sanitize-bypass finding for cIRC room history.
+func TestHTTPGetRoomMessages_SanitizesControlChars(t *testing.T) {
+	c := newClient(t, authHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, []map[string]any{
+			{"id": "m1", "userId": "u1", "username": "evil\u001b[31m", "content": "hi\u001b[0m", "timestamp": 1700000001000},
+		})
+	})))
+	c.LoginWithRefreshToken("tok")
+	msgs, err := c.GetRoomMessages("general", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.ContainsRune(msgs[0].From.Username, 0x1b) {
+		t.Errorf("From.Username contains unstripped ESC: %q", msgs[0].From.Username)
+	}
+	if strings.ContainsRune(msgs[0].Body, 0x1b) {
+		t.Errorf("Body contains unstripped ESC: %q", msgs[0].Body)
+	}
+}
+
 func TestHTTPGetMessages_ParsesMessages(t *testing.T) {
 	c := newClient(t, authHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/cmail/c1" || r.Method != http.MethodGet {
@@ -873,6 +1028,27 @@ func TestHTTPGetMessages_ParsesMessages(t *testing.T) {
 	}
 	if msgs[1].ID != "m2" || msgs[1].From.Username != "molly_millions" {
 		t.Errorf("msgs[1] mismatch: %+v", msgs[1])
+	}
+}
+
+// TestHTTPGetMessages_SanitizesControlChars guards against a regression of
+// the 2026-07-24 review's sanitize-bypass finding for C-Mail history.
+func TestHTTPGetMessages_SanitizesControlChars(t *testing.T) {
+	c := newClient(t, authHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, []map[string]any{
+			{"id": "m1", "senderId": "u1", "senderUsername": "evil\u001b[31m", "content": "hi\u001b[0m", "timestamp": 1700000001000},
+		})
+	})))
+	c.LoginWithRefreshToken("tok")
+	msgs, err := c.GetMessages("c1", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.ContainsRune(msgs[0].From.Username, 0x1b) {
+		t.Errorf("From.Username contains unstripped ESC: %q", msgs[0].From.Username)
+	}
+	if strings.ContainsRune(msgs[0].Body, 0x1b) {
+		t.Errorf("Body contains unstripped ESC: %q", msgs[0].Body)
 	}
 }
 

--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -49,6 +49,12 @@ type Config struct {
 	SSHListenAddr string `json:"sshListenAddr,omitempty"`
 	// SSHHostKeyPath is the path to the SSH host key file (default: ./ssh_host_key).
 	SSHHostKeyPath string `json:"sshHostKeyPath,omitempty"`
+	// AllowRemoteSSH permits sshListenAddr to bind a non-loopback address.
+	// SSH server mode performs no authentication, so binding beyond loopback
+	// exposes a full unauthenticated session to anyone who can reach it.
+	// Off by default so a non-loopback sshListenAddr requires two deliberate
+	// config choices instead of one.
+	AllowRemoteSSH bool `json:"allowRemoteSsh,omitempty"`
 
 	// WanderLust controls the wander mode easter egg, which silently updates
 	// the profile location to a random position twice per day.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ragnar/cyber-tui/internal/api"
 	"github.com/ragnar/cyber-tui/internal/config"
 	"github.com/ragnar/cyber-tui/internal/model"
+	"github.com/ragnar/cyber-tui/internal/sanitize"
 	"github.com/ragnar/cyber-tui/internal/ui/imgview"
 	"github.com/ragnar/cyber-tui/internal/ui/screens"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
@@ -759,7 +760,7 @@ func (a App) handleChatrooms(msg tea.Msg) (App, tea.Cmd, bool) {
 		a, cmd := a.notify(notifyInfo, "reconnected to live chat")
 		return a, cmd, true
 	case roomCommandReplyMsg:
-		a.chatrooms = a.chatrooms.AppendSystemMessage(msg.roomID, msg.reply)
+		a.chatrooms = a.chatrooms.AppendSystemMessage(msg.roomID, sanitize.Strip(msg.reply))
 		return a, nil, true
 	}
 	return a, nil, false
@@ -795,7 +796,7 @@ func (a App) handleCMail(msg tea.Msg) (App, tea.Cmd, bool) {
 		a, cmd := a.notify(notifyInfo, "reconnected to live chat")
 		return a, cmd, true
 	case cmailCommandReplyMsg:
-		a.cmail = a.cmail.AppendSystemMessage(msg.convID, msg.reply)
+		a.cmail = a.cmail.AppendSystemMessage(msg.convID, sanitize.Strip(msg.reply))
 		return a, nil, true
 	}
 	return a, nil, false

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/ragnar/cyber-tui/internal/model"
+	"github.com/ragnar/cyber-tui/internal/sanitize"
 	"github.com/ragnar/cyber-tui/internal/ui/markdown"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
@@ -253,6 +254,7 @@ func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFor
 // in the third person. The API returns IsAction messages with Body already
 // stripped of the username (just the action text), so it's assembled here.
 func renderActionLine(username, body, ts string, viewportWidth int) string {
+	username = sanitize.Strip(username)
 	const suffix = " *"
 	tsWidth := lipgloss.Width(ts)
 	const tsGap = 2
@@ -338,12 +340,13 @@ func renderChatMessages(msgs []model.Message, currentUser string, loc *time.Loca
 			continue
 		}
 		isMe := currentUser != "" && msg.From.Username == currentUser
+		username := sanitize.Strip(msg.From.Username)
 
 		var header string
 		if isMe {
-			header = theme.Subtle.Render(ts) + "  " + theme.Highlight.Render("@"+msg.From.Username)
+			header = theme.Subtle.Render(ts) + "  " + theme.Highlight.Render("@"+username)
 		} else {
-			header = theme.Highlight.Render("@"+msg.From.Username) + "  " + theme.Subtle.Render(ts)
+			header = theme.Highlight.Render("@"+username) + "  " + theme.Subtle.Render(ts)
 		}
 
 		// Natural inner width: widest of the header and each raw body line, capped at max.


### PR DESCRIPTION
## Summary
- Adds the 2026-07-24 code & security review report (`docs/reviews/2026-07-24-code-security-review.md`), tracked so future reviews can be diffed against it.
- Fixes all Security findings from that review:
  - **High**: chat messages (C-Mail DMs, cIRC rooms, room listings) bypassed the `sanitize.Strings` API-boundary control on 6 conversion paths in `internal/api/client.go` (5 from the report + `GetRooms`, found while fixing the others). Added render-layer defense in depth for usernames (`internal/ui/screens/render.go`) and system-reply text (`internal/ui/app.go`).
  - **Medium**: `apiTimestamp.UnmarshalJSON`'s fallback log line now quotes (`%q`) raw server bytes instead of logging them raw.
  - **Low**: `NewHTTPClient` now refuses to follow a redirect to a non-https URL, closing a same-host HTTPS→HTTP downgrade gap `validateBaseURL` didn't cover.
  - **Low**: Go toolchain bumped to `go1.26.5`, clearing `govulncheck` finding GO-2026-5856 (crypto/tls ECH privacy leak).
  - **Low**: SSH server mode now requires a new `allowRemoteSsh` opt-in (mirroring `allowInsecureApi`) before `sshListenAddr` can bind a non-loopback address.
- `docs/30-security-hardening.md` and `docs/00-project-reference.md` updated to document the fixes and the new `allowRemoteSsh` config field.

Code Quality findings from the report (doc drift beyond this PR's scope, `guilds.go` size, broad coverage growth) are intentionally out of scope — separate follow-up.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -cover` (8 new tests: 6 sanitize-coverage regressions across REST + RTDB SSE paths, 1 redirect-refusal test, 1 `validateSSHAddr` table test)
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] `govulncheck ./...` (confirmed GO-2026-5856 no longer present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)