### PR TITLE
fix: suppress chat_mention for open room + refresh API docs

### DIFF
--- a/docs/00-latest-api-reference.md
+++ b/docs/00-latest-api-reference.md
@@ -876,6 +876,40 @@ POST /v1/cmail/:conversationId/read
 
 Resets your unread count for the conversation to `0`.
 
+### Typing Indicator
+
+```
+POST /v1/cmail/:conversationId/typing
+```
+
+Tells the other participant you're composing a message — they see the same "…is typing" the website shows. No body; your username is set from your authenticated account.
+
+```json
+{ "data": { "conversationId": "...", "ok": true, "heartbeatMs": 3000, "staleAfterMs": 9000 } }
+```
+
+The flag is deliberately short-lived. Refresh it every `heartbeatMs` while the user is still typing; if you stop refreshing, it clears itself after `staleAfterMs`. That's what keeps a client that quits or crashes mid-sentence from leaving "…is typing" stuck on the other person's screen forever. Read both values off the response rather than hard-coding them.
+
+Sending a message clears your flag automatically, so you don't need to clear it before `POST /v1/cmail/:conversationId`.
+
+```
+DELETE /v1/cmail/:conversationId/typing
+```
+
+Clears the flag immediately — call it when the input goes idle (the website uses ~2.5 s) or the user closes the conversation, rather than waiting for it to age out. Returns `{ "data": { "conversationId": "...", "ok": true } }`.
+
+```
+GET /v1/cmail/:conversationId/typing
+```
+
+Whether the *other* participant is typing right now:
+
+```json
+{ "data": { "conversationId": "...", "userId": "...", "typing": true, "username": "alice", "since": 1719700000000, "staleAfterMs": 9000 } }
+```
+
+This is a polling convenience — for a live indicator, subscribe to the presence node directly (below) instead of hammering this endpoint.
+
 ### Reading in real time
 
 New messages are delivered by subscribing to the conversation in Realtime Database directly, using the `idToken` you already have.
@@ -917,6 +951,8 @@ A `data` of `null` means that path was deleted. Merge events into your local vie
 
 **Stay within bounds (or get denied):**
 
+For a live typing indicator, subscribe to `dm_presence/<conversationId>.json?auth=<idToken>` the same way. Entries look like `{ "<userId>": { "username": "...", "typing": true, "timestamp": 1719700000000 } }`. Apply the same rule the endpoint does — treat someone as typing only if `typing` is `true` **and** `timestamp` is newer than `staleAfterMs` — and re-check on a timer, since a flag going stale produces no event. Publishing your own still goes through `POST /v1/cmail/:conversationId/typing`.
+
 - You can only read conversations you're a participant in, and your own `user_conversations/<yourUid>` — nothing above those. The database rejects anything broader, so don't try to read the whole tree.
 - **Always** include `orderBy="timestamp"` and a `limitToLast` of **100 or fewer**. Page older history with `&endBefore=<timestamp>`. Unbounded reads pull the entire conversation and may be rejected.
 - Keep one stream open per conversation; don't reconnect in a loop.
@@ -933,7 +969,7 @@ A room is addressed by its `roomId` (its slug, e.g. `general`). Messages are pla
 GET /v1/circ
 ```
 
-Returns the rooms available to you, sorted by `sortOrder` then most-recently-active first. Each entry: `id`, `slug`, `name`, `lastMessageAt` (ms epoch), `sortOrder`.
+Returns the rooms available to you, sorted by `sortOrder` then most-recently-active first. Each entry: `id`, `slug`, `name`, `lastMessageAt` (ms epoch), `sortOrder`, `onlineCount` (how many people are in the room right now — see [Who's in a room](#whos-in-a-room)).
 
 ### Read a Room
 
@@ -965,6 +1001,40 @@ POST /v1/circ/:roomId/read
 
 Marks the room as viewed for you (drives the "new messages" indicator). Returns `{ "data": { "roomId": "...", "ok": true } }`.
 
+### Who's in a room
+
+```
+GET /v1/circ/:roomId/users
+```
+
+Returns the people currently in the room, sorted by username. Each entry: `userId`, `username`, `isChatAdmin`, `lastSeen` (ms epoch). Returns `403` if the room isn't available to you.
+
+Presence is heartbeat-based: someone counts as present while they keep announcing themselves. Stop hearing from a client and it drops off the list on its own, so a crashed or force-quit client clears itself without any cleanup call.
+
+### Announce Your Presence
+
+```
+POST /v1/circ/:roomId/presence
+```
+
+Call this when you enter a room, then repeat it every `heartbeatMs` for as long as you stay. This is what puts you in the room's user list — including for people on the website, who see you alongside everyone else. Skip it and you can still read and send, you're just invisible.
+
+No body. `username` and `isChatAdmin` are set from your authenticated account, so you can only ever publish your own presence. Returns:
+
+```json
+{ "data": { "roomId": "general", "ok": true, "heartbeatMs": 30000, "staleAfterMs": 180000 } }
+```
+
+Read the cadence off the response rather than hard-coding it: send a heartbeat every `heartbeatMs`, and you drop out of the room once `staleAfterMs` passes with no heartbeat. Returns `403` if the room isn't available to you.
+
+### Leave a Room
+
+```
+DELETE /v1/circ/:roomId/presence
+```
+
+Removes you from the room's user list immediately. Optional but polite — call it when the user leaves the room or quits your client. Without it you stay listed until `staleAfterMs` elapses. Returns `{ "data": { "roomId": "...", "ok": true } }`.
+
 ### Reading a room in real time
 
 New messages are delivered by subscribing to the room in Realtime Database directly — the same mechanism [C-Mail uses](#reading-in-real-time), using the `idToken` you already have. Connect to the `rtdbUrl` returned from `/v1/auth/login` and `/v1/auth/refresh` and open a Server-Sent Events stream:
@@ -975,6 +1045,8 @@ Accept: text/event-stream
 ```
 
 The first event is a `put` with the whole window; each new message is another `put`/`patch`. A `data` of `null` means that path was deleted. Merge events into your local view by `path`.
+
+To keep the room's user list live without polling `GET /v1/circ/:roomId/users`, open a second stream on `chat_presence/<roomId>.json?auth=<idToken>`. Entries look like `{ "<userId>": { "username": "...", "isChatAdmin": false, "online": true, "lastSeen": 1719700000000 } }`. Apply the same rule the endpoint does: show an entry only if `online` is `true` and `lastSeen` is newer than `staleAfterMs` — and re-evaluate on a timer, not just on events, since an entry going stale produces no event. Publishing your own presence still goes through `POST /v1/circ/:roomId/presence`.
 
 **Stay within bounds (or get denied):**
 
@@ -1113,8 +1185,10 @@ All responses follow this structure:
 | C-Mail message | 15 | 300 |
 | Start C-Mail conversation | 5 | 50 |
 | Mark C-Mail read | 60 | — |
+| C-Mail typing on/off | 45 | — |
 | cIRC message | 15 | 300 |
 | Mark cIRC room read | 60 | — |
+| cIRC presence heartbeat / leave | 30 | — |
 
 C-Mail messaging also has an hourly cap (150/hour); starting conversations is capped at 30/hour. cIRC messaging has the same hourly cap (150/hour).
 
@@ -1141,8 +1215,10 @@ C-Mail messaging also has an hourly cap (150/hour); starting conversations is ca
 | Watch status / list watched | 30 |
 | List C-Mail conversations | 30 |
 | Read a C-Mail conversation | 45 |
+| Check C-Mail typing | 60 |
 | List cIRC rooms | 30 |
 | Read a cIRC room | 45 |
+| List who's in a cIRC room | 60 |
 | Search | 30 |
 
 Exceeding a rate limit returns `429`. Limits use a rolling window (24 hours for daily, 60 seconds for per-minute).

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -416,6 +416,7 @@ Notification feed (replies, new followers, pokes, bookmarks, thread replies).
 - `m` emits `MarkNotifReadMsg`; `M` emits `MarkAllNotifsReadMsg`
 - `u` toggles unread-only filter
 - `chat_mention` and `post_mention`/`reply_mention` notifications show an inline `"> …"` preview of the mentioning content (`MessageContent`/`PostContent`/`ReplyContent`)
+- `chat_mention` notifications for the cIRC room currently open in Chatrooms detail view are auto-suppressed (marked read, no badge bump) — see `docs/15-notifications.md`
 
 Key types: `NotificationsModel`, `LoadMoreNotifsMsg`, `RefreshNotifsMsg`, `MarkNotifReadMsg`, `MarkAllNotifsReadMsg`, `ShowNotificationPostMsg`, `OpenRoomMsg`  
 Key methods: `SetNotifs(notifs, cursor)`, `AppendNotifs(notifs, cursor)`

--- a/docs/15-notifications.md
+++ b/docs/15-notifications.md
@@ -102,6 +102,12 @@ Pressing `enter` on `poke`, `new_follower`, or `unfollowed` notifications (or an
 
 Both deep-links record Notifications as the return screen (`App.chatroomsReturn` / `App.cmailReturn`) and mark the destination model's `canGoBack = true`, so pressing `Esc` from the room/conversation returns straight back to Notifications instead of dropping to Chatrooms'/C-Mail's own list — see `docs/33-circ.md` and `docs/08-cmail.md`.
 
+### chat_mention suppression for the room currently open
+
+The API has no concept of room presence — there's no join/leave endpoint, so it generates `chat_mention` unconditionally, even for a user actively reading the room the mention happened in (see "No online-users list" in `docs/33-circ.md`). Since that's redundant (the message is already on screen), the client auto-suppresses it: any unread `chat_mention` whose `RoomSlug` matches the room currently open in Chatrooms detail view is marked read (both locally and via `MarkNotificationRead`) as soon as it's fetched, so it never bumps the tab badge or appears unread in the list (`App.suppressActiveRoomMentions` in `internal/ui/app.go`).
+
+"Currently open" requires both: Chatrooms is the foreground screen (`App.active == screenChatrooms`) and that exact room is in detail view (`ChatroomsModel.ActiveRoomSlug()`). Switching to any other tab, or pressing `Esc` back to the room list, immediately stops the suppression for that room — mentions notify normally again from that point on.
+
 ---
 
 ## Notification Types

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2752,11 +2752,13 @@ func (a *App) saveProfileCmd(msg screens.SaveProfileMsg) tea.Cmd {
 func (a App) handleNotifications(msg tea.Msg) (App, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case notifsLoadedMsg:
+		a, cmd := a.suppressActiveRoomMentions(msg.notifs)
 		a.notifications = a.notifications.SetNotifs(msg.notifs, msg.cursor)
-		return a, nil, true
+		return a, cmd, true
 	case notifsPageMsg:
+		a, cmd := a.suppressActiveRoomMentions(msg.notifs)
 		a.notifications = a.notifications.AppendNotifs(msg.notifs, msg.cursor)
-		return a, nil, true
+		return a, cmd, true
 	case screens.RefreshNotifsMsg:
 		return a, a.loadNotifsCmd(), true
 	case screens.LoadMoreNotifsMsg:
@@ -2815,6 +2817,27 @@ func (a App) handleNotifications(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, nil, true
 	}
 	return a, nil, false
+}
+
+// suppressActiveRoomMentions marks read (locally + via API) any unread
+// chat_mention notifications for the cIRC room the user currently has open,
+// so being mentioned in a room you're already reading doesn't also notify.
+func (a App) suppressActiveRoomMentions(notifs []model.Notification) (App, tea.Cmd) {
+	roomSlug := a.chatrooms.ActiveRoomSlug()
+	if a.active != screenChatrooms || roomSlug == "" {
+		return a, nil
+	}
+	var cmds []tea.Cmd
+	for i, n := range notifs {
+		if n.Type == "chat_mention" && !n.Read && n.RoomSlug == roomSlug {
+			notifs[i].Read = true
+			if a.polledUnreadCount > 0 {
+				a.polledUnreadCount--
+			}
+			cmds = append(cmds, a.markNotifReadCmd(n.ID))
+		}
+	}
+	return a, tea.Batch(cmds...)
 }
 
 func (a *App) loadNotifsCmd() tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1012,6 +1012,79 @@ func TestHandleChatrooms_RoomsLoadedMsg_ConsumesPendingSlug(t *testing.T) {
 	}
 }
 
+// --- chat_mention suppression for the room currently open ---
+//
+// Reported behavior: being mentioned in a cIRC room you're actively reading
+// still notified, which reads as redundant since the message is already on
+// screen. Since the API has no room-presence concept (join/leave), the fix
+// filters chat_mention notifications client-side against the locally-tracked
+// open room, only while Chatrooms is the foreground screen.
+
+func TestNotifsLoaded_SuppressesMentionForActiveRoom(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenChatrooms
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "cyberspace", Name: "Cyberspace"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.chatrooms = cm
+	if a.chatrooms.ActiveRoomSlug() != "cyberspace" {
+		t.Fatal("setup: expected the room open in detail mode")
+	}
+	a.polledUnreadCount = 1
+
+	notifs := []model.Notification{{ID: "n1", Type: "chat_mention", RoomSlug: "cyberspace", Read: false}}
+	m, cmd := a.Update(notifsLoadedMsg{notifs: notifs})
+	got := m.(App)
+
+	if got.notifications.UnreadCount() != 0 {
+		t.Errorf("UnreadCount() = %d, want 0 (mention in the open room should be auto-suppressed)", got.notifications.UnreadCount())
+	}
+	if got.polledUnreadCount != 0 {
+		t.Errorf("polledUnreadCount = %d, want 0 (badge should not bump for the suppressed mention)", got.polledUnreadCount)
+	}
+	if cmd == nil {
+		t.Error("expected a mark-read cmd for the suppressed mention")
+	}
+}
+
+func TestNotifsLoaded_DoesNotSuppress_WhenNotOnChatroomsScreen(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenNotifications // not viewing Chatrooms at all
+	a.polledUnreadCount = 1
+
+	notifs := []model.Notification{{ID: "n1", Type: "chat_mention", RoomSlug: "cyberspace", Read: false}}
+	m, _ := a.Update(notifsLoadedMsg{notifs: notifs})
+	got := m.(App)
+
+	if got.notifications.UnreadCount() != 1 {
+		t.Errorf("UnreadCount() = %d, want 1 (mention must still notify once the room isn't open)", got.notifications.UnreadCount())
+	}
+	if got.polledUnreadCount != 1 {
+		t.Errorf("polledUnreadCount = %d, want 1 (badge should still reflect the mention)", got.polledUnreadCount)
+	}
+}
+
+func TestNotifsLoaded_DoesNotSuppress_ForADifferentRoom(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenChatrooms
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "zion", Name: "Zion"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.chatrooms = cm
+	if a.chatrooms.ActiveRoomSlug() != "zion" {
+		t.Fatal("setup: expected zion open in detail mode")
+	}
+	a.polledUnreadCount = 1
+
+	notifs := []model.Notification{{ID: "n1", Type: "chat_mention", RoomSlug: "cyberspace", Read: false}}
+	m, _ := a.Update(notifsLoadedMsg{notifs: notifs})
+	got := m.(App)
+
+	if got.notifications.UnreadCount() != 1 {
+		t.Errorf("UnreadCount() = %d, want 1 (mention in a different room must still notify)", got.notifications.UnreadCount())
+	}
+}
+
 func TestHandleCMail_ConvReconnected_ShowsToast(t *testing.T) {
 	a := loggedInApp()
 	m, _ := a.Update(screens.CMailReconnectedMsg{})

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -253,6 +253,15 @@ func (m ChatroomsModel) InputFocused() bool { return m.mode == chatroomModeDetai
 // IsShowingDetail reports whether the detail view is active.
 func (m ChatroomsModel) IsShowingDetail() bool { return m.mode == chatroomModeDetail }
 
+// ActiveRoomSlug returns the slug of the room currently shown in detail view,
+// or "" if no room is open.
+func (m ChatroomsModel) ActiveRoomSlug() string {
+	if m.mode != chatroomModeDetail || m.activeRoom == nil {
+		return ""
+	}
+	return m.activeRoom.Slug
+}
+
 // GetFocusedURLs returns URLs found across all currently loaded messages in
 // the open room, for the 'o' / ctrl+o open-link shortcut. Reachable via
 // ctrl+o even while the compose input is focused, which it always is in


### PR DESCRIPTION
## Summary
- Auto-suppress `chat_mention` notifications for a cIRC room the user already has open in Chatrooms detail view (marked read locally + via API, no badge bump). The API has no room-presence/join-leave concept, so it fires the mention unconditionally even while you're reading the room live.
- Refreshed `docs/00-latest-api-reference.md` against the live API docs: new C-Mail typing-indicator endpoints and cIRC room-presence endpoints (with RTDB presence streams and rate limits).

## Testing
- `go test ./... -count=1` — all pass
- `go vet ./...` — clean
- `staticcheck ./...` — clean

## Docs
- `docs/15-notifications.md` — new section on the suppression behavior
- `docs/00-project-reference.md` — updated notifications bullet list
- `docs/00-latest-api-reference.md` — API snapshot refresh