### PR TITLE
fix: clamp image display height to the terminal viewport

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1907,6 +1907,10 @@ func openExternalURL(u string) tea.Cmd {
 func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 	proto := a.graphicsProtocol
 	displayCols := a.width * 4 / 5
+	displayRows := a.height*4/5 - 2 // reserve 2 rows for the modal border
+	if displayRows < 1 {
+		displayRows = 1
+	}
 	return a, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
@@ -1916,10 +1920,10 @@ func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 		}
 		switch proto {
 		case imgview.ProtocolKitty:
-			encoded, cols, rows := imgview.EncodeKitty(img, displayCols)
+			encoded, cols, rows := imgview.EncodeKitty(img, displayCols, displayRows)
 			return imageFetchedMsg{rawURL: rawURL, encoded: encoded, cols: cols, rows: rows}
 		case imgview.ProtocolITerm2:
-			encoded, cols, rows, err := imgview.EncodeITerm2(img, displayCols)
+			encoded, cols, rows, err := imgview.EncodeITerm2(img, displayCols, displayRows)
 			return imageFetchedMsg{rawURL: rawURL, encoded: encoded, cols: cols, rows: rows, err: err}
 		default:
 			return imageFetchedMsg{rawURL: rawURL, err: fmt.Errorf("no graphics protocol")}

--- a/internal/ui/imgview/encode_test.go
+++ b/internal/ui/imgview/encode_test.go
@@ -12,7 +12,7 @@ import (
 func TestEncodeKitty_ContainsAPC(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{R: 255, A: 255})
-	seq, cols, rows := imgview.EncodeKitty(img, 40)
+	seq, cols, rows := imgview.EncodeKitty(img, 40, 20)
 	if !strings.HasPrefix(seq, "\x1b_G") {
 		t.Errorf("EncodeKitty: missing APC prefix, got %q", seq[:min(len(seq), 20)])
 	}
@@ -27,10 +27,22 @@ func TestEncodeKitty_ContainsAPC(t *testing.T) {
 	}
 }
 
+func TestEncodeKitty_CapsRows(t *testing.T) {
+	// Tall portrait image: without a row cap this would need 50 rows at 10 cols.
+	img := image.NewRGBA(image.Rect(0, 0, 100, 1000))
+	_, cols, rows := imgview.EncodeKitty(img, 40, 20)
+	if rows > 20 {
+		t.Errorf("EncodeKitty: rows=%d, want <= maxRows(20)", rows)
+	}
+	if cols < 1 || cols > 40 {
+		t.Errorf("EncodeKitty: cols=%d, want in [1, maxCols(40)]", cols)
+	}
+}
+
 func TestEncodeITerm2_ContainsOSC(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{G: 255, A: 255})
-	seq, cols, rows, err := imgview.EncodeITerm2(img, 80)
+	seq, cols, rows, err := imgview.EncodeITerm2(img, 80, 40)
 	if err != nil {
 		t.Fatalf("EncodeITerm2: %v", err)
 	}

--- a/internal/ui/imgview/iterm2.go
+++ b/internal/ui/imgview/iterm2.go
@@ -9,10 +9,11 @@ import (
 )
 
 // EncodeITerm2 encodes img for display via the iTerm2 inline image protocol,
-// which is also supported by WezTerm. maxCols is the maximum terminal column
-// width; the image is never upscaled beyond its natural pixel size. Returns the
-// OSC escape sequence and the computed display size in terminal columns and rows.
-func EncodeITerm2(img image.Image, maxCols int) (encoded string, cols, rows int, err error) {
+// which is also supported by WezTerm. maxCols/maxRows bound the terminal
+// display size; the image is never upscaled beyond its natural pixel size.
+// Returns the OSC escape sequence and the computed display size in terminal
+// columns and rows.
+func EncodeITerm2(img image.Image, maxCols, maxRows int) (encoded string, cols, rows int, err error) {
 	bounds := img.Bounds()
 	w := bounds.Max.X - bounds.Min.X
 	h := bounds.Max.Y - bounds.Min.Y
@@ -22,8 +23,7 @@ func EncodeITerm2(img image.Image, maxCols int) (encoded string, cols, rows int,
 		return "", 0, 0, fmt.Errorf("imgview: png encode: %w", encErr)
 	}
 	payload := base64.StdEncoding.EncodeToString(buf.Bytes())
-	cols = fitCols(w, maxCols)
-	rows = fitRows(h, w, cols)
+	cols, rows = fitBox(w, h, maxCols, maxRows)
 	// width/height without suffix means terminal character cells in iTerm2.
 	encoded = fmt.Sprintf(
 		"\x1b]1337;File=inline=1;width=%d;height=%d;preserveAspectRatio=1:%s\x07",

--- a/internal/ui/imgview/kitty.go
+++ b/internal/ui/imgview/kitty.go
@@ -7,10 +7,10 @@ import (
 )
 
 // EncodeKitty encodes img for display via the Kitty terminal graphics protocol.
-// maxCols is the maximum terminal column width; the image is never upscaled
-// beyond its natural pixel size. Returns the APC escape sequence and the
-// computed display size in terminal columns and rows.
-func EncodeKitty(img image.Image, maxCols int) (encoded string, cols, rows int) {
+// maxCols/maxRows bound the terminal display size; the image is never
+// upscaled beyond its natural pixel size. Returns the APC escape sequence and
+// the computed display size in terminal columns and rows.
+func EncodeKitty(img image.Image, maxCols, maxRows int) (encoded string, cols, rows int) {
 	bounds := img.Bounds()
 	w := bounds.Max.X - bounds.Min.X
 	h := bounds.Max.Y - bounds.Min.Y
@@ -30,8 +30,7 @@ func EncodeKitty(img image.Image, maxCols int) (encoded string, cols, rows int) 
 	}
 
 	payload := base64.StdEncoding.EncodeToString(raw)
-	cols = fitCols(w, maxCols)
-	rows = fitRows(h, w, cols)
+	cols, rows = fitBox(w, h, maxCols, maxRows)
 	// a=T: transmit and display. f=32: 32-bit RGBA. s/v: pixel dimensions.
 	// c/r: display size in terminal columns/rows (Kitty scales to fit, preserving aspect ratio).
 	// m=0: final chunk.

--- a/internal/ui/imgview/scale.go
+++ b/internal/ui/imgview/scale.go
@@ -33,3 +33,23 @@ func fitRows(imgHeight, imgWidth, cols int) int {
 	}
 	return rows
 }
+
+// fitBox computes the terminal cols/rows to display an image of imgWidth x
+// imgHeight pixels within a maxCols x maxRows box, preserving aspect ratio
+// and never upscaling. If fitting to maxCols would make rows exceed maxRows,
+// cols is recomputed from the row constraint instead so both bounds hold.
+func fitBox(imgWidth, imgHeight, maxCols, maxRows int) (cols, rows int) {
+	cols = fitCols(imgWidth, maxCols)
+	rows = fitRows(imgHeight, imgWidth, cols)
+	if maxRows > 0 && rows > maxRows && imgHeight > 0 {
+		rows = maxRows
+		cols = 2 * rows * imgWidth / imgHeight
+		if cols < 1 {
+			cols = 1
+		}
+		if maxCols > 0 && cols > maxCols {
+			cols = maxCols
+		}
+	}
+	return cols, rows
+}


### PR DESCRIPTION
## Summary
- Reported: opening a large/tall image in the in-terminal viewer showed no visible border and ran off the bottom of the screen.
- `fitRows` derived the image's terminal row count purely from aspect ratio, with no bound against the terminal's actual height (unlike `fitCols`, which was already capped against width). A tall image could produce a modal taller than the viewport; `overlayCenter` then silently dropped lines past the terminal height (losing the border), and the raw image escape sequence was positioned past the visible area.
- Added `fitBox` (`internal/ui/imgview/scale.go`) to fit an image within both a max-column and max-row bound, preserving aspect ratio, and threaded a height-derived `maxRows` through `EncodeKitty`/`EncodeITerm2` alongside the existing width bound (`internal/ui/app.go`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Added `TestEncodeKitty_CapsRows` covering a tall portrait image
- [x] Manual: open a large/tall image URL in a Kitty/iTerm2 terminal and confirm the border stays visible and the image fits within the viewport, including at a small terminal height