### PR TITLE
fix: guard profile tab pagination against duplicate in-flight fetches

### DIFF
--- a/internal/ui/screens/profile.go
+++ b/internal/ui/screens/profile.go
@@ -72,6 +72,7 @@ const tabItemLines = 3
 type tabScrollMeta struct {
 	cursor    string
 	loaded    bool
+	loading   bool // true while a next-page fetch is in flight
 	exhausted bool
 	top       int // first visible item index (scroll offset)
 }
@@ -228,6 +229,7 @@ func (m ProfileModel) AppendUserPosts(posts []model.Post, cursor string) Profile
 	m.posts = append(m.posts, posts...)
 	m.tabMeta[tabPosts].cursor = cursor
 	m.tabMeta[tabPosts].exhausted = cursor == ""
+	m.tabMeta[tabPosts].loading = false
 	return m
 }
 
@@ -245,6 +247,7 @@ func (m ProfileModel) AppendUserReplies(replies []model.Reply, cursor string) Pr
 	m.replies = append(m.replies, replies...)
 	m.tabMeta[tabReplies].cursor = cursor
 	m.tabMeta[tabReplies].exhausted = cursor == ""
+	m.tabMeta[tabReplies].loading = false
 	return m
 }
 
@@ -262,6 +265,7 @@ func (m ProfileModel) AppendUserFollowing(follows []model.Follow, cursor string)
 	m.following = append(m.following, follows...)
 	m.tabMeta[tabFollowing].cursor = cursor
 	m.tabMeta[tabFollowing].exhausted = cursor == ""
+	m.tabMeta[tabFollowing].loading = false
 	return m
 }
 
@@ -279,6 +283,7 @@ func (m ProfileModel) AppendUserFollowers(follows []model.Follow, cursor string)
 	m.followers = append(m.followers, follows...)
 	m.tabMeta[tabFollowers].cursor = cursor
 	m.tabMeta[tabFollowers].exhausted = cursor == ""
+	m.tabMeta[tabFollowers].loading = false
 	return m
 }
 
@@ -472,7 +477,7 @@ func (m ProfileModel) moveTabSelection(delta int) (ProfileModel, tea.Cmd) {
 	// Check for pagination near the bottom of the list.
 	var pageCmd tea.Cmd
 	if m.tabSelected >= n-3 {
-		pageCmd = m.loadMoreCmd()
+		m, pageCmd = m.loadMoreCmd()
 	}
 	return m, pageCmd
 }
@@ -486,28 +491,35 @@ func (m ProfileModel) setScrollTopForActiveTab(top int) ProfileModel {
 	return m
 }
 
-// loadMoreCmd returns a pagination command if the active tab has more pages.
-func (m ProfileModel) loadMoreCmd() tea.Cmd {
+// loadMoreCmd returns a pagination command if the active tab has more pages
+// and no fetch for it is already in flight.
+func (m ProfileModel) loadMoreCmd() (ProfileModel, tea.Cmd) {
 	meta := m.tabMeta[m.activeTab]
-	if meta.exhausted || meta.cursor == "" {
-		return nil
+	if meta.loading || meta.exhausted || meta.cursor == "" {
+		return m, nil
 	}
 	cursor := meta.cursor
+
+	var cmd tea.Cmd
 	switch m.activeTab {
 	case tabPosts:
 		username := m.user.Username
-		return func() tea.Msg { return LoadMoreUserPostsMsg{Username: username, Cursor: cursor} }
+		cmd = func() tea.Msg { return LoadMoreUserPostsMsg{Username: username, Cursor: cursor} }
 	case tabReplies:
 		username := m.user.Username
-		return func() tea.Msg { return LoadMoreUserRepliesMsg{Username: username, Cursor: cursor} }
+		cmd = func() tea.Msg { return LoadMoreUserRepliesMsg{Username: username, Cursor: cursor} }
 	case tabFollowing:
 		userID := m.user.ID
-		return func() tea.Msg { return LoadMoreUserFollowingMsg{UserID: userID, Cursor: cursor} }
+		cmd = func() tea.Msg { return LoadMoreUserFollowingMsg{UserID: userID, Cursor: cursor} }
 	case tabFollowers:
 		userID := m.user.ID
-		return func() tea.Msg { return LoadMoreUserFollowersMsg{UserID: userID, Cursor: cursor} }
+		cmd = func() tea.Msg { return LoadMoreUserFollowersMsg{UserID: userID, Cursor: cursor} }
+	default:
+		return m, nil
 	}
-	return nil
+
+	m.tabMeta[m.activeTab].loading = true
+	return m, cmd
 }
 
 // handleTabEnter activates the selected item in a list tab.

--- a/internal/ui/screens/profile_test.go
+++ b/internal/ui/screens/profile_test.go
@@ -382,3 +382,47 @@ func TestProfile_FilterNSFW_Off_ShowsAll(t *testing.T) {
 		t.Errorf("expected pp2 (nsfw), got %s", sp.Post.ID)
 	}
 }
+
+// --- pagination in-flight guard ---
+
+// TestProfile_LoadMore_SkipsWhileInFlight reproduces repeated down-presses
+// near the bottom of a list tab (arrow-repeat / held key). Without an
+// in-flight guard, each press re-dispatches a LoadMore*Msg carrying the same
+// stale cursor before the first request's response lands, causing the
+// eventual responses to be appended more than once (duplicate items).
+func TestProfile_LoadMore_SkipsWhileInFlight(t *testing.T) {
+	posts := []model.Post{
+		{ID: "pp1", AuthorUsername: "ragnar", Content: "one"},
+		{ID: "pp2", AuthorUsername: "ragnar", Content: "two"},
+		{ID: "pp3", AuthorUsername: "ragnar", Content: "three"},
+		{ID: "pp4", AuthorUsername: "ragnar", Content: "four"},
+		{ID: "pp5", AuthorUsername: "ragnar", Content: "five"},
+		{ID: "pp6", AuthorUsername: "ragnar", Content: "six"},
+	}
+	m := screens.NewProfileModel().SetUser(testUser()).SetReadOnly(true)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m = m.SetUserPosts(posts, "next-cursor") // non-empty cursor: more pages available
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	// Move to the last 3 items (n-3) to enter pagination range, then keep
+	// pressing down as if the key were held/repeated.
+	var cmds []tea.Cmd
+	for i := 0; i < 5; i++ {
+		var cmd tea.Cmd
+		m, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+		cmds = append(cmds, cmd)
+	}
+
+	fired := 0
+	for _, cmd := range cmds {
+		if cmd == nil {
+			continue
+		}
+		if _, ok := cmd().(screens.LoadMoreUserPostsMsg); ok {
+			fired++
+		}
+	}
+	if fired != 1 {
+		t.Errorf("expected exactly 1 LoadMoreUserPostsMsg while a fetch is in flight, got %d", fired)
+	}
+}


### PR DESCRIPTION
﻿## Bug

Paging down through a Profile list tab (Posts/Replies/Following/Followers) could show already-seen posts reappearing. The Feed screen was not affected.

## Root cause

`ProfileModel`'s `tabScrollMeta` had no in-flight-request guard. `moveTabSelection` fired a new pagination fetch on every down-press once the selection was within 3 items of the list end, but the pagination cursor only advances once a response arrives. Rapid/held down-presses near the bottom dispatched multiple `LoadMore*Msg` requests carrying the same stale cursor before the first response landed; each response was appended with no dedup, producing duplicate items.

`FeedModel` already avoids this with a `loading` flag set before the fetch command fires and cleared once the page result is applied.

## Fix

Added the same `loading` guard to `tabScrollMeta`, covering all four Profile list tabs (Posts, Replies, Following, Followers) in one place (`loadMoreCmd` / `AppendUser*`).

## Testing

- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./internal/ui/screens/...`
- Added `TestProfile_LoadMore_SkipsWhileInFlight`, reproducing rapid down-presses near the bottom of a list and asserting only one pagination fetch fires while a request is in flight.

## Known follow-up (pre-existing, not introduced by this change)

Neither Profile nor Feed clears their `loading` flag on a failed page fetch — a network error mid-pagination would stall further paging on that tab until reload. Flagging for `docs/00-api-backlog.md` if worth tracking separately.
