### PR TITLE
feat: image carousel in the URL picker, cached across cycles

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"image"
 	"math"
 	"math/rand"
 	neturl "net/url"
@@ -122,6 +123,17 @@ type App struct {
 	urlPickerItems  []string
 	urlPickerCursor int
 
+	// imageCarousel state — populated when an image is opened from a picker
+	// containing more than one image, letting left/right cycle between them
+	// without closing the image modal. Nil imageCarouselItems means a plain
+	// single-image view (existing behavior, arrows never shown).
+	imageCarouselItems []string
+	imageCarouselIndex int
+	// imageCache holds decoded images already fetched during the current
+	// modal's lifetime, keyed by URL, so cycling back to one skips the
+	// network fetch. Cleared whenever the modal closes.
+	imageCache map[string]image.Image
+
 	// timezone is the active UTC offset label (e.g. "UTC+2"). Empty = UTC.
 	// loc is the parsed *time.Location derived from timezone.
 	timezone string
@@ -192,6 +204,7 @@ type App struct {
 	imageModalCols     int
 	imageModalRows     int
 	imageNeedsCleanup  bool // true after modal closes until a delete-placement frame reaches the terminal
+	imageFetchGen      int  // bumped on every fetch and on close; stale imageFetchedMsg results are dropped
 
 	// ephemeral marks an SSH-hosted session whose state must never be read from
 	// or written to the host operator's config file.
@@ -354,11 +367,24 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.notifyText = ""
 		a.notifyGen++
 	}
-	// Any keypress closes the image modal. Consume the key so it doesn't
+	// Left/right cycle through a picker-opened image carousel without closing
+	// the modal. Any other keypress closes it — consume the key so it doesn't
 	// accidentally trigger another action while the modal is visible.
-	if _, ok := msg.(tea.KeyMsg); ok && a.imageModalOpen {
+	if km, ok := msg.(tea.KeyMsg); ok && a.imageModalOpen {
+		if len(a.imageCarouselItems) > 1 {
+			switch km.String() {
+			case "left":
+				return a.cycleImageCarousel(-1)
+			case "right":
+				return a.cycleImageCarousel(+1)
+			}
+		}
 		a.imageModalOpen = false
 		a.imageNeedsCleanup = (a.graphicsProtocol == imgview.ProtocolKitty)
+		a.imageCarouselItems = nil
+		a.imageCarouselIndex = 0
+		a.imageFetchGen++ // invalidate anything still in flight
+		a.imageCache = nil
 		return a, nil
 	}
 	if a2, cmd, ok := a.handleKeys(msg); ok {
@@ -1880,12 +1906,23 @@ func (a App) routeURL(rawURL string) (App, tea.Cmd) {
 	if a.ephemeral {
 		return a.notify(notifyInfo, "Opening links is disabled in SSH sessions")
 	}
-	if urlutil.IsImageURL(rawURL) &&
-		a.graphicsProtocol != imgview.ProtocolNone &&
-		a.imageViewer != "browser" {
+	if a.canRenderImageInline(rawURL) {
 		return a.openImageInTerminal(rawURL)
 	}
 	return a, openExternalURL(rawURL)
+}
+
+// canRenderImageInline reports whether u should be displayed in the inline
+// terminal image viewer rather than the OS browser: it must look like an
+// image, the terminal must support a graphics protocol, the user's image
+// viewer setting must not be "browser", and the session must not be an
+// ephemeral SSH-hosted one (which must never have the host fetch a
+// remote-chosen URL — see the SSRF guard in routeURL).
+func (a App) canRenderImageInline(u string) bool {
+	return !a.ephemeral &&
+		urlutil.IsImageURL(u) &&
+		a.graphicsProtocol != imgview.ProtocolNone &&
+		a.imageViewer != "browser"
 }
 
 // openExternalURL opens u in the OS default browser as a fire-and-forget command.
@@ -1905,32 +1942,49 @@ func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 	if displayRows < 1 {
 		displayRows = 1
 	}
+	a.imageFetchGen++
+	gen := a.imageFetchGen
+	cached, hit := a.imageCache[rawURL]
 	return a, func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		defer cancel()
-		img, err := imgview.Fetch(ctx, rawURL)
-		if err != nil {
-			return imageFetchedMsg{rawURL: rawURL, err: err}
+		img := cached
+		if !hit {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			var err error
+			img, err = imgview.Fetch(ctx, rawURL)
+			if err != nil {
+				return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
+			}
 		}
 		switch proto {
 		case imgview.ProtocolKitty:
 			encoded, cols, rows := imgview.EncodeKitty(img, displayCols, displayRows)
-			return imageFetchedMsg{rawURL: rawURL, encoded: encoded, cols: cols, rows: rows}
+			return imageFetchedMsg{rawURL: rawURL, gen: gen, decoded: img, encoded: encoded, cols: cols, rows: rows}
 		case imgview.ProtocolITerm2:
 			encoded, cols, rows, err := imgview.EncodeITerm2(img, displayCols, displayRows)
-			return imageFetchedMsg{rawURL: rawURL, encoded: encoded, cols: cols, rows: rows, err: err}
+			return imageFetchedMsg{rawURL: rawURL, gen: gen, decoded: img, encoded: encoded, cols: cols, rows: rows, err: err}
 		default:
-			return imageFetchedMsg{rawURL: rawURL, err: fmt.Errorf("no graphics protocol")}
+			return imageFetchedMsg{rawURL: rawURL, gen: gen, err: fmt.Errorf("no graphics protocol")}
 		}
 	}
 }
 
 // handleImageViewer processes image fetch results. On success it opens the
-// inline modal overlay; on failure it silently falls back to the browser.
+// inline modal overlay; on failure it falls back to the browser, unless a
+// carousel is already showing an image, in which case it just notifies and
+// leaves the current image displayed rather than surprising the user with a
+// browser tab mid-cycle.
 func (a App) handleImageViewer(msg tea.Msg) (App, tea.Cmd, bool) {
 	switch m := msg.(type) {
 	case imageFetchedMsg:
+		if m.gen != a.imageFetchGen {
+			return a, nil, true // superseded by a later cycle or a close
+		}
 		if m.err != nil {
+			if a.imageModalOpen {
+				a2, cmd := a.notify(notifyInfo, "couldn't load image")
+				return a2, cmd, true
+			}
 			return a, openExternalURL(m.rawURL), true
 		}
 		a.imageModalEncoded = m.encoded
@@ -1938,9 +1992,28 @@ func (a App) handleImageViewer(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.imageModalRows = m.rows
 		a.imageModalOpen = true
 		a.imageNeedsCleanup = false
+		if a.imageCache == nil {
+			a.imageCache = make(map[string]image.Image)
+		}
+		a.imageCache[m.rawURL] = m.decoded
+		if a.graphicsProtocol == imgview.ProtocolITerm2 && len(a.imageCarouselItems) > 1 {
+			// iTerm2/WezTerm has no Kitty-style delete-all self-heal; force a
+			// full repaint so a cycled-to smaller image can't leave stray
+			// pixels from the previous one in rows the new frame skips.
+			return a, tea.ClearScreen, true
+		}
 		return a, nil, true
 	}
 	return a, nil, false
+}
+
+// cycleImageCarousel moves to the next/prev image in imageCarouselItems
+// (wrapping around) and starts fetching it. The currently displayed image
+// stays on screen until the new one arrives.
+func (a App) cycleImageCarousel(delta int) (App, tea.Cmd) {
+	n := len(a.imageCarouselItems)
+	a.imageCarouselIndex = (a.imageCarouselIndex + delta + n) % n
+	return a.openImageInTerminal(a.imageCarouselItems[a.imageCarouselIndex])
 }
 
 // handleURLPickerKey processes keyboard input while the URL picker overlay is open.
@@ -1953,6 +2026,25 @@ func (a App) handleURLPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.urlPickerCursor = (a.urlPickerCursor + 1) % n
 	case "enter":
 		u := a.urlPickerItems[a.urlPickerCursor]
+		if a.canRenderImageInline(u) {
+			var images []string
+			idx := 0
+			for _, item := range a.urlPickerItems {
+				if a.canRenderImageInline(item) {
+					if item == u {
+						idx = len(images)
+					}
+					images = append(images, item)
+				}
+			}
+			a.urlPickerOpen = false
+			a.urlPickerItems = nil
+			if len(images) > 1 {
+				a.imageCarouselItems = images
+				a.imageCarouselIndex = idx
+			}
+			return a.openImageInTerminal(u)
+		}
 		a.urlPickerOpen = false
 		a.urlPickerItems = nil
 		return a.routeURL(u)
@@ -2130,6 +2222,8 @@ type notifPostLoadErrMsg struct{ err error }
 // is retained so a failed decode can fall back to opening the browser.
 type imageFetchedMsg struct {
 	rawURL  string
+	gen     int
+	decoded image.Image
 	encoded string
 	cols    int
 	rows    int

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"errors"
 	"fmt"
+	"image"
 	"strings"
 	"testing"
 	"time"
@@ -1267,5 +1268,258 @@ func TestHandleImageViewer_NewImage_ClearsCleanupFlag(t *testing.T) {
 	}
 	if a2.imageNeedsCleanup {
 		t.Error("expected opening a new image to clear any pending cleanup flag")
+	}
+}
+
+// --- Image carousel: cycling through a picker's images without closing ---
+//
+// When the URL picker holds more than one image URL, opening one now enters
+// a carousel: left/right cycle between the picker's images instead of
+// closing the modal. Any other key still closes it immediately, same as a
+// plain single-image view. Async fetch results are stamped with a
+// generation counter (bumped on every new fetch and on close) so a stale
+// result — from cycling again before the previous fetch resolved, or from
+// closing before it resolved — can never resurrect the modal or overwrite a
+// newer image.
+
+func TestCanRenderImageInline_Ephemeral_AlwaysFalse(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.imageViewer = "terminal"
+	a.ephemeral = true
+	if a.canRenderImageInline("https://example.com/x.jpg") {
+		t.Error("expected ephemeral (SSH-hosted) sessions to never render images inline")
+	}
+}
+
+func TestHandleURLPickerKey_Enter_MultipleImages_StartsCarousel(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.urlPickerOpen = true
+	a.urlPickerItems = []string{"https://x.com/page", "https://x.com/a.jpg", "https://x.com/b.png"}
+	a.urlPickerCursor = 2 // b.png
+
+	m, cmd := a.handleURLPickerKey(tea.KeyMsg{Type: tea.KeyEnter})
+	a2 := m.(App)
+	if a2.urlPickerOpen {
+		t.Error("expected the picker to close")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch cmd")
+	}
+	if len(a2.imageCarouselItems) != 2 {
+		t.Fatalf("expected 2 carousel items (the images only), got %d: %v", len(a2.imageCarouselItems), a2.imageCarouselItems)
+	}
+	if a2.imageCarouselIndex != 1 {
+		t.Errorf("expected carousel index 1 (b.png, the second image), got %d", a2.imageCarouselIndex)
+	}
+}
+
+func TestHandleURLPickerKey_Enter_SingleImage_NoCarousel(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.urlPickerOpen = true
+	a.urlPickerItems = []string{"https://x.com/page", "https://x.com/a.jpg"}
+	a.urlPickerCursor = 1
+
+	m, _ := a.handleURLPickerKey(tea.KeyMsg{Type: tea.KeyEnter})
+	a2 := m.(App)
+	if a2.imageCarouselItems != nil {
+		t.Errorf("expected no carousel with only one image among the picker's URLs, got %v", a2.imageCarouselItems)
+	}
+}
+
+func TestUpdate_ImageModal_LeftRight_CyclesWithoutClosing(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.imageModalOpen = true
+	a.imageCarouselItems = []string{"https://x.com/a.jpg", "https://x.com/b.jpg", "https://x.com/c.jpg"}
+	a.imageCarouselIndex = 0
+	genBefore := a.imageFetchGen
+
+	m, cmd := a.Update(tea.KeyMsg{Type: tea.KeyRight})
+	a2 := m.(App)
+	if !a2.imageModalOpen {
+		t.Error("expected the modal to stay open while cycling")
+	}
+	if a2.imageCarouselIndex != 1 {
+		t.Errorf("expected carousel index 1 after right, got %d", a2.imageCarouselIndex)
+	}
+	if len(a2.imageCarouselItems) != 3 {
+		t.Error("expected carousel items to survive cycling")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch cmd for the newly cycled-to image")
+	}
+	if a2.imageFetchGen == genBefore {
+		t.Error("expected imageFetchGen to advance on cycle")
+	}
+
+	m2, _ := a2.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	a3 := m2.(App)
+	if a3.imageCarouselIndex != 0 {
+		t.Errorf("expected carousel index to wrap/return to 0 after left, got %d", a3.imageCarouselIndex)
+	}
+}
+
+func TestUpdate_ImageModal_OtherKey_ClosesAndClearsCarousel(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.imageModalOpen = true
+	a.imageCarouselItems = []string{"https://x.com/a.jpg", "https://x.com/b.jpg"}
+	a.imageCarouselIndex = 1
+	a.imageCache = map[string]image.Image{"https://x.com/a.jpg": image.NewRGBA(image.Rect(0, 0, 2, 2))}
+	genBefore := a.imageFetchGen
+
+	m, _ := a.Update(keyMsg("x"))
+	a2 := m.(App)
+	if a2.imageModalOpen {
+		t.Error("expected a non-arrow key to close the modal even mid-carousel")
+	}
+	if a2.imageCarouselItems != nil {
+		t.Error("expected carousel state to be cleared on close")
+	}
+	if a2.imageFetchGen == genBefore {
+		t.Error("expected imageFetchGen to advance on close, invalidating any in-flight fetch")
+	}
+	if a2.imageCache != nil {
+		t.Error("expected imageCache to be cleared on close")
+	}
+}
+
+// --- Image cache: cycling back to an already-viewed image skips the fetch ---
+
+func TestOpenImageInTerminal_CacheHit_SkipsFetch(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	cachedImg := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	a.imageCache = map[string]image.Image{"https://x.com/a.jpg": cachedImg}
+
+	_, cmd := a.openImageInTerminal("https://x.com/a.jpg")
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	// Safe to invoke directly: a cache hit performs no network I/O, so this
+	// stays a fast, deterministic unit test.
+	msg := cmd()
+	fm, ok := msg.(imageFetchedMsg)
+	if !ok {
+		t.Fatalf("expected imageFetchedMsg, got %T", msg)
+	}
+	if fm.err != nil {
+		t.Errorf("expected no error on a cache hit, got %v", fm.err)
+	}
+	if fm.decoded != cachedImg {
+		t.Error("expected the cached image to be reused rather than re-fetched")
+	}
+	if fm.encoded == "" {
+		t.Error("expected the cached image to still be (re-)encoded for the current terminal size")
+	}
+}
+
+func TestHandleImageViewer_Success_PopulatesCache(t *testing.T) {
+	a := loggedInApp()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+
+	a2, _, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/a.jpg", decoded: img, encoded: "seq", cols: 2, rows: 2})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled")
+	}
+	if a2.imageCache["https://x.com/a.jpg"] != img {
+		t.Error("expected the decoded image to be cached under its URL")
+	}
+}
+
+func TestHandleImageViewer_StaleGeneration_Dropped(t *testing.T) {
+	a := loggedInApp()
+	a.imageFetchGen = 5
+	a.imageModalEncoded = "current"
+
+	a2, cmd, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/a.jpg", gen: 3, encoded: "stale", cols: 1, rows: 1})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled (and dropped)")
+	}
+	if cmd != nil {
+		t.Error("expected no cmd for a stale result")
+	}
+	if a2.imageModalEncoded != "current" {
+		t.Error("expected a stale (superseded) result to be dropped, not overwrite the current image")
+	}
+}
+
+func TestHandleImageViewer_ErrorMidCarousel_NotifiesKeepsImage(t *testing.T) {
+	a := loggedInApp()
+	a.imageModalOpen = true
+	a.imageModalEncoded = "current"
+
+	a2, cmd, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/bad.jpg", err: errors.New("fetch failed")})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled")
+	}
+	if a2.imageModalEncoded != "current" {
+		t.Error("expected the current image to stay displayed on a mid-carousel fetch error")
+	}
+	if a2.notifyText == "" {
+		t.Error("expected a notify on a mid-carousel fetch error")
+	}
+	if cmd == nil {
+		t.Error("expected the notify's cmd (not nil)")
+	}
+}
+
+func TestHandleImageViewer_ErrorNoModalOpen_FallsBackToBrowser(t *testing.T) {
+	a := loggedInApp()
+	a.imageModalOpen = false
+
+	_, cmd, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/bad.jpg", err: errors.New("fetch failed")})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled")
+	}
+	if cmd == nil {
+		t.Error("expected a browser-open cmd when nothing was already showing")
+	}
+}
+
+func TestHandleImageViewer_ITerm2CycleSuccess_ForcesClearScreen(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolITerm2
+	a.imageCarouselItems = []string{"https://x.com/a.jpg", "https://x.com/b.jpg"}
+
+	a2, cmd, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/b.jpg", encoded: "seq", cols: 10, rows: 5})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled")
+	}
+	if !a2.imageModalOpen {
+		t.Fatal("expected the image to open")
+	}
+	if cmd == nil {
+		t.Error("expected tea.ClearScreen to force a full repaint on an iTerm2 carousel cycle")
+	}
+}
+
+func TestHandleImageViewer_KittyCycleSuccess_NoClearScreen(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.imageCarouselItems = []string{"https://x.com/a.jpg", "https://x.com/b.jpg"}
+
+	_, cmd, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/b.jpg", encoded: "seq", cols: 10, rows: 5})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled")
+	}
+	if cmd != nil {
+		t.Error("Kitty self-heals via its own delete-all prefix, no ClearScreen needed")
+	}
+}
+
+func TestHandleImageViewer_SingleImageSuccess_NoClearScreen(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolITerm2 // even on iTerm2
+
+	_, cmd, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/a.jpg", encoded: "seq", cols: 10, rows: 5})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled")
+	}
+	if cmd != nil {
+		t.Error("expected no ClearScreen outside a carousel")
 	}
 }

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -9,7 +9,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/ragnar/cyber-tui/internal/ui/imgview"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
-	"github.com/ragnar/cyber-tui/internal/ui/urlutil"
 )
 
 // hintRows converts hints to modal row strings, skipping the "?" entry.
@@ -557,9 +556,7 @@ func (l TabsLayout) renderURLPicker(a App) string {
 	items := make([]string, len(a.urlPickerItems))
 	for i, u := range a.urlPickerItems {
 		display := u
-		if urlutil.IsImageURL(u) &&
-			a.graphicsProtocol != imgview.ProtocolNone &&
-			a.imageViewer != "browser" {
+		if a.canRenderImageInline(u) {
 			display = "[img] " + display
 		}
 		if len(display) > 60 {
@@ -585,5 +582,15 @@ func (l TabsLayout) renderImageModal(a App) string {
 	for i := range lines {
 		lines[i] = blankLine
 	}
-	return theme.ActiveBorder.Render(strings.Join(lines, "\n"))
+	content := strings.Join(lines, "\n")
+	if len(a.imageCarouselItems) > 1 {
+		// A plain text hint below the image, not overlaid on it — Kitty
+		// placements are an independent compositing layer that can hide text
+		// drawn into their own cells regardless of z-index, so cycling
+		// arrows drawn "on" the image were invisible in practice. This line
+		// renders through the normal bordered-box text path instead.
+		hint := theme.Subtle.Render(fmt.Sprintf("◂ %d/%d ▸", a.imageCarouselIndex+1, len(a.imageCarouselItems)))
+		content += "\n" + lipgloss.PlaceHorizontal(a.imageModalCols, lipgloss.Center, hint)
+	}
+	return theme.ActiveBorder.Render(content)
 }

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -39,6 +39,36 @@ func TestRenderNav_DoesNotShowSearch(t *testing.T) {
 	}
 }
 
+// --- renderImageModal: carousel position hint ---
+//
+// Cycling arrows overlaid directly on the image were invisible in practice —
+// Kitty placements are an independent compositing layer that can hide text
+// drawn into their own cells regardless of z-index. The hint line renders
+// through the normal bordered-box text path instead, so it can't be hidden
+// by an image placement.
+
+func TestRenderImageModal_Carousel_ShowsPositionHint(t *testing.T) {
+	a := loggedInApp()
+	a.imageModalCols = 20
+	a.imageModalRows = 5
+	a.imageCarouselItems = []string{"https://x.com/a.jpg", "https://x.com/b.jpg", "https://x.com/c.jpg"}
+	a.imageCarouselIndex = 1
+	out := ansi.Strip(TabsLayout{}.renderImageModal(a))
+	if !strings.Contains(out, "2/3") {
+		t.Errorf("expected a 2/3 position hint, got: %q", out)
+	}
+}
+
+func TestRenderImageModal_SingleImage_NoHint(t *testing.T) {
+	a := loggedInApp()
+	a.imageModalCols = 20
+	a.imageModalRows = 5
+	out := ansi.Strip(TabsLayout{}.renderImageModal(a))
+	if strings.Contains(out, "◂") || strings.Contains(out, "▸") {
+		t.Errorf("expected no position hint for a plain single-image view, got: %q", out)
+	}
+}
+
 // --- screenForNumber ---
 
 func TestScreenForNumber_1Through9_MatchMenuTabsOrder(t *testing.T) {


### PR DESCRIPTION
## Summary
- When the URL picker ('o'/'ctrl+o') contains more than one image, selecting one now enters a carousel: left/right cycles between the picker's images without closing the modal (wraps around), with a `◂ N/M ▸` position hint drawn in the modal's border. Any other key still closes it immediately, same as a plain single-image view.
- Async fetch results are stamped with a generation counter (bumped on every new fetch and on close) so a stale result — from cycling again or closing before a fetch resolves — is always dropped instead of resurrecting the modal or clobbering a newer image. A fetch error mid-carousel notifies and keeps the current image rather than launching a surprise browser tab; the very first image of a carousel still falls back to the browser on error, matching existing single-image behavior.
- Decoded images are cached per-URL for the modal's lifetime, so cycling back to an already-viewed image skips the network fetch. The image is still re-encoded at the current terminal size on every cycle, so a resize between cycles can't leave a stale-sized image. No eviction policy — cache is cleared when the modal closes, and picker image counts are naturally small, so this is an accepted tradeoff rather than an oversight.
- Fixes a real security gap the carousel design surfaced: `routeURL`'s ephemeral (SSH-hosted session) guard against fetching attacker-chosen URLs wasn't applied to the new carousel-entry path, which calls `openImageInTerminal` directly instead of going through `routeURL`. Folded into a shared `canRenderImageInline` helper now used by all three call sites (`routeURL`, the picker's `[img]` tag, and carousel entry).
- An earlier attempt drew the cycling arrows directly on top of the image via raw cursor positioning. Kitty placements are an independent compositing layer that can hide such text regardless of z-index, so the arrows were invisible in practice. The position hint now renders through the modal's normal bordered-box text path instead, which can't be hidden by an image placement.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New tests: ephemeral-session gating, carousel entry (multi vs. single image among picker URLs), left/right cycling without closing, any-other-key closing + state/cache clearing, stale-generation dropping, both fetch-error branches, iTerm2-vs-Kitty `ClearScreen` behavior on cycle, cache-hit skips fetch, cache populated on successful fetch, position-hint rendering
- [x] Manual: verified in a real Kitty/Ghostty terminal — carousel cycling, position hint visibility, cache making repeat visits instant