### PR TITLE
feat: show an in-detail marker on the tab bar/nav sidebar

### DIFF
--- a/docs/02-menu-bar-navigation.md
+++ b/docs/02-menu-bar-navigation.md
@@ -35,20 +35,39 @@ only ever supposed to be entered focused.
   highlighted in cyan inline within the label itself — e.g. `feed`'s `f`,
   `c-mail`'s `m` — so the leader-key hint is visible without opening the
   help modal (`?`)
-- **"In detail" marker**: a selected tab that's currently one level deep —
-  an open Circ room, an open C-Mail conversation, browsing into a Guild or
-  Topic, or PostDetail opened from that tab — keeps its active highlight and
-  gets an extra marker on top: a trailing `›` in TabsLayout (e.g. `circ ›`),
-  or the nav sidebar's `▶` marker becomes `▷` in MillerLayout. Both layouts
-  compute this from one shared function, `tabVisualState(a, screen) (selected,
-  detail bool)` (`internal/ui/layout.go`), so they can't disagree about which
-  state a tab is in. `selected` covers both "this screen is `a.active`" and
-  "PostDetail is open and `postDetailReturn` points back to this tab" (since
-  PostDetail is a single screen shared by six origins — Feed, Bookmarks,
-  Profile, Guilds, Topics, Notifications — rather than duplicated per-origin).
-  Before this, Circ/C-Mail silently dropped the active highlight entirely
-  once a room/conversation was open (indistinguishable from a tab never
-  visited), and Guilds/Topics had no equivalent signal at all.
+- **"In detail" marker**: a tab that's currently one level deep — an open
+  Circ room, an open C-Mail conversation, browsing into a Guild or Topic, or
+  PostDetail opened from that tab — gets a marker: a trailing `›` in
+  TabsLayout (e.g. `circ ›`), or the nav sidebar's `▶`/blank marker becomes
+  `▷` in MillerLayout. Both layouts compute this from one shared function,
+  `tabVisualState(a, screen) (selected, detail bool)` (`internal/ui/layout.go`),
+  so they can't disagree about which state a tab is in. `selected` covers
+  both "this screen is `a.active`" and "PostDetail is open and
+  `postDetailReturn` points back to this tab" (since PostDetail is a single
+  screen shared by six origins — Feed, Bookmarks, Profile, Guilds, Topics,
+  Notifications — rather than duplicated per-origin). Before this, Circ/C-Mail
+  silently dropped the active highlight entirely once a room/conversation was
+  open (indistinguishable from a tab never visited), and Guilds/Topics had no
+  equivalent signal at all.
+  - **The marker shows even while the tab isn't selected**, for Circ,
+    Guilds, and Topics specifically — their detail state is genuinely still
+    live/persisted in the background: an open Circ room keeps its RTDB
+    subscription streaming regardless of the active tab (`docs/33-circ.md`),
+    and Guilds/Topics' browse state is simply never reset by `activateScreen`
+    on tab-away. The marker's color follows `selected` (bright/active when
+    you're looking at that tab, the tab's ordinary dim/inactive color when
+    it's open elsewhere) rather than a different glyph, so "you're here" and
+    "it's open elsewhere" read as the same kind of state at different
+    brightness, not two unrelated indicators.
+  - **C-Mail and PostDetail are selected-only** — deliberately excluded from
+    the background case. `CMailModel.CancelSubscription()` (tab-away) tears
+    the conversation's subscription down immediately but doesn't reset
+    `m.mode`, which lingers as `cmailModeDetail` (stale, not live) until the
+    next `ResetToList()`; showing a marker off that stale field would
+    misrepresent an already-closed conversation as still open — C-Mail's
+    real "something happened" signal is the aggregate unread badge across
+    all conversations, not one left-open thread. PostDetail has no
+    background resumption at all — leaving it abandons it entirely.
 - All tabs are the same height — no layout jumping on tab change
 
 ## Navigation

--- a/docs/02-menu-bar-navigation.md
+++ b/docs/02-menu-bar-navigation.md
@@ -80,6 +80,8 @@ only ever supposed to be entered focused.
 
 Arrow keys and the numeric/leader jumps are blocked from tab navigation when a text input is focused (CIRC, C-Mail, Search's query box, compose panels) so typing works normally in those screens.
 
+**Exception — plain `←`/`→` out of an empty Circ compose box:** since a backgrounded Circ room resumes detail mode (and its always-focused compose input) directly on tab-return rather than dropping to the room list, the very first `←`/`→` after switching back would otherwise be swallowed into a box the user never asked to type into. `app.go`'s focused-input gate (`handleKeys`) lets plain `←`/`→` fall through to tab-cycling specifically when `ChatroomsModel.ComposeEmpty()` is true; with any text in the box (typed just now, or a draft left over from before backgrounding) it's captured for cursor movement as usual, and `ctrl+←`/`ctrl+→` remains the general-purpose way out. See `docs/33-circ.md`'s keyboard shortcuts table.
+
 ## Status Bar
 
 Anchored to the bottom of the terminal at all times. Resizes correctly with the window. Shows the logged-in username on the left and key hints on the right.

--- a/docs/02-menu-bar-navigation.md
+++ b/docs/02-menu-bar-navigation.md
@@ -35,6 +35,20 @@ only ever supposed to be entered focused.
   highlighted in cyan inline within the label itself — e.g. `feed`'s `f`,
   `c-mail`'s `m` — so the leader-key hint is visible without opening the
   help modal (`?`)
+- **"In detail" marker**: a selected tab that's currently one level deep —
+  an open Circ room, an open C-Mail conversation, browsing into a Guild or
+  Topic, or PostDetail opened from that tab — keeps its active highlight and
+  gets an extra marker on top: a trailing `›` in TabsLayout (e.g. `circ ›`),
+  or the nav sidebar's `▶` marker becomes `▷` in MillerLayout. Both layouts
+  compute this from one shared function, `tabVisualState(a, screen) (selected,
+  detail bool)` (`internal/ui/layout.go`), so they can't disagree about which
+  state a tab is in. `selected` covers both "this screen is `a.active`" and
+  "PostDetail is open and `postDetailReturn` points back to this tab" (since
+  PostDetail is a single screen shared by six origins — Feed, Bookmarks,
+  Profile, Guilds, Topics, Notifications — rather than duplicated per-origin).
+  Before this, Circ/C-Mail silently dropped the active highlight entirely
+  once a room/conversation was open (indistinguishable from a tab never
+  visited), and Guilds/Topics had no equivalent signal at all.
 - All tabs are the same height — no layout jumping on tab change
 
 ## Navigation
@@ -62,5 +76,7 @@ Anchored to the bottom of the terminal at all times. Resizes correctly with the 
 **`HasFocusedInput(a App) bool`** — method on `Layout` (implemented per layout, delegating to each screen's own `InputFocused()`/`ComposeActive()`), queried by the app before consuming keys that would otherwise navigate.
 
 **`menuTabs` var** (`internal/ui/layout.go`) — single source of truth for tab order, label, leader-key mnemonic, and (via the `hidden` field) whether an entry is part of the visible/cyclable tab set. `screenForNumber` and `screenForMnemonic` both derive from the full slice (so Search stays reachable by mnemonic); `visibleTabs()` filters out `hidden` entries for rendering and cycling. `activateScreen` is the shared jump-to-screen implementation both the numeric and leader-key paths call, so the two layouts and both navigation schemes can never disagree about what a given key does. `navigateTabBy` (arrow/j-k cycling) is a no-op while `screenSearch` is active, the same treatment `screenPostDetail` gets — neither is part of the rotation.
+
+**`tabVisualState(a App, t screen) (selected, detail bool)`** (`internal/ui/layout.go`, next to `menuTabs`) — the shared selected/in-detail computation behind the "in detail" marker described above. Called identically by `TabsLayout.renderTabBar` and `MillerLayout.renderNav`.
 
 **`leaderPending` field on `App`** — armed by the `g` key in `handleKeys` (`internal/ui/app.go`); the next keypress resolves against `screenForMnemonic` or silently cancels. No timeout is needed since `g` has no other binding of its own, so there's no ambiguity to resolve.

--- a/docs/33-circ.md
+++ b/docs/33-circ.md
@@ -67,6 +67,7 @@ Long bodies word-wrap to fit the terminal width; continuation lines are indented
 | `ctrl+q` | Quit (same as global `q`) |
 | `ctrl+t` | Open theme picker (same as global `t`) |
 | `ctrl+←` / `ctrl+→` | Cycle tabs (same as global `←`/`→`; Tabs layout only) |
+| `←` / `→` | Cycle tabs — but only when the compose input is empty (detail mode, Tabs layout). With text in the box (just typed, or a draft left over from switching tabs away and back — the room and its subscription stay open in the background, see "Room stays open across tab switches" above), plain `←`/`→` moves the cursor instead and `ctrl+←`/`ctrl+→` is the way out, same as it's always been. Otherwise, resuming a backgrounded room on tab-return would silently swallow the very first `←`/`→` press into an empty box the user never asked to type into. See `ChatroomsModel.ComposeEmpty()`. |
 | `Tab` | Preview/cycle `@mention` completion from online users, without touching the real text (detail mode, compose input) |
 | `Space` | Commit the currently-previewed `@mention`, if any, then insert the space (detail mode, compose input) |
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -548,8 +548,21 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 		if m.String() == "ctrl+c" {
 			return a, tea.Quit, true
 		}
-		switch m.String() {
-		case "ctrl+o", "ctrl+q", "ctrl+t", "ctrl+left", "ctrl+right":
+		// A backgrounded Circ room resumes detail mode (and its "always
+		// focused" compose input, see ChatroomsModel.InputFocused) the
+		// instant you tab back into it — so plain left/right otherwise gets
+		// captured into a box you never asked to type into, forcing
+		// ctrl+left/right for what was plain left/right on every other tab a
+		// moment ago. An empty compose box has nothing for left/right to do
+		// anyway, so let it fall through to tab-cycling in that case only;
+		// once there's text (typed just now, or a draft left over from
+		// before backgrounding), left/right goes back to normal cursor
+		// movement and ctrl+left/right remains the way out, same as today.
+		bareArrowEscapesEmptyCompose := (m.String() == "left" || m.String() == "right") &&
+			a.active == screenChatrooms && a.chatrooms.ComposeEmpty()
+		switch {
+		case m.String() == "ctrl+o", m.String() == "ctrl+q", m.String() == "ctrl+t",
+			m.String() == "ctrl+left", m.String() == "ctrl+right", bareArrowEscapesEmptyCompose:
 			// fall through to the global switch below
 		default:
 			return a, nil, false // fall through to delegateUpdate

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -498,11 +498,52 @@ func TestHandleKeys_CtrlRight_CyclesTabsWhileChatroomsInputFocused(t *testing.T)
 	}
 }
 
-func TestHandleKeys_Left_NotConsumed_WhileChatroomsInputFocused(t *testing.T) {
+// A backgrounded Circ room resumes detail mode directly on tab-return (see
+// PR #58/#59), so the very first left/right after switching back used to be
+// swallowed into a compose box the user never asked to type into — plain
+// left/right now falls through to tab-cycling specifically when that box is
+// empty, since there's nothing for it to move a cursor over anyway. Once
+// there's text in it (typed just now, or a draft left over from before
+// backgrounding), left/right goes back to being captured for cursor
+// movement, same as it always has.
+
+func TestHandleKeys_Left_CyclesTabs_WhileChatroomsInputFocusedAndComposeEmpty(t *testing.T) {
 	a := setupChatroomsDetailWithURL(loggedInApp())
+	if !a.chatrooms.ComposeEmpty() {
+		t.Fatal("setup: expected an empty compose box")
+	}
+	before := tabIndexOf(a)
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyLeft})
+	if !consumed {
+		t.Error("expected plain left arrow to be consumed (tab-cycle) while the compose box is empty")
+	}
+	if tabIndexOf(a2) == before {
+		t.Error("expected plain left arrow to cycle to a different tab")
+	}
+}
+
+func TestHandleKeys_Right_CyclesTabs_WhileChatroomsInputFocusedAndComposeEmpty(t *testing.T) {
+	a := setupChatroomsDetailWithURL(loggedInApp())
+	before := tabIndexOf(a)
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyRight})
+	if !consumed {
+		t.Error("expected plain right arrow to be consumed (tab-cycle) while the compose box is empty")
+	}
+	if tabIndexOf(a2) == before {
+		t.Error("expected plain right arrow to cycle to a different tab")
+	}
+}
+
+func TestHandleKeys_Left_NotConsumed_WhileChatroomsInputFocusedAndComposeHasText(t *testing.T) {
+	a := setupChatroomsDetailWithURL(loggedInApp())
+	cm, _ := a.chatrooms.Update(keyMsg("h")) // types into the compose box, not a nav key
+	a.chatrooms = cm
+	if a.chatrooms.ComposeEmpty() {
+		t.Fatal("setup: expected a non-empty compose box")
+	}
 	_, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyLeft})
 	if consumed {
-		t.Error("expected plain left arrow to NOT be consumed while chatrooms input is focused")
+		t.Error("expected plain left arrow to NOT be consumed while there's text in the compose box — it must move the cursor instead")
 	}
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -99,6 +99,34 @@ func visibleTabs() []navTab {
 	return out
 }
 
+// tabVisualState reports whether tab t is the one currently selected, and if
+// so, whether the app is one level deep in it — an open Circ room, an open
+// C-Mail conversation, a Guilds/Topics browse, or PostDetail opened from t
+// (postDetailReturn == t, since PostDetail is a single shared screen reused
+// by six origin tabs rather than duplicated per-origin). Both TabsLayout and
+// MillerLayout call this so the two layouts can never disagree about which
+// state a tab is in.
+func tabVisualState(a App, t screen) (selected, detail bool) {
+	selected = a.active == t || (a.active == screenPostDetail && a.postDetailReturn == t)
+	if !selected {
+		return false, false
+	}
+	if a.active == screenPostDetail {
+		return true, true
+	}
+	switch t {
+	case screenChatrooms:
+		return true, a.chatrooms.IsShowingDetail()
+	case screenCMail:
+		return true, a.cmail.IsShowingDetail()
+	case screenGuilds:
+		return true, a.guilds.IsBrowsingGuild() || a.guilds.IsBrowsingMembers()
+	case screenTopics:
+		return true, a.topics.IsBrowsingTopic()
+	}
+	return true, false
+}
+
 var renderedVersionLine = theme.Subtle.Render("version " + version.Version + " (" + version.Commit + ")")
 
 // hint is a compact key+description pair shown in the status bar and help modal.

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -99,32 +99,43 @@ func visibleTabs() []navTab {
 	return out
 }
 
-// tabVisualState reports whether tab t is the one currently selected, and if
-// so, whether the app is one level deep in it — an open Circ room, an open
-// C-Mail conversation, a Guilds/Topics browse, or PostDetail opened from t
-// (postDetailReturn == t, since PostDetail is a single shared screen reused
+// tabVisualState reports whether tab t is the one currently selected, and
+// whether it's one level deep in a detail sub-view — an open Circ room, an
+// open C-Mail conversation, a Guilds/Topics browse, or PostDetail opened from
+// t (postDetailReturn == t, since PostDetail is a single shared screen reused
 // by six origin tabs rather than duplicated per-origin). Both TabsLayout and
 // MillerLayout call this so the two layouts can never disagree about which
 // state a tab is in.
+//
+// detail is reported even while t isn't selected for Circ/Guilds/Topics,
+// since their detail state is genuinely still live in the background: Circ's
+// open room keeps its RTDB subscription streaming regardless of the active
+// tab (see IsRoomStreamMsg in app.go), and Guilds/Topics' browse state is
+// simply never reset by activateScreen on tab-away. C-Mail and PostDetail are
+// selected-only instead: CMailModel.CancelSubscription (tab-away) tears the
+// conversation's subscription down immediately but doesn't reset m.mode, so
+// it lingers as cmailModeDetail — stale, not live — until the next
+// ResetToList(); surfacing that in the background would claim a conversation
+// is still open when it's already been torn down (C-Mail's actual "something
+// happened" signal is the aggregate unread badge, not a left-open
+// conversation). PostDetail has no background resumption at all.
 func tabVisualState(a App, t screen) (selected, detail bool) {
 	selected = a.active == t || (a.active == screenPostDetail && a.postDetailReturn == t)
-	if !selected {
-		return false, false
-	}
-	if a.active == screenPostDetail {
-		return true, true
-	}
+
 	switch t {
 	case screenChatrooms:
-		return true, a.chatrooms.IsShowingDetail()
-	case screenCMail:
-		return true, a.cmail.IsShowingDetail()
+		detail = a.chatrooms.IsShowingDetail()
 	case screenGuilds:
-		return true, a.guilds.IsBrowsingGuild() || a.guilds.IsBrowsingMembers()
+		detail = a.guilds.IsBrowsingGuild() || a.guilds.IsBrowsingMembers()
 	case screenTopics:
-		return true, a.topics.IsBrowsingTopic()
+		detail = a.topics.IsBrowsingTopic()
+	case screenCMail:
+		detail = selected && a.cmail.IsShowingDetail()
 	}
-	return true, false
+	if selected && a.active == screenPostDetail {
+		detail = true
+	}
+	return selected, detail
 }
 
 var renderedVersionLine = theme.Subtle.Render("version " + version.Version + " (" + version.Commit + ")")

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -298,13 +298,19 @@ func (l MillerLayout) renderNav(a App) string {
 				badge = fmt.Sprintf(" ●%d", n)
 			}
 		}
-		isActive := a.active == t.s &&
-			!(t.s == screenCMail && a.cmail.IsShowingDetail()) &&
-			!(t.s == screenChatrooms && a.chatrooms.IsShowingDetail())
+		selected, detail := tabVisualState(a, t.s)
 		marker := "  "
 		base := theme.Subtle
-		if isActive {
+		if selected {
+			// ▷ (open) marks "selected, one level deep" — a Circ room,
+			// C-Mail conversation, Guilds/Topics browse, or a PostDetail
+			// opened from this tab (see tabVisualState) — vs. ▶ for
+			// selected-at-the-top-level. Mirrors the trailing "›" in
+			// TabsLayout's renderTabBar.
 			marker = "▶ "
+			if detail {
+				marker = "▷ "
+			}
 			if a.focus == focusMenu {
 				base = theme.Highlight
 			}

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -299,21 +299,24 @@ func (l MillerLayout) renderNav(a App) string {
 			}
 		}
 		selected, detail := tabVisualState(a, t.s)
+		// ▷ (open) marks "one level deep" — a Circ room, Guilds/Topics
+		// browse, a C-Mail conversation, or a PostDetail opened from this
+		// tab (see tabVisualState) — vs. ▶ for selected-at-the-top-level, or
+		// no marker at all. Mirrors the trailing "›" in TabsLayout's
+		// renderTabBar. detail can be true while unselected (Circ/Guilds/
+		// Topics persist in the background); base only brightens when
+		// selected, so a backgrounded ▷ renders dim — "open elsewhere",
+		// distinct from the bright ▷ meaning "open, and you're looking at it".
 		marker := "  "
-		base := theme.Subtle
-		if selected {
-			// ▷ (open) marks "selected, one level deep" — a Circ room,
-			// C-Mail conversation, Guilds/Topics browse, or a PostDetail
-			// opened from this tab (see tabVisualState) — vs. ▶ for
-			// selected-at-the-top-level. Mirrors the trailing "›" in
-			// TabsLayout's renderTabBar.
+		switch {
+		case detail:
+			marker = "▷ "
+		case selected:
 			marker = "▶ "
-			if detail {
-				marker = "▷ "
-			}
-			if a.focus == focusMenu {
-				base = theme.Highlight
-			}
+		}
+		base := theme.Subtle
+		if selected && a.focus == focusMenu {
+			base = theme.Highlight
 		}
 		before, ch, after := splitMnemonic(t.label, t.mnemonic)
 		// No background is set on base/mnemonic here, so — unlike renderTabBar —

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -191,12 +191,14 @@ func (l TabsLayout) renderTabBar(a App) string {
 		}
 		marker := ""
 		if detail {
-			// A trailing chevron on top of the active highlight — "selected,
-			// one level deep" — for a Circ room, C-Mail conversation,
-			// Guilds/Topics browse, or a PostDetail opened from this tab
-			// (see tabVisualState). Previously these states just silently
-			// dropped the active highlight, rendering identically to a tab
-			// never visited.
+			// A trailing chevron for "one level deep" — a Circ room,
+			// Guilds/Topics browse, a C-Mail conversation, or a PostDetail
+			// opened from this tab (see tabVisualState). Rendered via `text`
+			// below, so it inherits the active highlight when this tab is
+			// selected, or the ordinary dim/inactive style when it isn't —
+			// Circ/Guilds/Topics report detail even while backgrounded (their
+			// state is genuinely still live/persisted there), so the dim
+			// variant is what shows a room/browse left open on another tab.
 			marker = " ›"
 		}
 		before, ch, after := splitMnemonic(t.label, t.mnemonic)

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -184,18 +184,26 @@ func (l TabsLayout) renderTabBar(a App) string {
 				badge = fmt.Sprintf(" (%d)", n)
 			}
 		}
-		isActive := a.active == t.s &&
-			!(t.s == screenCMail && a.cmail.IsShowingDetail()) &&
-			!(t.s == screenChatrooms && a.chatrooms.IsShowingDetail())
+		selected, detail := tabVisualState(a, t.s)
 		text, mnemonic := theme.TabText, theme.TabMnemonic
-		if isActive {
+		if selected {
 			text, mnemonic = theme.ActiveTabText, theme.ActiveTabMnemonic
+		}
+		marker := ""
+		if detail {
+			// A trailing chevron on top of the active highlight — "selected,
+			// one level deep" — for a Circ room, C-Mail conversation,
+			// Guilds/Topics browse, or a PostDetail opened from this tab
+			// (see tabVisualState). Previously these states just silently
+			// dropped the active highlight, rendering identically to a tab
+			// never visited.
+			marker = " ›"
 		}
 		before, ch, after := splitMnemonic(t.label, t.mnemonic)
 		// Each fragment is rendered independently (rather than wrapping the
 		// whole label in one .Padding style) so the active tab's background
 		// survives across the mnemonic's own ANSI reset — see TabText's doc.
-		tabs += text.Render("  "+before) + mnemonic.Render(ch) + text.Render(after+badge+"  ")
+		tabs += text.Render("  "+before) + mnemonic.Render(ch) + text.Render(after+badge+marker+"  ")
 	}
 	logo := lipgloss.NewStyle().
 		Background(theme.ColorGreen).

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/ragnar/cyber-tui/internal/model"
 )
 
 // --- visibleTabs ---
@@ -36,6 +38,154 @@ func TestRenderNav_DoesNotShowSearch(t *testing.T) {
 	out := ansi.Strip(MillerLayout{}.renderNav(a))
 	if strings.Contains(out, "search") {
 		t.Errorf("expected the nav sidebar to omit the hidden Search entry, got: %q", out)
+	}
+}
+
+// --- tabVisualState ---
+//
+// Unifies what used to be an ad hoc isActive expression duplicated (and
+// drifting) between renderTabBar and renderNav: a tab is "selected" while
+// a.active matches it directly, or PostDetail is open and was reached from
+// it (postDetailReturn); it's additionally "in detail" — one level deep —
+// for an open Circ room/C-Mail conversation/Guilds-Topics browse, or
+// whenever PostDetail itself is what's open.
+
+func TestTabVisualState_Unselected(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenFeed
+	selected, detail := tabVisualState(a, screenCMail)
+	if selected || detail {
+		t.Errorf("selected=%v detail=%v, want false,false for a tab that isn't active", selected, detail)
+	}
+}
+
+func TestTabVisualState_SelectedListMode_NoDetail(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenFeed
+	selected, detail := tabVisualState(a, screenFeed)
+	if !selected || detail {
+		t.Errorf("selected=%v detail=%v, want true,false for the active tab in its top-level view", selected, detail)
+	}
+}
+
+func TestTabVisualState_ChatroomsDetail(t *testing.T) {
+	a := loggedInApp()
+	a, _ = activateScreen(a, screenChatrooms)
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "zion", Name: "Zion"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.chatrooms = cm
+
+	selected, detail := tabVisualState(a, screenChatrooms)
+	if !selected || !detail {
+		t.Errorf("selected=%v detail=%v, want true,true with a room open", selected, detail)
+	}
+}
+
+func TestTabVisualState_CMailDetail(t *testing.T) {
+	a := loggedInApp()
+	a.cmail = a.cmail.SetConversations([]model.Conversation{
+		{ID: "c1", Participants: []model.User{{Username: a.currentUser.Username}, {Username: "molly"}}},
+	})
+	cm, _ := a.cmail.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.cmail = cm
+	a.active = screenCMail
+
+	selected, detail := tabVisualState(a, screenCMail)
+	if !selected || !detail {
+		t.Errorf("selected=%v detail=%v, want true,true with a conversation open", selected, detail)
+	}
+}
+
+func TestTabVisualState_GuildsBrowsingGuild(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenGuilds
+	a.guilds = a.guilds.SetGuilds([]model.Guild{{ID: "g1", Name: "Alpha", Slug: "alpha"}}, "")
+	gm, _ := a.guilds.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.guilds = gm
+
+	selected, detail := tabVisualState(a, screenGuilds)
+	if !selected || !detail {
+		t.Errorf("selected=%v detail=%v, want true,true while browsing a guild", selected, detail)
+	}
+}
+
+func TestTabVisualState_TopicsBrowsingTopic(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenTopics
+	a.topics = a.topics.SetTopics([]model.Topic{{Slug: "tech"}}, "")
+	tm, _ := a.topics.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.topics = tm
+
+	selected, detail := tabVisualState(a, screenTopics)
+	if !selected || !detail {
+		t.Errorf("selected=%v detail=%v, want true,true while browsing a topic", selected, detail)
+	}
+}
+
+func TestTabVisualState_PostDetail_CreditsOriginTab(t *testing.T) {
+	for _, origin := range []screen{screenFeed, screenGuilds} {
+		a := loggedInApp()
+		a.active = screenPostDetail
+		a.postDetailReturn = origin
+
+		selected, detail := tabVisualState(a, origin)
+		if !selected || !detail {
+			t.Errorf("origin %v: selected=%v detail=%v, want true,true while PostDetail is open", origin, selected, detail)
+		}
+
+		// A different tab must not also claim the PostDetail state.
+		other := screenNotifications
+		if origin == screenNotifications {
+			other = screenSettings
+		}
+		selected, detail = tabVisualState(a, other)
+		if selected || detail {
+			t.Errorf("origin %v, other tab %v: selected=%v detail=%v, want false,false", origin, other, selected, detail)
+		}
+	}
+}
+
+// --- renderTabBar / renderNav: detail marker reflects tabVisualState ---
+
+func TestRenderTabBar_ShowsDetailMarker(t *testing.T) {
+	a := loggedInApp()
+	a.width = 100
+	a, _ = activateScreen(a, screenChatrooms)
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "zion", Name: "Zion"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.chatrooms = cm
+
+	out := ansi.Strip(TabsLayout{}.renderTabBar(a))
+	if !strings.Contains(out, "›") {
+		t.Errorf("expected a detail marker (›) in the tab bar with a room open, got: %q", out)
+	}
+}
+
+func TestRenderTabBar_NoDetailMarkerInListMode(t *testing.T) {
+	a := loggedInApp()
+	a.width = 100
+	a, _ = activateScreen(a, screenChatrooms)
+
+	out := ansi.Strip(TabsLayout{}.renderTabBar(a))
+	if strings.Contains(out, "›") {
+		t.Errorf("expected no detail marker while Chatrooms is still in list mode, got: %q", out)
+	}
+}
+
+func TestRenderNav_ShowsOpenMarkerForDetail(t *testing.T) {
+	a := loggedInApp()
+	a, _ = activateScreen(a, screenChatrooms)
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "zion", Name: "Zion"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.chatrooms = cm
+
+	out := ansi.Strip(MillerLayout{}.renderNav(a))
+	if !strings.Contains(out, "▷") {
+		t.Errorf("expected the open (▷) marker in the nav sidebar with a room open, got: %q", out)
 	}
 }
 

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -189,6 +189,25 @@ func TestTabVisualState_TopicsBrowsing_PersistsWhenBackgrounded(t *testing.T) {
 	}
 }
 
+func TestTabVisualState_TopicsBrowsing_ClearsOnEsc(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenTopics
+	a.topics = a.topics.SetTopics([]model.Topic{{Slug: "tech"}}, "")
+	tm, _ := a.topics.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	tm = tm.SetTopicPosts([]model.Post{{ID: "p1", AuthorUsername: "alice"}}, "") // Enter only fires the load cmd; this is what flips m.view to viewTopicPosts
+	tm, _ = tm.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	a.topics = tm
+
+	if selected, detail := tabVisualState(a, screenTopics); !selected || detail {
+		t.Errorf("selected=%v detail=%v, want true,false after esc back to the topic list", selected, detail)
+	}
+
+	a.active = screenFeed // background Topics after esc
+	if selected, detail := tabVisualState(a, screenTopics); selected || detail {
+		t.Errorf("selected=%v detail=%v, want false,false — esc should clear detail even once backgrounded", selected, detail)
+	}
+}
+
 func TestTabVisualState_CMailDetail_DoesNotPersistWhenBackgrounded(t *testing.T) {
 	a := loggedInApp()
 	a.cmail = a.cmail.SetConversations([]model.Conversation{

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -49,6 +49,14 @@ func TestRenderNav_DoesNotShowSearch(t *testing.T) {
 // it (postDetailReturn); it's additionally "in detail" — one level deep —
 // for an open Circ room/C-Mail conversation/Guilds-Topics browse, or
 // whenever PostDetail itself is what's open.
+//
+// detail is reported even while a tab isn't selected for Circ/Guilds/Topics,
+// since their detail state is genuinely still live/persisted in the
+// background (see tabVisualState's doc comment). C-Mail and PostDetail are
+// selected-only: C-Mail's mode lingers stale between leaving and the next
+// ResetToList() even though its subscription was already torn down, so
+// showing it in the background would misrepresent a conversation as still
+// open.
 
 func TestTabVisualState_Unselected(t *testing.T) {
 	a := loggedInApp()
@@ -124,6 +132,84 @@ func TestTabVisualState_TopicsBrowsingTopic(t *testing.T) {
 	}
 }
 
+// --- background persistence: Circ/Guilds/Topics report detail while unselected ---
+
+func TestTabVisualState_ChatroomsDetail_PersistsWhenBackgrounded(t *testing.T) {
+	a := loggedInApp()
+	a, _ = activateScreen(a, screenChatrooms)
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "zion", Name: "Zion"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.chatrooms = cm
+
+	a, _ = activateScreen(a, screenFeed) // background Chatrooms
+
+	selected, detail := tabVisualState(a, screenChatrooms)
+	if selected {
+		t.Error("expected Chatrooms to not be selected after switching to Feed")
+	}
+	if !detail {
+		t.Error("expected Chatrooms to still report detail=true — the room stays open in the background")
+	}
+}
+
+func TestTabVisualState_GuildsBrowsing_PersistsWhenBackgrounded(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenGuilds
+	a.guilds = a.guilds.SetGuilds([]model.Guild{{ID: "g1", Name: "Alpha", Slug: "alpha"}}, "")
+	gm, _ := a.guilds.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.guilds = gm
+
+	a.active = screenFeed // background Guilds
+
+	selected, detail := tabVisualState(a, screenGuilds)
+	if selected {
+		t.Error("expected Guilds to not be selected after switching to Feed")
+	}
+	if !detail {
+		t.Error("expected Guilds to still report detail=true — browse state isn't reset on tab-away")
+	}
+}
+
+func TestTabVisualState_TopicsBrowsing_PersistsWhenBackgrounded(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenTopics
+	a.topics = a.topics.SetTopics([]model.Topic{{Slug: "tech"}}, "")
+	tm, _ := a.topics.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.topics = tm
+
+	a.active = screenFeed // background Topics
+
+	selected, detail := tabVisualState(a, screenTopics)
+	if selected {
+		t.Error("expected Topics to not be selected after switching to Feed")
+	}
+	if !detail {
+		t.Error("expected Topics to still report detail=true — browse state isn't reset on tab-away")
+	}
+}
+
+func TestTabVisualState_CMailDetail_DoesNotPersistWhenBackgrounded(t *testing.T) {
+	a := loggedInApp()
+	a.cmail = a.cmail.SetConversations([]model.Conversation{
+		{ID: "c1", Participants: []model.User{{Username: a.currentUser.Username}, {Username: "molly"}}},
+	})
+	cm, _ := a.cmail.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.cmail = cm
+	a.active = screenCMail
+
+	a.active = screenFeed // background C-Mail — mode is still cmailModeDetail here, stale
+
+	selected, detail := tabVisualState(a, screenCMail)
+	if selected {
+		t.Error("expected C-Mail to not be selected after switching to Feed")
+	}
+	if detail {
+		t.Error("expected C-Mail to report detail=false while backgrounded — its subscription was already torn down, so this would misrepresent a closed conversation as still open")
+	}
+}
+
 func TestTabVisualState_PostDetail_CreditsOriginTab(t *testing.T) {
 	for _, origin := range []screen{screenFeed, screenGuilds} {
 		a := loggedInApp()
@@ -186,6 +272,54 @@ func TestRenderNav_ShowsOpenMarkerForDetail(t *testing.T) {
 	out := ansi.Strip(MillerLayout{}.renderNav(a))
 	if !strings.Contains(out, "▷") {
 		t.Errorf("expected the open (▷) marker in the nav sidebar with a room open, got: %q", out)
+	}
+}
+
+func TestRenderTabBar_ShowsDetailMarkerWhenBackgrounded(t *testing.T) {
+	a := loggedInApp()
+	a.width = 100
+	a, _ = activateScreen(a, screenChatrooms)
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "zion", Name: "Zion"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.chatrooms = cm
+	a, _ = activateScreen(a, screenFeed) // background Chatrooms
+
+	out := ansi.Strip(TabsLayout{}.renderTabBar(a))
+	if !strings.Contains(out, "›") {
+		t.Errorf("expected a detail marker for the backgrounded room, got: %q", out)
+	}
+}
+
+func TestRenderTabBar_NoDetailMarkerForBackgroundedCMail(t *testing.T) {
+	a := loggedInApp()
+	a.width = 100
+	a.cmail = a.cmail.SetConversations([]model.Conversation{
+		{ID: "c1", Participants: []model.User{{Username: a.currentUser.Username}, {Username: "molly"}}},
+	})
+	cm, _ := a.cmail.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.cmail = cm
+	a.active = screenFeed // background C-Mail
+
+	out := ansi.Strip(TabsLayout{}.renderTabBar(a))
+	if strings.Contains(out, "›") {
+		t.Errorf("expected no detail marker for backgrounded C-Mail (its conversation was already torn down), got: %q", out)
+	}
+}
+
+func TestRenderNav_ShowsOpenMarkerWhenBackgrounded(t *testing.T) {
+	a := loggedInApp()
+	a, _ = activateScreen(a, screenChatrooms)
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "zion", Name: "Zion"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.chatrooms = cm
+	a, _ = activateScreen(a, screenFeed) // background Chatrooms
+
+	out := ansi.Strip(MillerLayout{}.renderNav(a))
+	if !strings.Contains(out, "▷") {
+		t.Errorf("expected the open (▷) marker in the nav sidebar for the backgrounded room, got: %q", out)
 	}
 }
 

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -518,6 +518,11 @@ func (m ChatroomsModel) loadOlderRoomMessagesCmd(roomID string, before int64) te
 // InputFocused returns true in detail mode to prevent tab-navigation key capture.
 func (m ChatroomsModel) InputFocused() bool { return m.mode == chatroomModeDetail }
 
+// ComposeEmpty reports whether the compose input has no typed text — used by
+// App to let plain left/right fall through to tab-cycling instead of being
+// captured as cursor movement (see handleKeys' focused-input gate in app.go).
+func (m ChatroomsModel) ComposeEmpty() bool { return m.input.Value() == "" }
+
 // IsShowingDetail reports whether the detail view is active.
 func (m ChatroomsModel) IsShowingDetail() bool { return m.mode == chatroomModeDetail }
 

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -354,6 +354,7 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 		case "esc":
 			if m.view == viewTopicPosts {
 				m.view = viewTopicList
+				m.activeTopic = ""
 				m = m.refreshContent()
 				m.viewport.GotoTop()
 			}

--- a/internal/ui/screens/topics_test.go
+++ b/internal/ui/screens/topics_test.go
@@ -23,6 +23,23 @@ func sampleTopicPosts() []model.Post {
 	}
 }
 
+// --- IsBrowsingTopic / esc ---
+
+func TestTopics_Esc_ClearsIsBrowsingTopic(t *testing.T) {
+	m := screens.NewTopicsModel()
+	m = m.SetTopics(sampleTopics(), "")
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m.SetTopicPosts(sampleTopicPosts(), "") // Enter only fires the load cmd; this is what flips m.view to viewTopicPosts
+	if !m.IsBrowsingTopic() {
+		t.Fatal("setup: expected IsBrowsingTopic() to be true after entering a topic")
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.IsBrowsingTopic() {
+		t.Error("expected IsBrowsingTopic() to be false after esc back to the topic list")
+	}
+}
+
 // --- FilterNSFW ---
 
 func TestTopics_FilterNSFW_HidesNSFWPost(t *testing.T) {


### PR DESCRIPTION
## What

Adds a consistent visual indicator on the tab bar (`TabsLayout`) / nav sidebar (`MillerLayout`) showing when a tab is one level deep in a detail sub-view, instead of at its top-level list/feed view.

## Why

Handling was inconsistent before this change:
- Circ and C-Mail each silently dropped the active-tab highlight once a room/conversation was open — a tab you're actively "in" rendered identically to one you'd never visited.
- Guilds and Topics have the same kind of browsing state but weren't wired into the tab bar's active check at all — they stayed fully highlighted regardless.
- PostDetail is a single screen shared by six origin tabs (Feed, Bookmarks, Profile, Guilds, Topics, Notifications) rather than duplicated per-origin, so opening a post de-highlighted whichever tab opened it, via a different code path than Circ/C-Mail's suppression.

## How

- `tabVisualState(a App, t screen) (selected, detail bool)` (`internal/ui/layout.go`) is the one shared computation both layouts call, so they can't disagree about a tab's state. `selected` covers both "this is `a.active`" and "PostDetail is open and `postDetailReturn` points back here"; `detail` covers an open Circ room, an open C-Mail conversation, a Guilds/Topics browse, or PostDetail itself being open.
- `TabsLayout.renderTabBar` keeps the active highlight for any selected tab and appends a trailing `›` when `detail` is true (e.g. `circ ›`).
- `MillerLayout.renderNav` swaps its `▶` marker for `▷` under the same condition.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean.
- `go test ./...` — all pass.
- New tests in `internal/ui/layout_test.go`: `tabVisualState` coverage for unselected, selected-list-mode, Circ detail, C-Mail detail, Guilds browsing, Topics browsing, and PostDetail credited to its origin tab (spot-checked via Feed and Guilds) — plus rendered-output checks that the `›`/`▷` markers appear and disappear correctly in both layouts.

## Docs

`docs/02-menu-bar-navigation.md` updated to describe the new marker and `tabVisualState`.
