### PR TITLE
fix: stop losing the Kitty image cleanup on large/slow images

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -191,7 +191,7 @@ type App struct {
 	imageModalEncoded  string
 	imageModalCols     int
 	imageModalRows     int
-	imageNeedsCleanup  bool // true for one frame after modal closes, to delete Kitty placement
+	imageNeedsCleanup  bool // true after modal closes until a delete-placement frame reaches the terminal
 
 	// ephemeral marks an SSH-hosted session whose state must never be read from
 	// or written to the host operator's config file.
@@ -342,12 +342,6 @@ func (a App) Init() tea.Cmd {
 // handled first and always falls through to delegateUpdate so the active
 // screen can also react to it.
 func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// imageNeedsCleanup is a one-render-cycle flag: it is set true by the
-	// keypress that closes the modal and cleared here at the very start of the
-	// next Update call. This guarantees the cleanup frame is rendered before
-	// the flag is cleared, with no goroutine race.
-	a.imageNeedsCleanup = false
-
 	if m, ok := msg.(tea.WindowSizeMsg); ok {
 		a = a.applyWindowSize(m)
 		contentMsg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(m.Width), Height: a.layout.ContentHeight(m.Height)}
@@ -1943,6 +1937,7 @@ func (a App) handleImageViewer(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.imageModalCols = m.cols
 		a.imageModalRows = m.rows
 		a.imageModalOpen = true
+		a.imageNeedsCleanup = false
 		return a, nil, true
 	}
 	return a, nil, false

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/ragnar/cyber-tui/internal/api"
 	"github.com/ragnar/cyber-tui/internal/model"
+	"github.com/ragnar/cyber-tui/internal/ui/imgview"
 	"github.com/ragnar/cyber-tui/internal/ui/screens"
 )
 
@@ -1173,5 +1174,98 @@ func TestHandleChatrooms_NormalTabEntry_EscStillDropsToList(t *testing.T) {
 	}
 	if escCmd != nil {
 		t.Error("expected no LeaveChatroomsMsg when the room wasn't reached via a deep link")
+	}
+}
+
+// --- Kitty image-modal cleanup survives a fast follow-up keystroke ---
+//
+// Reported behavior: typing while an image loads could leave the Kitty image
+// placement stuck on screen forever, needing a full TUI restart to clear.
+// Root cause: the delete-placement escape was injected into exactly one
+// View() frame, and the very next Update() call unconditionally cleared
+// imageNeedsCleanup regardless of whether the renderer's independent flush
+// ticker had actually sent that frame to the terminal yet. A first fix used a
+// fixed delay before clearing the flag, but Bubble Tea's write()/flush() share
+// a mutex and flush() blocks on the OS write for as long as the terminal takes
+// to drain it — for a large image that can exceed any fixed delay, so the
+// fixed-delay fix still lost the race for big/slow images. imageNeedsCleanup
+// now simply isn't auto-cleared at all: it stays true (re-injecting the
+// delete-placement escape into every closed-state frame) until a new Kitty
+// image is opened, so however long the renderer's backlog takes to drain,
+// the pending cleanup frame is still there once it does.
+
+func TestUpdate_ImageModalClose_Kitty_SetsCleanupFlag(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.imageModalOpen = true
+
+	m, cmd := a.Update(keyMsg("x"))
+	a2 := m.(App)
+	if a2.imageModalOpen {
+		t.Error("expected the keypress to close the modal")
+	}
+	if !a2.imageNeedsCleanup {
+		t.Error("expected imageNeedsCleanup to be set for the Kitty protocol")
+	}
+	if cmd != nil {
+		t.Error("expected no cmd from closing the modal")
+	}
+}
+
+func TestUpdate_ImageModalClose_ITerm2_NoCleanupFlag(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolITerm2
+	a.imageModalOpen = true
+
+	m, cmd := a.Update(keyMsg("x"))
+	a2 := m.(App)
+	if a2.imageModalOpen {
+		t.Error("expected the keypress to close the modal")
+	}
+	if a2.imageNeedsCleanup {
+		t.Error("iTerm2 has no placement to clean up, expected imageNeedsCleanup to stay false")
+	}
+	if cmd != nil {
+		t.Error("expected no cmd scheduled for iTerm2")
+	}
+}
+
+func TestUpdate_ImageNeedsCleanup_NotAutoCleared(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.imageModalOpen = true
+
+	m, _ := a.Update(keyMsg("x"))
+	a2 := m.(App)
+	if !a2.imageNeedsCleanup {
+		t.Fatal("setup: expected imageNeedsCleanup to be set after close")
+	}
+
+	// Several unrelated Update cycles (e.g. more typing while the renderer's
+	// flush is still backed up on a large image) must not clear the flag —
+	// only actually opening a new image should.
+	for i := 0; i < 5; i++ {
+		m2, _ := a2.Update(keyMsg("y"))
+		a2 = m2.(App)
+	}
+	if !a2.imageNeedsCleanup {
+		t.Error("expected imageNeedsCleanup to survive unrelated Update calls until a new image opens")
+	}
+}
+
+func TestHandleImageViewer_NewImage_ClearsCleanupFlag(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.imageNeedsCleanup = true
+
+	a2, _, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://example.com/x.jpg", encoded: "seq", cols: 10, rows: 5})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled")
+	}
+	if !a2.imageModalOpen {
+		t.Error("expected the new image to open the modal")
+	}
+	if a2.imageNeedsCleanup {
+		t.Error("expected opening a new image to clear any pending cleanup flag")
 	}
 }

--- a/internal/ui/imgview/encode_test.go
+++ b/internal/ui/imgview/encode_test.go
@@ -39,6 +39,25 @@ func TestEncodeKitty_CapsRows(t *testing.T) {
 	}
 }
 
+func TestEncodeKitty_PrependsDeleteAllPlacements(t *testing.T) {
+	// EncodeKitty always leads with a delete-all-placements command so
+	// opening a new image self-heals a leftover placement from a previous
+	// image whose own close-cleanup frame never reached the terminal (e.g.
+	// dropped behind a slow flush of a large prior image).
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	seq, _, _ := imgview.EncodeKitty(img, 40, 20)
+	if !strings.HasPrefix(seq, "\x1b_Ga=d,d=A\x1b\\") {
+		t.Errorf("EncodeKitty: expected delete-all-placements prefix, got %q", seq[:min(len(seq), 30)])
+	}
+
+	// Back-to-back calls (as would happen opening several images in a row)
+	// must each still lead with the delete-all command.
+	seq2, _, _ := imgview.EncodeKitty(img, 40, 20)
+	if !strings.HasPrefix(seq2, "\x1b_Ga=d,d=A\x1b\\") {
+		t.Errorf("EncodeKitty: expected delete-all-placements prefix on repeated call, got %q", seq2[:min(len(seq2), 30)])
+	}
+}
+
 func TestEncodeITerm2_ContainsOSC(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{G: 255, A: 255})

--- a/internal/ui/imgview/kitty.go
+++ b/internal/ui/imgview/kitty.go
@@ -34,6 +34,11 @@ func EncodeKitty(img image.Image, maxCols, maxRows int) (encoded string, cols, r
 	// a=T: transmit and display. f=32: 32-bit RGBA. s/v: pixel dimensions.
 	// c/r: display size in terminal columns/rows (Kitty scales to fit, preserving aspect ratio).
 	// m=0: final chunk.
-	encoded = fmt.Sprintf("\x1b_Ga=T,f=32,s=%d,v=%d,c=%d,r=%d,m=0;%s\x1b\\", w, h, cols, rows, payload)
+	//
+	// Prefixed with a=d,d=A (delete all placements): a no-op if nothing is
+	// currently displayed, but self-heals a leftover placement from a
+	// previous image whose own close-cleanup frame never reached the
+	// terminal (e.g. dropped behind a slow flush of a large prior image).
+	encoded = fmt.Sprintf("\x1b_Ga=d,d=A\x1b\\\x1b_Ga=T,f=32,s=%d,v=%d,c=%d,r=%d,m=0;%s\x1b\\", w, h, cols, rows, payload)
 	return
 }


### PR DESCRIPTION
## Summary
- Reported: typing while a large image was loading could leave the image permanently stuck on screen (a Kitty graphics placement), with no in-app way to dismiss it — only a full TUI restart cleared it. The rest of the app remained responsive; only the image itself never went away.
- Root cause: `imageNeedsCleanup` was set true by the keypress that closes the modal, and the delete-placement escape was injected into exactly the *next* rendered frame — but that flag was then unconditionally cleared on the very next `Update()` call, regardless of whether Bubble Tea's independent render ticker had actually flushed that frame to the terminal yet. A fast follow-up keystroke (or, for a large image, the renderer still being busy draining the huge image payload — `write()`/`flush()` share a mutex, and `flush()` blocks on the OS write for as long as the terminal takes to drain it) could overwrite the buffered cleanup frame before it was ever sent. A first attempt used a fixed delay before clearing the flag, but no fixed delay is safe against an arbitrarily large, terminal-dependent transmission time — confirmed by live testing, which showed it fixed small/fast images but not large/slow ones (https://latex.gg/share/aNGbxQ10.jpg).
- Fix: `imageNeedsCleanup` no longer auto-clears at all. It stays true — re-injecting the delete-placement escape into every closed-state frame — until a new Kitty image is actually opened, so however long the renderer's backlog takes to drain, the pending cleanup frame is still there once it does. `EncodeKitty` also now unconditionally prepends a delete-all-placements command to its own transmit sequence (harmless no-op if nothing's displayed), so opening a new image self-heals any leftover placement regardless of whether a previous image's own close-cleanup ever reached the terminal.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New/updated tests: cleanup flag set on Kitty close with no scheduled cmd, unset for iTerm2, survives repeated unrelated `Update` calls, cleared when a new image opens; `EncodeKitty` always leads with the delete-all prefix
- [x] Manual: reproduced and confirmed fixed with the large repro image in a real Kitty terminal