### PR TITLE
feat: fix PostDetail left/right cycling and persist it across tab switches

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -381,11 +381,13 @@ Single post with all its replies in a scrollable pager.
 - `j`/`k` (or arrows) navigate/select post or individual replies
 - `r` on a selected item opens the compose box (top-level or nested reply)
 - `d` on the selected item (own post or own reply) shows a y/n confirmation overlay; on `y` emits `DeletePostMsg` or `DeleteReplyMsg`
-- ESC emits `BackToFeedMsg` → App returns to feed
+- ESC emits `BackToFeedMsg` → App returns to `postDetailReturn` (whichever of the 7 origins — Feed, Profile, Bookmarks, Guilds, Topics, Notifications, Search — opened the post) and closes it (`PostDetailModel.Close()`)
 - `ScrollToReply(replyID)` scrolls to a specific reply (used by Notifications to deep-link)
+- **Persists across tab switches**: switching away from PostDetail (any nav key) no longer closes it — `PostDetailModel.SetPost` (the only thing that resets its state) isn't called again until a *different* post is opened, so the open post, its scroll position, and any in-progress reply draft just sit there until you come back. `activateScreen` (`layout.go`) checks `PostDetailModel.HasPost()`: landing on the origin tab *from elsewhere* resumes the post instead of showing that tab's own list; re-navigating to the origin tab *from PostDetail itself* (its own key/chord, or plain/ctrl `←`/`→` landing back on it, though cycling never does in one step — see `tabIndexOf`) is the escape hatch that actually closes it, matching Circ/C-Mail's re-press-the-tab-key convention. If the post was opened from inside a browsed Guild/Topic, closing it lands back on that same guild/topic, not the top-level list — Guilds/Topics' own browse state is untouched throughout, and PostDetail's check runs first in `activateScreen` so it "wins" while open. Mirrors Circ's background-room persistence (`docs/33-circ.md`) but architecturally simpler: pure REST content, no live subscription to keep alive. The tab-bar/nav "in detail" marker (`docs/02-menu-bar-navigation.md`) reflects this the same way it does for Circ/Guilds/Topics.
+- Plain `←`/`→` cycle tabs from PostDetail exactly like `ctrl+←`/`ctrl+→` already did (previously excluded — a live bug, not intentional). Cycling's tab-position lookup (`tabIndexOf`) resolves `screenPostDetail` to `postDetailReturn`'s position rather than defaulting to Feed's, so cycling away is anchored to wherever the post was actually opened from.
 
 Key types: `PostDetailModel`, `BackToFeedMsg`, `SubmitReplyMsg` (postID, parentReplyID, content), `DeletePostMsg`, `DeleteReplyMsg`  
-Key methods: `SetCurrentUsername(username)`, `RemoveReply(replyID)`
+Key methods: `SetCurrentUsername(username)`, `RemoveReply(replyID)`, `HasPost()`, `Close()`
 
 #### `profile.go`
 

--- a/docs/02-menu-bar-navigation.md
+++ b/docs/02-menu-bar-navigation.md
@@ -50,24 +50,24 @@ only ever supposed to be entered focused.
   open (indistinguishable from a tab never visited), and Guilds/Topics had no
   equivalent signal at all.
   - **The marker shows even while the tab isn't selected**, for Circ,
-    Guilds, and Topics specifically — their detail state is genuinely still
+    Guilds, Topics, and PostDetail — their detail state is genuinely still
     live/persisted in the background: an open Circ room keeps its RTDB
     subscription streaming regardless of the active tab (`docs/33-circ.md`),
-    and Guilds/Topics' browse state is simply never reset by `activateScreen`
-    on tab-away. The marker's color follows `selected` (bright/active when
-    you're looking at that tab, the tab's ordinary dim/inactive color when
-    it's open elsewhere) rather than a different glyph, so "you're here" and
-    "it's open elsewhere" read as the same kind of state at different
-    brightness, not two unrelated indicators.
-  - **C-Mail and PostDetail are selected-only** — deliberately excluded from
-    the background case. `CMailModel.CancelSubscription()` (tab-away) tears
-    the conversation's subscription down immediately but doesn't reset
-    `m.mode`, which lingers as `cmailModeDetail` (stale, not live) until the
-    next `ResetToList()`; showing a marker off that stale field would
-    misrepresent an already-closed conversation as still open — C-Mail's
-    real "something happened" signal is the aggregate unread badge across
-    all conversations, not one left-open thread. PostDetail has no
-    background resumption at all — leaving it abandons it entirely.
+    Guilds/Topics' browse state is simply never reset by `activateScreen` on
+    tab-away, and an open post (`PostDetailModel.HasPost()`) stays open until
+    explicitly closed (see below). The marker's color follows `selected`
+    (bright/active when you're looking at that tab, the tab's ordinary
+    dim/inactive color when it's open elsewhere) rather than a different
+    glyph, so "you're here" and "it's open elsewhere" read as the same kind
+    of state at different brightness, not two unrelated indicators.
+  - **C-Mail alone is selected-only** — deliberately excluded from the
+    background case. `CMailModel.CancelSubscription()` (tab-away) tears the
+    conversation's subscription down immediately but doesn't reset `m.mode`,
+    which lingers as `cmailModeDetail` (stale, not live) until the next
+    `ResetToList()`; showing a marker off that stale field would misrepresent
+    an already-closed conversation as still open — C-Mail's real "something
+    happened" signal is the aggregate unread badge across all conversations,
+    not one left-open thread.
 - All tabs are the same height — no layout jumping on tab change
 
 ## Navigation
@@ -81,6 +81,8 @@ only ever supposed to be entered focused.
 Arrow keys and the numeric/leader jumps are blocked from tab navigation when a text input is focused (CIRC, C-Mail, Search's query box, compose panels) so typing works normally in those screens.
 
 **Exception — plain `←`/`→` out of an empty Circ compose box:** since a backgrounded Circ room resumes detail mode (and its always-focused compose input) directly on tab-return rather than dropping to the room list, the very first `←`/`→` after switching back would otherwise be swallowed into a box the user never asked to type into. `app.go`'s focused-input gate (`handleKeys`) lets plain `←`/`→` fall through to tab-cycling specifically when `ChatroomsModel.ComposeEmpty()` is true; with any text in the box (typed just now, or a draft left over from before backgrounding) it's captured for cursor movement as usual, and `ctrl+←`/`ctrl+→` remains the general-purpose way out. See `docs/33-circ.md`'s keyboard shortcuts table.
+
+**PostDetail cycles like any other screen:** plain `←`/`→` now cycle tabs from PostDetail exactly like `ctrl+←`/`ctrl+→` already did — the earlier `a.active != screenPostDetail` exclusion in `TabsLayout.HandleNav` was a live bug, not intentional (`screenPostDetail` isn't itself a tab, so it was never meant to be excluded from cycling, just absent from `visibleTabs()`). `tabIndexOf` resolves `screenPostDetail` to `postDetailReturn`'s position rather than defaulting to Feed's, so cycling away is anchored to wherever the post was actually opened from — and since cycling always moves to a *different* tab, it can never itself land back on the origin in one step, so it never triggers PostDetail's close-on-return-to-origin escape hatch (see `docs/00-project-reference.md`'s `postdetail.go` section).
 
 ## Status Bar
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -774,6 +774,7 @@ func (a App) handlePostDetail(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, a.loadRepliesCmd(msg.postID), true
 	case screens.BackToFeedMsg:
 		a.active = a.postDetailReturn
+		a.postDetail = a.postDetail.Close()
 		return a, nil, true
 	case screens.ShowUserProfileMsg:
 		if a.active != screenPostDetail {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -636,6 +636,125 @@ func TestShowSearchReplyMsg_NavigatesToPostDetailAndScrollsToReply(t *testing.T)
 	}
 }
 
+// --- PostDetail persists across tab switches ---
+//
+// Mirrors Circ's background-room persistence (PR #58): a post left open
+// (not explicitly closed) resumes automatically when navigation lands back
+// on the tab it was opened from, instead of showing that tab's own list.
+// Re-navigating to the origin tab *from PostDetail itself* is the escape
+// hatch that actually closes it — same convention as Circ/C-Mail's
+// re-press-the-tab-key pattern.
+
+func openPostFrom(a App, origin screen) App {
+	a.active = screenPostDetail
+	a.postDetailReturn = origin
+	a.postDetail = a.postDetail.SetPost(model.Post{ID: "p1"})
+	return a
+}
+
+func TestActivateScreen_PostDetail_ResumesOnReturnToOrigin(t *testing.T) {
+	a := openPostFrom(loggedInApp(), screenBookmarks)
+
+	a, _ = activateScreen(a, screenFeed) // jump to an unrelated tab
+	if a.active != screenFeed {
+		t.Fatalf("setup: expected screenFeed, got %v", a.active)
+	}
+	if !a.postDetail.HasPost() {
+		t.Error("expected the post to stay open in the background after switching to an unrelated tab")
+	}
+
+	a, _ = activateScreen(a, screenBookmarks) // return to the origin
+	if a.active != screenPostDetail {
+		t.Errorf("expected returning to Bookmarks to resume PostDetail, got %v", a.active)
+	}
+	if !a.postDetail.HasPost() {
+		t.Error("expected the post to still be open after resuming")
+	}
+}
+
+func TestActivateScreen_PostDetail_ClosesViaOriginTabEscapeHatch(t *testing.T) {
+	a := openPostFrom(loggedInApp(), screenBookmarks)
+
+	a, _ = activateScreen(a, screenBookmarks) // re-press Bookmarks' own key from PostDetail
+	if a.active != screenBookmarks {
+		t.Errorf("expected the escape hatch to land on Bookmarks' list, got %v", a.active)
+	}
+	if a.postDetail.HasPost() {
+		t.Error("expected the post to be closed after using the escape hatch")
+	}
+}
+
+func TestHandlePostDetail_Esc_ClosesPost(t *testing.T) {
+	a := openPostFrom(loggedInApp(), screenBookmarks)
+
+	m, _ := a.Update(screens.BackToFeedMsg{})
+	a2 := m.(App)
+	if a2.active != screenBookmarks {
+		t.Errorf("expected esc to return to Bookmarks, got %v", a2.active)
+	}
+	if a2.postDetail.HasPost() {
+		t.Error("expected esc to close the post")
+	}
+}
+
+func TestActivateScreen_PostDetail_ClosingLeavesBrowsedGuildIntact(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenGuilds
+	a.guilds = a.guilds.SetGuilds([]model.Guild{{ID: "g1", Name: "Alpha", Slug: "alpha"}}, "")
+	gm, _ := a.guilds.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a.guilds = gm
+	if !a.guilds.IsBrowsingGuild() {
+		t.Fatal("setup: expected to be browsing a guild")
+	}
+
+	a = openPostFrom(a, screenGuilds) // open a post from within that guild
+
+	a, _ = activateScreen(a, screenGuilds) // close it via the escape hatch
+	if a.active != screenGuilds {
+		t.Fatalf("expected escape hatch to land on Guilds, got %v", a.active)
+	}
+	if a.postDetail.HasPost() {
+		t.Error("expected the post to be closed")
+	}
+	if !a.guilds.IsBrowsingGuild() {
+		t.Error("expected closing the post to still show the browsed guild, not the guild list — Guilds' own browse state is untouched by PostDetail")
+	}
+}
+
+func TestHandleKeys_Left_CyclesTabs_FromPostDetail(t *testing.T) {
+	a := openPostFrom(loggedInApp(), screenBookmarks)
+	before := tabIndexOf(a)
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyLeft})
+	if !consumed {
+		t.Error("expected plain left arrow to be consumed (tab-cycle) from PostDetail")
+	}
+	if tabIndexOf(a2) == before {
+		t.Error("expected plain left arrow to cycle to a different tab")
+	}
+}
+
+func TestHandleKeys_Right_CyclesTabs_FromPostDetail(t *testing.T) {
+	a := openPostFrom(loggedInApp(), screenBookmarks)
+	before := tabIndexOf(a)
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyRight})
+	if !consumed {
+		t.Error("expected plain right arrow to be consumed (tab-cycle) from PostDetail")
+	}
+	if tabIndexOf(a2) == before {
+		t.Error("expected plain right arrow to cycle to a different tab")
+	}
+}
+
+func TestTabIndexOf_PostDetail_AnchorsOnOriginNotFeed(t *testing.T) {
+	a := openPostFrom(loggedInApp(), screenBookmarks)
+
+	got := tabIndexOf(a)
+	want := tabIndexOf(App{active: screenBookmarks})
+	if got != want {
+		t.Errorf("tabIndexOf(PostDetail from Bookmarks) = %d, want %d (Bookmarks' own position)", got, want)
+	}
+}
+
 // TestHandleKeys_EscBlursSearchQuery_ThenQuitWorks reproduces the reported
 // bug: after opening Search, esc must be able to blur the query box so 'q'
 // (and tab navigation) work again — this held even when a search failed,

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -107,18 +107,20 @@ func visibleTabs() []navTab {
 // MillerLayout call this so the two layouts can never disagree about which
 // state a tab is in.
 //
-// detail is reported even while t isn't selected for Circ/Guilds/Topics,
-// since their detail state is genuinely still live in the background: Circ's
-// open room keeps its RTDB subscription streaming regardless of the active
-// tab (see IsRoomStreamMsg in app.go), and Guilds/Topics' browse state is
-// simply never reset by activateScreen on tab-away. C-Mail and PostDetail are
-// selected-only instead: CMailModel.CancelSubscription (tab-away) tears the
-// conversation's subscription down immediately but doesn't reset m.mode, so
-// it lingers as cmailModeDetail — stale, not live — until the next
-// ResetToList(); surfacing that in the background would claim a conversation
-// is still open when it's already been torn down (C-Mail's actual "something
-// happened" signal is the aggregate unread badge, not a left-open
-// conversation). PostDetail has no background resumption at all.
+// detail is reported even while t isn't selected for Circ/Guilds/Topics/
+// PostDetail, since their detail state is genuinely still live/persisted in
+// the background: Circ's open room keeps its RTDB subscription streaming
+// regardless of the active tab (see IsRoomStreamMsg in app.go), Guilds/
+// Topics' browse state is simply never reset by activateScreen on tab-away,
+// and a post opened via t stays open (PostDetailModel.HasPost) until closed
+// via Esc or re-navigating to t from PostDetail itself (activateScreen's
+// escape hatch). C-Mail alone is selected-only:
+// CMailModel.CancelSubscription (tab-away) tears the conversation's
+// subscription down immediately but doesn't reset m.mode, so it lingers as
+// cmailModeDetail — stale, not live — until the next ResetToList();
+// surfacing that in the background would claim a conversation is still open
+// when it's already been torn down (C-Mail's actual "something happened"
+// signal is the aggregate unread badge, not a left-open conversation).
 func tabVisualState(a App, t screen) (selected, detail bool) {
 	selected = a.active == t || (a.active == screenPostDetail && a.postDetailReturn == t)
 
@@ -132,7 +134,7 @@ func tabVisualState(a App, t screen) (selected, detail bool) {
 	case screenCMail:
 		detail = selected && a.cmail.IsShowingDetail()
 	}
-	if selected && a.active == screenPostDetail {
+	if a.postDetail.HasPost() && a.postDetailReturn == t {
 		detail = true
 	}
 	return selected, detail
@@ -220,9 +222,17 @@ func themeIndex(name string) int {
 // 0. a.active won't normally be a hidden screen (Search) here, since
 // navigateTabBy — the only caller — is a no-op while Search is active; if it
 // ever is, this defaults to 0 (Feed) same as any other not-found screen.
+// screenPostDetail isn't itself a tab either, so it resolves to
+// postDetailReturn instead — otherwise cycling away from PostDetail would
+// always be anchored to Feed's position rather than wherever the post was
+// actually opened from.
 func tabIndexOf(a App) int {
+	active := a.active
+	if active == screenPostDetail {
+		active = a.postDetailReturn
+	}
 	for i, t := range visibleTabs() {
-		if t.s == a.active {
+		if t.s == active {
 			return i
 		}
 	}
@@ -296,6 +306,20 @@ func activateScreen(a App, s screen) (App, tea.Cmd) {
 		a.chatrooms = a.chatrooms.SetFocused(false)
 	}
 	prev := a.active
+	// A post left open (see PostDetailModel.HasPost) resumes automatically
+	// when navigation lands back on the tab it was opened from — mirrors
+	// Circ's background-room persistence. Re-navigating to that same tab
+	// *from PostDetail itself* (prev == screenPostDetail) is instead the
+	// explicit "close and show the list" escape hatch, matching Circ/C-Mail's
+	// re-press-the-tab-key convention. Cycling can never land exactly back on
+	// the origin tab in one step (see tabIndexOf), so it only ever hits the
+	// resume branch, never the close one.
+	if prev == screenPostDetail && s == a.postDetailReturn {
+		a.postDetail = a.postDetail.Close()
+	} else if prev != screenPostDetail && s == a.postDetailReturn && a.postDetail.HasPost() {
+		a.active = screenPostDetail
+		return a, nil
+	}
 	a.active = s
 	if a.active == screenSearch && prev != screenSearch {
 		a.searchReturn = prev

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -110,13 +110,17 @@ func (l TabsLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {
 	}
 	switch msg.String() {
 	case "left":
-		if a.active != screenPostDetail && a.focus == focusMenu {
+		// PostDetail used to be excluded here, forcing ctrl+left to leave it —
+		// now it cycles the same as everywhere else (tabIndexOf anchors on
+		// postDetailReturn, so this never lands back on the origin tab in one
+		// step; see activateScreen's escape hatch for how that's reached).
+		if a.focus == focusMenu {
 			var cmd tea.Cmd
 			a, cmd = navigateTabBy(a, -1)
 			return a, cmd, true
 		}
 	case "right":
-		if a.active != screenPostDetail && a.focus == focusMenu {
+		if a.focus == focusMenu {
 			var cmd tea.Cmd
 			a, cmd = navigateTabBy(a, +1)
 			return a, cmd, true

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -234,6 +234,7 @@ func TestTabVisualState_PostDetail_CreditsOriginTab(t *testing.T) {
 		a := loggedInApp()
 		a.active = screenPostDetail
 		a.postDetailReturn = origin
+		a.postDetail = a.postDetail.SetPost(model.Post{ID: "p1"})
 
 		selected, detail := tabVisualState(a, origin)
 		if !selected || !detail {
@@ -249,6 +250,23 @@ func TestTabVisualState_PostDetail_CreditsOriginTab(t *testing.T) {
 		if selected || detail {
 			t.Errorf("origin %v, other tab %v: selected=%v detail=%v, want false,false", origin, other, selected, detail)
 		}
+	}
+}
+
+func TestTabVisualState_PostDetail_PersistsWhenBackgrounded(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenPostDetail
+	a.postDetailReturn = screenBookmarks
+	a.postDetail = a.postDetail.SetPost(model.Post{ID: "p1"})
+
+	a.active = screenFeed // background PostDetail
+
+	selected, detail := tabVisualState(a, screenBookmarks)
+	if selected {
+		t.Error("expected Bookmarks to not be selected after switching to Feed")
+	}
+	if !detail {
+		t.Error("expected Bookmarks to still report detail=true — the post stays open in the background")
 	}
 }
 

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -154,6 +154,33 @@ func (m PostDetailModel) SetPost(post model.Post) PostDetailModel {
 	return m
 }
 
+// HasPost reports whether a post is currently open or persisted in the
+// background — used by activateScreen to decide whether returning to the
+// origin tab should resume it instead of that tab's own list.
+func (m PostDetailModel) HasPost() bool { return m.post.ID != "" }
+
+// Close resets PostDetailModel back to "no post open" — called on Esc or on
+// re-navigating to the post's own origin tab (the escape hatch out of a
+// persisted PostDetail — see activateScreen). Preserves layout/broadcast-only
+// fields (width/height/ready/relaxed/loc/timeDisplayFormat/currentUsername/
+// the bookmark+watch ID sets) since those aren't re-supplied by the next
+// SetPost either — only the SetPost-adjacent fields plus compose/confirming
+// (which SetPost itself doesn't reset) are cleared.
+func (m PostDetailModel) Close() PostDetailModel {
+	m.post = model.Post{}
+	m.replies = nil
+	m.flatTree = nil
+	m.replyOffsets = nil
+	m.replyHeights = nil
+	m.postHeight = 0
+	m.selectedReply = -1
+	m.loading = false
+	m.err = nil
+	m.compose = m.compose.Close()
+	m.confirming = pdConfirmNone
+	return m
+}
+
 func (m PostDetailModel) SetReplies(replies []model.Reply) PostDetailModel {
 	m.selectedReply = -1 // keep post selected after replies load
 	m.loading = false


### PR DESCRIPTION
## What

Two related PostDetail navigation fixes:

1. Plain `←`/`→` now cycle tabs from PostDetail, matching `ctrl+←`/`ctrl+→` (previously dead — an explicit, unintentional exclusion in `TabsLayout.HandleNav`).
2. PostDetail now persists across tab switches: a post left open (not explicitly closed) resumes automatically when navigation returns to the tab it was opened from, instead of showing that tab's own list.

## Why

Reported: left/right didn't work in PostDetail even though ctrl+left/right did. While fixing that, found the underlying tab-cycling position lookup (`tabIndexOf`) didn't know about `postDetailReturn` either, so cycling away from PostDetail was always anchored to Feed's position instead of wherever the post was actually opened from. Discussing the fix surfaced a natural follow-up: mirror Circ's background-room persistence (PR #58) for PostDetail too, since there was no real reason for it not to.

## How

- `PostDetailModel.HasPost()`/`.Close()` (`internal/ui/screens/postdetail.go`) — whether a post is open, and resetting back to "none" (post/replies/compose/confirm state; layout/broadcast-only fields like `loc`/`currentUsername`/bookmark ID sets are preserved since `SetPost` doesn't touch them either).
- `tabIndexOf` (`internal/ui/layout.go`) resolves `screenPostDetail` to `postDetailReturn`'s position instead of defaulting to Feed's.
- `activateScreen` (`internal/ui/layout.go`) checks `HasPost()`: landing on the origin tab from elsewhere resumes PostDetail; re-navigating to the origin tab *from PostDetail itself* (its own key/chord) closes it — the escape hatch, mirroring Circ/C-Mail's re-press-the-tab-key convention. Cycling can never land back on the origin in one step, so it never accidentally triggers the close path.
- A post opened from inside a browsed Guild/Topic resumes that guild/topic on close, since the PostDetail check runs first in `activateScreen` and Guilds/Topics' own (already-persistent) browse state is untouched throughout.
- `handlePostDetail`'s Esc handler (`BackToFeedMsg`) also calls `Close()`.
- `TabsLayout.HandleNav`'s plain `←`/`→` cases drop the `screenPostDetail` exclusion.
- `tabVisualState` extends the PR #59 tab-bar "in detail" marker to PostDetail, consistent with Circ/Guilds/Topics' background-visible treatment (C-Mail remains selected-only, unchanged).

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean.
- `go test ./...` — all pass.
- New tests cover: plain left/right cycling from PostDetail; `tabIndexOf` anchoring on `postDetailReturn`; resume-on-return; close-via-escape-hatch; Esc closing; the Guilds-interaction case (closing a post opened from a browsed guild leaves that guild browsed, not the guild list); `tabVisualState` background persistence for PostDetail.

## Docs

`docs/00-project-reference.md` and `docs/02-menu-bar-navigation.md` updated.
