### PR TITLE
feat: add post/reply/message flagging and cIRC message delete

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -144,13 +144,13 @@ Both cIRC and C-Mail support IRC-style slash commands expanded server-side: `/me
 |---|---|---|---|
 | `/v1/posts/:id/flag` | POST | Report a post | **Done** — `!` key in Feed and Post Detail; see `docs/35-flagging.md` |
 | `/v1/replies/:id/flag` | POST | Report a reply | **Done** — `!` key in Post Detail; see `docs/35-flagging.md` |
-| `/v1/circ/:roomId/messages/:messageId/flag` | POST | Report a cIRC message | Deferred — needs per-message navigation in cIRC first |
+| `/v1/circ/:roomId/messages/:messageId/flag` | POST | Report a cIRC message | **Done** — `!` while browsing messages (`up`/`down`); see `docs/36-circ-message-flagging.md` |
 
 ### cIRC message delete (new in v0.8)
 
 | Endpoint | Method | Description | Priority |
 |---|---|---|---|
-| `/v1/circ/:roomId/messages/:messageId` | DELETE | Soft-delete own cIRC message (`content` → `[DELETED]`, attachments stripped); arrives to other clients as an RTDB `patch`, not a new message | Not implemented |
+| `/v1/circ/:roomId/messages/:messageId` | DELETE | Soft-delete own cIRC message (`content` → `[DELETED]`, attachments stripped); arrives to other clients as an RTDB `patch`, not a new message | **Done** — `d` while browsing messages (own messages only), with live propagation to other clients via the now-handled RTDB `patch` event; see `docs/36-circ-message-flagging.md` |
 
 ### Message attachments & styles (new in v0.8)
 

--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -142,9 +142,9 @@ Both cIRC and C-Mail support IRC-style slash commands expanded server-side: `/me
 
 | Endpoint | Method | Description | Priority |
 |---|---|---|---|
-| `/v1/posts/:id/flag` | POST | Report a post | Not implemented |
-| `/v1/replies/:id/flag` | POST | Report a reply | Not implemented |
-| `/v1/circ/:roomId/messages/:messageId/flag` | POST | Report a cIRC message | Not implemented |
+| `/v1/posts/:id/flag` | POST | Report a post | **Done** — `!` key in Feed and Post Detail; see `docs/35-flagging.md` |
+| `/v1/replies/:id/flag` | POST | Report a reply | **Done** — `!` key in Post Detail; see `docs/35-flagging.md` |
+| `/v1/circ/:roomId/messages/:messageId/flag` | POST | Report a cIRC message | Deferred — needs per-message navigation in cIRC first |
 
 ### cIRC message delete (new in v0.8)
 

--- a/docs/35-flagging.md
+++ b/docs/35-flagging.md
@@ -1,0 +1,27 @@
+# Feature 35: Flagging / reporting (posts and replies)
+
+Report a post or reply for moderation review (`POST /v1/posts/:id/flag`, `POST /v1/replies/:id/flag`, API v0.8). cIRC message flagging is out of scope for this feature — it needs per-message navigation in cIRC first.
+
+## Entry point
+
+`!` on the selected post (Feed, Post Detail) or the selected reply (Post Detail). Blocked with no key effect on your own content — the API returns `403` for a self-report and the client never sends the request.
+
+## Flow
+
+`FlagPrompt` (`internal/ui/screens/flagprompt.go`) is a small two-step overlay shared by `FeedModel` and `PostDetailModel`:
+
+1. **Reason** — a single-line `textinput.Model` (max 500 chars, optional). `enter` moves to the confirm step with whatever was typed (blank is fine); `esc` cancels the whole flow.
+2. **Confirm** — shows the typed reason (or "(no reason)") and asks `[y]es` / `[n]o back`. `y` submits; `n` returns to editing the reason; `esc` cancels.
+
+There is no confirmation step before the reason box appears — pressing `!` goes straight to typing, matching the no-confirm feel of bookmark/watch. The confirm step sits right before the irreversible, un-withdrawable send.
+
+On submit, `FeedModel`/`PostDetailModel` emit `FlagPostMsg{PostID, Reason}` or `FlagReplyMsg{ReplyID, PostID, Reason}` (`messages.go`). `App` (`app.go`) routes these to `flagPostCmd`/`flagReplyCmd`, which call the API and show a transient global banner: "reported" or "already reported" (the API is idempotent — reporting the same content twice returns `alreadyFlagged: true` instead of an error).
+
+## API / model
+
+- `api.Client` gained `FlagPost(postID, reason string) (flagID string, alreadyFlagged bool, err error)` and `FlagReply(replyID, reason string) (...)` — both POST a `{reason}` body and parse `{flagId, alreadyFlagged}` from the response, mirroring `CreateBookmark`.
+- No new model fields: the API doesn't return flag status on `GET`, so there's nothing to persist client-side. Each `!` press is a fire-and-forget call; the banner is the only feedback.
+
+## Not covered here
+
+- cIRC message flagging (`POST /v1/circ/:roomId/messages/:messageId/flag`) — deferred until cIRC has per-message selection/navigation.

--- a/docs/36-circ-message-flagging.md
+++ b/docs/36-circ-message-flagging.md
@@ -1,0 +1,51 @@
+# Feature 36: cIRC message selection, flagging, and delete
+
+Per-message navigation in cIRC chat rooms, flagging a selected message for moderation review (`POST /v1/circ/:roomId/messages/:messageId/flag`, API v0.8), and deleting your own message (`DELETE /v1/circ/:roomId/messages/:messageId`). This is the message-level counterpart to `docs/35-flagging.md`'s post/reply flagging.
+
+## The problem
+
+cIRC's compose box is always focused the moment a room is open (unlike Feed/Post Detail, where compose is a separate panel you explicitly open) — so an action key like `!` risks being typed into a message instead of triggering an action. Two alternatives were rejected: a brand-new control key (breaks consistency with the `!` used elsewhere) and gating `!`/`d` on "input is currently empty" (silently steals the ability to start a message with a literal `!`, and would be much worse for `d` — a very common English sentence-starter).
+
+## Design
+
+Entry/exit are anchored to keys already meaningful in this context, not an arbitrary toggle:
+
+- **`up`** from the normal typing state (`selectedMsgID == ""`, the sentinel): if there's at least one selectable message, blurs the compose input, selects the newest one, and scrolls it into view. If there's nothing selectable, falls back to the old raw scroll-by-one-line.
+- **While browsing** (`selectedMsgID != ""`): `up`/`down` move the selection (via `millerPageNav`, the same pager math `PostDetailModel` uses for replies); `!` reports the selected message; `d` deletes it (own messages only); `esc` clears the selection and refocuses the input; anything else is swallowed rather than typed. Both `!` and `d` no-op on an already-deleted (tombstoned) message.
+- **`down`** past the newest selectable message exits browsing the same way `esc` does — "scrolled back to live" means "back to typing."
+
+This works because `bubbles/textinput.Update` already no-ops on any key while blurred (verified against its source) — blurring on entering "browsing" is the actual mechanism that prevents `!`/`d` (or anything else) from being typed, not a heuristic. `Blur()`/`Focus()` never touch the input's value, so an in-progress draft survives a trip into history and back untouched. Typing in the normal state is completely unrestricted: every key, including `!`, types exactly as it always has.
+
+Selection is tracked by the message's **ID**, not a slice index — `PrependMessages` splices older history onto the *front* of the message list, which would silently invalidate a stored index (replies in `PostDetailModel` only ever append, so that bug class doesn't apply there). This also means delete works cleanly: a message is never removed from the slice (see Delete below), so the selected ID always still resolves.
+
+System notices (locally-injected, e.g. a `/help` reply) have no ID and are never selectable, flaggable, or deletable.
+
+## Bugs found during manual testing (fixed)
+
+Three real bugs surfaced only under live use, not the initial test suite — each got a regression test once understood:
+
+1. **Pagination fired on almost every `up` press.** The older-history fetch was triggered by checking `viewport.AtTop()`, but a room whose content already fits the viewport is trivially "at top" from the moment it renders, regardless of which message is selected. Fixed by only firing the fetch when the selection actually lands on the oldest loaded message (`newPos == 0` / `curPos == 0`), not whenever the raw scroll offset happens to read 0.
+2. **`down` got permanently stuck partway through a long room.** Root cause was in `renderCircMessagesWithSelection`: each message's height was measured with `lipgloss.Height()` (`strings.Count(s, "\n") + 1`), which is correct once for a whole rendered block but wrong per-message-then-summed, since every message already ends in its own `\n`. The inflated, summed offsets slowly desynced from the viewport's real line count until `millerPageNav` and the viewport's own scroll clamp permanently disagreed. Fixed by measuring with `strings.Count(rendered, "\n")` (no phantom `+1`).
+3. **Left/right arrow inside the flag-reason field (and later the delete-confirm box) jumped tabs instead of moving the cursor.** `ChatroomsModel.ComposeEmpty()` — which `app.go` uses to decide whether a bare left/right arrow can escape to tab-cycling — only checked the compose box's own value. Since the compose box is genuinely empty while flagging/deleting, the escape fired even though focus was actually on the overlay. Fixed by making `ComposeEmpty()` also return `false` while `flagPrompt.Active()` or `confirmingDeleteMsg`.
+
+## Visual feedback
+
+The selected message is highlighted with `theme.SelectedRow` (the same style `settings.go` uses for its selected-row highlight) rather than a bordered box — cIRC's tight IRC-log rendering has no per-message bounding box, and a border would look inconsistent with that. The highlight can't simply wrap the normally-colorized message text (the inner `theme.Highlight`/`markdown.RenderInline` calls emit ANSI resets that would cut off an outer background mid-line), so the selected message is stripped back to plain text (`ansi.Strip`) and only that plain text gets the highlight style — same approach `settings.go` uses.
+
+## Flag flow
+
+On `!`, the shared `FlagPrompt` overlay opens with a `FlagKindMessage` kind ("Report this message?"). On submit, `ChatroomsModel` emits `FlagMessageMsg{RoomID, MessageID, Reason}` (`messages.go`). `App` routes it to `flagRoomMessageCmd`, reusing the same `flagErrorMsg`/`flagResultText` helpers posts/replies use — the documented self-report 403 becomes "you can't report your own content," and everything else shows "reported" or "already reported."
+
+## Delete flow
+
+On `d` (own messages only, guarded like flag but the opposite way), a plain y/n confirm opens (`confirmingDeleteMsg`, matching Feed/Post Detail's existing delete-confirm style — no reason field, since there's nothing to type). On confirm, `ChatroomsModel` emits `DeleteRoomMessageMsg{RoomID, MessageID}`, routed to `deleteRoomMessageCmd` → `api.Client.DeleteRoomMessage`. On success, `App` calls `ChatroomsModel.ApplyMessageDeleted(messageID)`.
+
+Delete is a **soft** delete per the API: the message stays in the list (`ApplyMessageDeleted` finds it by ID and sets `Deleted: true` / `Body: "[DELETED]"` in place — it never splices the message out), and renders as a muted tombstone (`renderDeletedTombstone` in `render.go`) that keeps the author and original timestamp but drops the body, action/style flags, and attachments — matching what the API documents ("your name and the original timestamp stay").
+
+**Live propagation to other users.** The API delivers a delete as an RTDB `patch` event, not a new message — `{"content":"[DELETED]","deleted":true}`, with sender/timestamp omitted since they don't change. `SubscribeRoom` previously only handled `put` events; `patch` was silently ignored, so a message would vanish from the sender's own view but never update for anyone else already in the room until they reopened it. Fixed: `SubscribeRoom` now also handles `patch`, and for a delete patch specifically emits a `model.Message` carrying **only** `{ID, Deleted: true}` — never a zeroed-out full message that could be mistaken for a real (if empty) one. `ChatroomsModel`'s `roomReceivedMsg` handler branches on `msg.msg.Deleted`: `true` merges onto the existing message via `ApplyMessageDeleted`, otherwise it's a genuinely new message and goes through the normal `AppendMessage` append path.
+
+## API / model
+
+- `api.Client` gained `FlagRoomMessage(roomID, messageID, reason string) (flagID string, alreadyFlagged bool, err error)` and `DeleteRoomMessage(roomID, messageID string) error`, mirroring `FlagPost`/`FlagReply` and `DeletePost`/`DeleteReply` respectively.
+- `model.Message` gained `Deleted bool` (cIRC only). Populated from REST history (`wireCircMessage.Deleted`) and the RTDB stream (`wireRTDBCircMessage.Deleted`), so a message already deleted before you opened the room also renders as a tombstone.
+- The mock client's live-injected message previously reused one hardcoded ID (`"mock-room-live-1"`) on every delivery; since the app reconnects and redelivers whenever that mock channel closes, a room left open for a while would accumulate several messages sharing one ID — harmless for rendering, but breaks anything keyed by message ID. Fixed to generate a fresh ID per delivery.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -303,6 +303,15 @@ type createBookmarkResponseData struct {
 	BookmarkID string `json:"bookmarkId"`
 }
 
+type flagRequest struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+type flagResponseData struct {
+	FlagID         string `json:"flagId"`
+	AlreadyFlagged bool   `json:"alreadyFlagged"`
+}
+
 type createPostRequest struct {
 	Content  string   `json:"content"`
 	Title    string   `json:"title,omitempty"`
@@ -1167,6 +1176,30 @@ func (c *HTTPClient) DeletePost(postID string) error {
 func (c *HTTPClient) DeleteReply(replyID string) error {
 	_, err := c.doRequest("DELETE", "/v1/replies/"+url.PathEscape(replyID), nil)
 	return err
+}
+
+func (c *HTTPClient) FlagPost(postID, reason string) (string, bool, error) {
+	env, err := c.doJSON("POST", "/v1/posts/"+url.PathEscape(postID)+"/flag", flagRequest{Reason: reason})
+	if err != nil {
+		return "", false, err
+	}
+	var data flagResponseData
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		return "", false, err
+	}
+	return data.FlagID, data.AlreadyFlagged, nil
+}
+
+func (c *HTTPClient) FlagReply(replyID, reason string) (string, bool, error) {
+	env, err := c.doJSON("POST", "/v1/replies/"+url.PathEscape(replyID)+"/flag", flagRequest{Reason: reason})
+	if err != nil {
+		return "", false, err
+	}
+	var data flagResponseData
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		return "", false, err
+	}
+	return data.FlagID, data.AlreadyFlagged, nil
 }
 
 func (c *HTTPClient) GetReply(replyID string) (model.Reply, error) {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -452,6 +452,7 @@ type wireCircMessage struct {
 	IsAction    bool   `json:"isAction"` // undocumented; true for /me and other emote commands
 	Content     string `json:"content"`
 	Timestamp   int64  `json:"timestamp"` // epoch ms
+	Deleted     bool   `json:"deleted"`
 }
 
 // --- C-Mail wire types ---
@@ -521,6 +522,7 @@ type wireRTDBCircMessage struct {
 	IsAction    bool    `json:"isAction"` // undocumented; true for /me and other emote commands
 	Content     string  `json:"content"`
 	Timestamp   float64 `json:"timestamp"` // epoch ms as a Firebase number
+	Deleted     bool    `json:"deleted"`
 }
 
 // wireRTDBSSEData is the outer wrapper of a Firebase "put" SSE event's data field.
@@ -1626,6 +1628,7 @@ func wireCircMessageToModel(w wireCircMessage) model.Message {
 		CreatedAt:   time.UnixMilli(w.Timestamp),
 		IsChatAdmin: w.IsChatAdmin,
 		IsAction:    w.IsAction,
+		Deleted:     w.Deleted,
 	}
 }
 
@@ -1647,6 +1650,24 @@ func (c *HTTPClient) SendRoomMessage(roomID, body string) (string, error) {
 // MarkRoomRead resets the unread indicator for roomID via POST /v1/circ/:roomId/read.
 func (c *HTTPClient) MarkRoomRead(roomID string) error {
 	_, err := c.doRequest("POST", "/v1/circ/"+url.PathEscape(roomID)+"/read", nil)
+	return err
+}
+
+func (c *HTTPClient) FlagRoomMessage(roomID, messageID, reason string) (string, bool, error) {
+	env, err := c.doJSON("POST", "/v1/circ/"+url.PathEscape(roomID)+"/messages/"+url.PathEscape(messageID)+"/flag", flagRequest{Reason: reason})
+	if err != nil {
+		return "", false, err
+	}
+	var data flagResponseData
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		return "", false, err
+	}
+	return data.FlagID, data.AlreadyFlagged, nil
+}
+
+// DeleteRoomMessage soft-deletes a message via DELETE /v1/circ/:roomId/messages/:messageId.
+func (c *HTTPClient) DeleteRoomMessage(roomID, messageID string) error {
+	_, err := c.doRequest("DELETE", "/v1/circ/"+url.PathEscape(roomID)+"/messages/"+url.PathEscape(messageID), nil)
 	return err
 }
 
@@ -1675,7 +1696,7 @@ func (c *HTTPClient) SubscribeRoom(ctx context.Context, roomID string) (<-chan m
 			if ev.Err != nil {
 				return
 			}
-			if ev.Event != "put" {
+			if ev.Event != "put" && ev.Event != "patch" {
 				continue
 			}
 			var d wireRTDBSSEData
@@ -1690,13 +1711,28 @@ func (c *HTTPClient) SubscribeRoom(ctx context.Context, roomID string) (<-chan m
 				// Deletion event — skip.
 				continue
 			}
+			msgID := strings.TrimPrefix(d.Path, "/")
 			var wm wireRTDBCircMessage
 			if err := json.Unmarshal(d.Data, &wm); err != nil {
 				continue
 			}
-			msgID := strings.TrimPrefix(d.Path, "/")
+			var msg model.Message
+			if ev.Event == "patch" {
+				// A patch on an existing message's path is currently only
+				// ever a delete ({"content":"[DELETED]","deleted":true}),
+				// which omits sender/timestamp/etc. entirely — unmarshaling
+				// it as a full message would zero those fields out. Send
+				// just {ID, Deleted}; callers must merge this onto the
+				// existing message by ID, never append it as new.
+				if !wm.Deleted {
+					continue
+				}
+				msg = model.Message{ID: msgID, Deleted: true}
+			} else {
+				msg = wireRTDBCircMessageToModel(msgID, wm)
+			}
 			select {
-			case out <- wireRTDBCircMessageToModel(msgID, wm):
+			case out <- msg:
 			case <-ctx.Done():
 				return
 			}
@@ -1965,6 +2001,7 @@ func wireRTDBCircMessageToModel(id string, wm wireRTDBCircMessage) model.Message
 		CreatedAt:   time.UnixMilli(int64(wm.Timestamp)),
 		IsChatAdmin: wm.IsChatAdmin,
 		IsAction:    wm.IsAction,
+		Deleted:     wm.Deleted,
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1951,6 +1951,77 @@ func TestHTTPCreateBookmark_Reply(t *testing.T) {
 	}
 }
 
+func TestHTTPFlagPost_SendsReasonAndParsesResponse(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		writeOK(t, w, map[string]any{"postId": "p1", "flagId": "flag-1", "flagged": true})
+	})))
+	c.Login("u@example.com", "pass")
+
+	flagID, alreadyFlagged, err := c.FlagPost("p1", "spam")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v1/posts/p1/flag" {
+		t.Errorf("path = %q, want /v1/posts/p1/flag", gotPath)
+	}
+	if gotBody["reason"] != "spam" {
+		t.Errorf("reason = %v, want spam", gotBody["reason"])
+	}
+	if flagID != "flag-1" {
+		t.Errorf("flagID = %q, want flag-1", flagID)
+	}
+	if alreadyFlagged {
+		t.Error("alreadyFlagged = true, want false")
+	}
+}
+
+func TestHTTPFlagPost_AlreadyFlagged(t *testing.T) {
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, map[string]any{"postId": "p1", "flagged": true, "alreadyFlagged": true})
+	})))
+	c.Login("u@example.com", "pass")
+
+	_, alreadyFlagged, err := c.FlagPost("p1", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !alreadyFlagged {
+		t.Error("alreadyFlagged = false, want true")
+	}
+}
+
+func TestHTTPFlagReply_SendsReasonAndParsesResponse(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		writeOK(t, w, map[string]any{"replyId": "r5", "flagId": "flag-2", "flagged": true})
+	})))
+	c.Login("u@example.com", "pass")
+
+	flagID, alreadyFlagged, err := c.FlagReply("r5", "harassment")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v1/replies/r5/flag" {
+		t.Errorf("path = %q, want /v1/replies/r5/flag", gotPath)
+	}
+	if gotBody["reason"] != "harassment" {
+		t.Errorf("reason = %v, want harassment", gotBody["reason"])
+	}
+	if flagID != "flag-2" {
+		t.Errorf("flagID = %q, want flag-2", flagID)
+	}
+	if alreadyFlagged {
+		t.Error("alreadyFlagged = true, want false")
+	}
+}
+
 func TestHTTPDeleteBookmark_Success(t *testing.T) {
 	var gotPath string
 	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -830,6 +830,96 @@ func TestHTTPSubscribeRoom_SanitizesControlChars(t *testing.T) {
 	}
 }
 
+// TestHTTPSubscribeRoom_PatchDeleteDeliversMergeSignal covers a delete
+// arriving as a partial "patch" event ({"content":"[DELETED]","deleted":true},
+// no sender/timestamp/etc.) — the delivered model.Message must carry only
+// {ID, Deleted}, never zeroed-out sender/body fields a caller could
+// mistake for a real (if empty) message.
+func TestHTTPSubscribeRoom_PatchDeleteDeliversMergeSignal(t *testing.T) {
+	c, _ := newClientWithRTDB(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeSSEEvent(w, "patch", `{"path":"/msg1","data":{"content":"[DELETED]","deleted":true}}`)
+	}))
+
+	ch, cancel, err := c.SubscribeRoom(context.Background(), "zion")
+	if err != nil {
+		t.Fatalf("SubscribeRoom error: %v", err)
+	}
+	defer cancel()
+
+	select {
+	case msg, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before delivering message")
+		}
+		if msg.ID != "msg1" {
+			t.Errorf("ID = %q, want msg1", msg.ID)
+		}
+		if !msg.Deleted {
+			t.Error("Deleted = false, want true")
+		}
+		if msg.From.Username != "" || msg.Body != "" {
+			t.Errorf("expected only {ID, Deleted} set, got From=%+v Body=%q", msg.From, msg.Body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+// TestHTTPSubscribeRoom_PatchWithoutDeletedIgnored guards the defensive
+// branch for a patch event that isn't a delete (not documented as occurring
+// today, but nothing should crash or misdeliver if the server ever sends
+// one) — it must be skipped, not delivered as a zeroed-out message.
+func TestHTTPSubscribeRoom_PatchWithoutDeletedIgnored(t *testing.T) {
+	c, _ := newClientWithRTDB(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeSSEEvent(w, "patch", `{"path":"/msg1","data":{"isChatAdmin":true}}`)
+		writeSSEEvent(w, "put", `{"path":"/msg2","data":{"userId":"u2","username":"molly","content":"hi","timestamp":1700000001000}}`)
+	}))
+
+	ch, cancel, err := c.SubscribeRoom(context.Background(), "zion")
+	if err != nil {
+		t.Fatalf("SubscribeRoom error: %v", err)
+	}
+	defer cancel()
+
+	select {
+	case msg, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before delivering message")
+		}
+		if msg.ID != "msg2" {
+			t.Errorf("expected the non-delete patch to be skipped and msg2 delivered instead, got ID=%q", msg.ID)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+// TestHTTPDeleteRoomMessage_Success mirrors the other simple DELETE-verb
+// action tests (e.g. TestHTTPDeleteBookmark_Success).
+func TestHTTPDeleteRoomMessage_Success(t *testing.T) {
+	var gotMethod, gotPath string
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		writeOK(t, w, map[string]any{"roomId": "zion", "messageId": "m1", "deleted": true})
+	})))
+	c.Login("u@example.com", "pass")
+
+	if err := c.DeleteRoomMessage("zion", "m1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "DELETE" {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/v1/circ/zion/messages/m1" {
+		t.Errorf("path = %q, want /v1/circ/zion/messages/m1", gotPath)
+	}
+}
+
 // --- C-Mail REST tests ---
 
 func TestHTTPGetConversations_ParsesList(t *testing.T) {
@@ -2019,6 +2109,49 @@ func TestHTTPFlagReply_SendsReasonAndParsesResponse(t *testing.T) {
 	}
 	if alreadyFlagged {
 		t.Error("alreadyFlagged = true, want false")
+	}
+}
+
+func TestHTTPFlagRoomMessage_SendsReasonAndParsesResponse(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		writeOK(t, w, map[string]any{"roomId": "general", "messageId": "m1", "flagId": "flag-3", "flagged": true})
+	})))
+	c.Login("u@example.com", "pass")
+
+	flagID, alreadyFlagged, err := c.FlagRoomMessage("general", "m1", "spam")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/v1/circ/general/messages/m1/flag" {
+		t.Errorf("path = %q, want /v1/circ/general/messages/m1/flag", gotPath)
+	}
+	if gotBody["reason"] != "spam" {
+		t.Errorf("reason = %v, want spam", gotBody["reason"])
+	}
+	if flagID != "flag-3" {
+		t.Errorf("flagID = %q, want flag-3", flagID)
+	}
+	if alreadyFlagged {
+		t.Error("alreadyFlagged = true, want false")
+	}
+}
+
+func TestHTTPFlagRoomMessage_AlreadyFlagged(t *testing.T) {
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, map[string]any{"roomId": "general", "messageId": "m1", "flagged": true, "alreadyFlagged": true})
+	})))
+	c.Login("u@example.com", "pass")
+
+	_, alreadyFlagged, err := c.FlagRoomMessage("general", "m1", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !alreadyFlagged {
+		t.Error("alreadyFlagged = false, want true")
 	}
 }
 

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -67,8 +67,16 @@ type Client interface {
 	SendRoomMessage(roomID, body string) (string, error)
 	// MarkRoomRead resets the "new messages" indicator for the caller.
 	MarkRoomRead(roomID string) error
+	// FlagRoomMessage reports a chatroom message for review. Same semantics as FlagPost.
+	FlagRoomMessage(roomID, messageID, reason string) (flagID string, alreadyFlagged bool, err error)
+	// DeleteRoomMessage soft-deletes a message owned by the authenticated user.
+	// Returns 409 if it's already deleted, 403 if it isn't the caller's own.
+	DeleteRoomMessage(roomID, messageID string) error
 	// SubscribeRoom opens a live RTDB SSE stream for the given chatroom.
-	// Returns a channel of incoming messages and a cancel function.
+	// Returns a channel of incoming messages and a cancel function. A delete
+	// (by the caller or another client) arrives as a partial update rather
+	// than a new message: only ID and Deleted are set on that model.Message —
+	// callers must merge it onto the existing message by ID, not append it.
 	SubscribeRoom(ctx context.Context, roomID string) (<-chan model.Message, context.CancelFunc, error)
 	// GetRoomUsers returns who's currently present in roomID (server-side
 	// staleness-filtered already; no client-side filtering needed).

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -153,6 +153,13 @@ type Client interface {
 	// DeleteReply soft-deletes a reply owned by the authenticated user.
 	DeleteReply(replyID string) error
 
+	// FlagPost reports a post for review. reason is optional (max 500 chars).
+	// Idempotent: reporting the same post again returns alreadyFlagged=true
+	// instead of an error. Returns 403 if the post is the caller's own.
+	FlagPost(postID, reason string) (flagID string, alreadyFlagged bool, err error)
+	// FlagReply reports a reply for review. Same semantics as FlagPost.
+	FlagReply(replyID, reason string) (flagID string, alreadyFlagged bool, err error)
+
 	// User posts/replies — cursor-paginated history for any user.
 	GetUserPosts(username, cursor string) ([]model.Post, string, error)
 	GetUserReplies(username, cursor string) ([]model.Reply, string, error)

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -248,6 +248,14 @@ func (m *MockClient) DeleteReply(replyID string) error {
 	return nil // no-op: in-memory replies are rebuilt on each GetPostReplies call
 }
 
+func (m *MockClient) FlagPost(postID, reason string) (string, bool, error) {
+	return "flag-mock-" + postID, false, nil
+}
+
+func (m *MockClient) FlagReply(replyID, reason string) (string, bool, error) {
+	return "flag-mock-" + replyID, false, nil
+}
+
 func (m *MockClient) GetPost(postID string) (model.Post, error) {
 	posts, _, _ := m.GetFeed("")
 	for _, p := range posts {

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -444,6 +444,14 @@ func (m *MockClient) MarkRoomRead(roomID string) error {
 	return nil
 }
 
+func (m *MockClient) FlagRoomMessage(roomID, messageID, reason string) (string, bool, error) {
+	return "flag-mock-" + messageID, false, nil
+}
+
+func (m *MockClient) DeleteRoomMessage(roomID, messageID string) error {
+	return nil
+}
+
 // SubscribeRoom returns a channel that delivers one fake incoming message after
 // 2 seconds (to exercise the live-stream UI path), then closes.
 func (m *MockClient) SubscribeRoom(ctx context.Context, roomID string) (<-chan model.Message, context.CancelFunc, error) {
@@ -454,8 +462,13 @@ func (m *MockClient) SubscribeRoom(ctx context.Context, roomID string) (<-chan m
 		select {
 		case <-time.After(2 * time.Second):
 			select {
+			// A fresh, unique ID each delivery: the app reconnects and
+			// re-subscribes whenever this mock channel closes (below), which
+			// would otherwise repeatedly deliver messages sharing one
+			// hardcoded ID — harmless for rendering, but breaks anything
+			// keyed by message ID (selection, flag/delete).
 			case ch <- model.Message{
-				ID:        "mock-room-live-1",
+				ID:        fmt.Sprintf("mock-room-live-%d", time.Now().UnixNano()),
 				From:      mockUsers[1],
 				Body:      "incoming mock room message",
 				CreatedAt: time.Now(),

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -124,6 +124,7 @@ type Message struct {
 	IsSystem    bool // local-only notice (e.g. a /help reply); never sent to or stored by the server
 	IsAction    bool // true for /me and other emote-style commands (undocumented API field);
 	// Body is just the action text with no username baked in — render as "* username body *"
+	Deleted bool // CIRC only: message was soft-deleted by its author; Body is "[DELETED]", render as a tombstone
 }
 
 type Conversation struct {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -833,6 +833,13 @@ func (a App) handleChatrooms(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, tea.Batch(a.markNotifReadCmd(msg.NotifID), activateCmd), true
 	case screens.SendRoomMessageMsg:
 		return a, a.sendRoomMessageCmd(msg.RoomID, msg.Body), true
+	case screens.FlagMessageMsg:
+		return a, a.flagRoomMessageCmd(msg.RoomID, msg.MessageID, msg.Reason), true
+	case screens.DeleteRoomMessageMsg:
+		return a, a.deleteRoomMessageCmd(msg.RoomID, msg.MessageID), true
+	case roomMessageDeletedMsg:
+		a.chatrooms = a.chatrooms.ApplyMessageDeleted(msg.messageID)
+		return a, nil, true
 	case screens.RoomOpenedMsg:
 		return a, a.markRoomReadCmd(msg.RoomID), true
 	case screens.RoomReconnectedMsg:
@@ -2235,6 +2242,7 @@ type roomCommandReplyMsg struct {
 	roomID string
 	reply  string
 }
+type roomMessageDeletedMsg struct{ messageID string }
 type cmailCommandReplyMsg struct {
 	convID string
 	reply  string
@@ -3360,6 +3368,25 @@ func (a *App) flagReplyCmd(replyID, reason string) tea.Cmd {
 			return flagErrorMsg(err)
 		}
 		return notifyMsg{level: notifyInfo, text: flagResultText(alreadyFlagged)}
+	}
+}
+
+func (a *App) flagRoomMessageCmd(roomID, messageID, reason string) tea.Cmd {
+	return func() tea.Msg {
+		_, alreadyFlagged, err := a.client.FlagRoomMessage(roomID, messageID, reason)
+		if err != nil {
+			return flagErrorMsg(err)
+		}
+		return notifyMsg{level: notifyInfo, text: flagResultText(alreadyFlagged)}
+	}
+}
+
+func (a *App) deleteRoomMessageCmd(roomID, messageID string) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.client.DeleteRoomMessage(roomID, messageID); err != nil {
+			return actionErrMsg{err}
+		}
+		return roomMessageDeletedMsg{messageID: messageID}
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -741,6 +741,11 @@ func (a App) handleFeed(msg tea.Msg) (App, tea.Cmd, bool) {
 			return a, a.loadFeedCmd(), true
 		}
 		return a, nil, true
+	case screens.FlagPostMsg:
+		if a.active != screenFeed {
+			return a, nil, false
+		}
+		return a, a.flagPostCmd(msg.PostID, msg.Reason), true
 	}
 	return a, nil, false
 }
@@ -795,6 +800,13 @@ func (a App) handlePostDetail(msg tea.Msg) (App, tea.Cmd, bool) {
 	case replyDeletedMsg:
 		a.postDetail = a.postDetail.RemoveReply(msg.replyID)
 		return a, nil, true
+	case screens.FlagPostMsg:
+		if a.active != screenPostDetail {
+			return a, nil, false
+		}
+		return a, a.flagPostCmd(msg.PostID, msg.Reason), true
+	case screens.FlagReplyMsg:
+		return a, a.flagReplyCmd(msg.ReplyID, msg.Reason), true
 	}
 	return a, nil, false
 }
@@ -3304,6 +3316,50 @@ func (a *App) deleteReplyCmd(replyID string) tea.Cmd {
 			return actionErrMsg{err}
 		}
 		return replyDeletedMsg{replyID: replyID}
+	}
+}
+
+// flagResultText picks the banner text for a completed report, distinguishing
+// a fresh report from one the caller had already filed (idempotent replay).
+func flagResultText(alreadyFlagged bool) string {
+	if alreadyFlagged {
+		return "already reported"
+	}
+	return "reported"
+}
+
+// flagErrorMsg converts a flag-action error into the message to emit. The API's
+// only documented 403 for these endpoints is reporting your own content — the
+// client-side guard (see FeedModel/PostDetailModel's "!" handler) should make
+// this unreachable, but a stale currentUsername could still race past it, so
+// it gets a friendly banner instead of the raw "API error FORBIDDEN (403): …"
+// text. Anything else falls through to actionErrMsg's normal handling
+// (including the session-expiry redirect in handleUnauthorized).
+func flagErrorMsg(err error) tea.Msg {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) && apiErr.Status == 403 {
+		return notifyMsg{level: notifyError, text: "you can't report your own content"}
+	}
+	return actionErrMsg{err}
+}
+
+func (a *App) flagPostCmd(postID, reason string) tea.Cmd {
+	return func() tea.Msg {
+		_, alreadyFlagged, err := a.client.FlagPost(postID, reason)
+		if err != nil {
+			return flagErrorMsg(err)
+		}
+		return notifyMsg{level: notifyInfo, text: flagResultText(alreadyFlagged)}
+	}
+}
+
+func (a *App) flagReplyCmd(replyID, reason string) tea.Cmd {
+	return func() tea.Msg {
+		_, alreadyFlagged, err := a.client.FlagReply(replyID, reason)
+		if err != nil {
+			return flagErrorMsg(err)
+		}
+		return notifyMsg{level: notifyInfo, text: flagResultText(alreadyFlagged)}
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -643,6 +643,70 @@ func TestHandleKeys_Slash_NotConsumed_WhileChatroomsInputFocused(t *testing.T) {
 	}
 }
 
+// --- Flag/report overlay: same input-focus bug class as chatrooms/cmail ---
+
+// setupFeedFlagPromptOpen opens the flag/report overlay on someone else's
+// post via FeedModel's own Update, mirroring setupChatroomsDetailWithURL
+// above (ComposeActive() must report true afterwards, or handleKeys will
+// treat later keys as global shortcuts instead of reason-box input).
+func setupFeedFlagPromptOpen(a App) App {
+	a.active = screenFeed
+	a.feed = a.feed.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "bob", Content: "not mine"},
+	}, "")
+	a.feed = a.feed.SetCurrentUsername("alice")
+	m, _ := a.feed.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	a.feed = m
+	return a
+}
+
+func TestHandleKeys_Q_NotConsumed_WhileFeedFlagPromptOpen(t *testing.T) {
+	a := setupFeedFlagPromptOpen(loggedInApp())
+	if !a.feed.ComposeActive() {
+		t.Fatal("setup: expected flag prompt open (ComposeActive true) after '!'")
+	}
+	_, _, consumed := a.handleKeys(keyMsg("q"))
+	if consumed {
+		t.Error("expected plain 'q' to NOT be consumed while the flag/report reason box is focused — it must still type into the reason field")
+	}
+}
+
+func TestHandleKeys_Digit_NotConsumed_WhileFeedFlagPromptOpen(t *testing.T) {
+	a := setupFeedFlagPromptOpen(loggedInApp())
+	_, _, consumed := a.handleKeys(keyMsg("1"))
+	if consumed {
+		t.Error("expected digit '1' to NOT be consumed while the flag/report reason box is focused — it must still type into the reason field")
+	}
+}
+
+func TestHandleKeys_CtrlQ_QuitsWhileFeedFlagPromptOpen(t *testing.T) {
+	a := setupFeedFlagPromptOpen(loggedInApp())
+	_, cmd, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	if !consumed {
+		t.Error("expected ctrl+q to be consumed even while the flag/report reason box is focused")
+	}
+	if cmd == nil {
+		t.Error("expected ctrl+q to fire a quit command")
+	}
+}
+
+func TestHandleKeys_Digit_NotConsumed_WhileFeedConfirmingDelete(t *testing.T) {
+	a := loggedInApp()
+	a.feed = a.feed.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "mine"},
+	}, "")
+	a.feed = a.feed.SetCurrentUsername("alice")
+	m, _ := a.feed.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	a.feed = m
+	if !a.feed.ComposeActive() {
+		t.Fatal("setup: expected delete-confirm overlay open (ComposeActive true) after 'd'")
+	}
+	_, _, consumed := a.handleKeys(keyMsg("1"))
+	if consumed {
+		t.Error("expected digit '1' to NOT be consumed while the delete-confirm overlay is open")
+	}
+}
+
 // --- Search reply deep-link ---
 
 // resolveMsgs runs cmd and flattens a tea.BatchMsg into its individual resolved messages.
@@ -1292,6 +1356,34 @@ func TestFriendlyErr_404IsSoftened(t *testing.T) {
 	}
 	if got := friendlyErr(errors.New("boom")); got != "boom" {
 		t.Errorf("friendlyErr(non-api) = %q, want raw text", got)
+	}
+}
+
+// flagErrorMsg softens the documented self-report 403 into a friendly banner;
+// anything else falls through to the normal actionErrMsg handling.
+func TestFlagErrorMsg_403IsSoftened(t *testing.T) {
+	got := flagErrorMsg(&api.APIError{Code: "FORBIDDEN", Status: 403, Message: "cannot flag own content"})
+	msg, ok := got.(notifyMsg)
+	if !ok {
+		t.Fatalf("flagErrorMsg(403) = %T, want notifyMsg", got)
+	}
+	if msg.level != notifyError {
+		t.Errorf("level = %v, want notifyError", msg.level)
+	}
+	if msg.text != "you can't report your own content" {
+		t.Errorf("text = %q, want friendly self-report message", msg.text)
+	}
+}
+
+func TestFlagErrorMsg_OtherErrorsFallThrough(t *testing.T) {
+	err := &api.APIError{Code: "RATE_LIMITED", Status: 429, Message: "too many requests"}
+	got := flagErrorMsg(err)
+	ae, ok := got.(actionErrMsg)
+	if !ok {
+		t.Fatalf("flagErrorMsg(429) = %T, want actionErrMsg", got)
+	}
+	if ae.err != err {
+		t.Errorf("actionErrMsg.err = %v, want the original error", ae.err)
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -560,6 +560,53 @@ func TestHandleKeys_Left_NotConsumed_WhileChatroomsInputFocusedAndComposeHasText
 	}
 }
 
+// TestHandleKeys_Left_NotConsumed_WhileChatroomsFlagPromptOpen guards a bug
+// found in manual testing: ComposeEmpty() only checked the compose box's own
+// value, so left/right escaped to tab-cycling while typing a flag/report
+// reason — even though focus was on the reason field, not the (empty)
+// compose box.
+func TestHandleKeys_Left_NotConsumed_WhileChatroomsFlagPromptOpen(t *testing.T) {
+	a := setupChatroomsDetailWithURL(loggedInApp())
+	cm, _ := a.chatrooms.Update(tea.KeyMsg{Type: tea.KeyUp}) // select the message
+	cm, _ = cm.Update(keyMsg("!"))                           // open the flag prompt
+	a.chatrooms = cm
+
+	if a.chatrooms.ComposeEmpty() {
+		t.Fatal("setup: expected ComposeEmpty() false while the flag prompt is open, even with an empty compose box")
+	}
+	_, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyLeft})
+	if consumed {
+		t.Error("expected plain left arrow to NOT be consumed while the flag/report reason box is focused — it must move the cursor instead")
+	}
+}
+
+// TestHandleKeys_Left_NotConsumed_WhileChatroomsDeleteConfirmOpen is the same
+// bug class as the flag-prompt case above, for the delete-confirm overlay:
+// ComposeEmpty() must also account for confirmingDeleteMsg, not just the
+// flag prompt.
+func TestHandleKeys_Left_NotConsumed_WhileChatroomsDeleteConfirmOpen(t *testing.T) {
+	a := loggedInApp()
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{ID: "r1", Slug: "zion", Name: "Zion"}})
+	cm, _ := a.chatrooms.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	cm, _ = cm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	cm = cm.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: ""}, Body: "mine", CreatedAt: time.Now()},
+	})
+	a.active = screenChatrooms
+	a.chatrooms = cm
+	cm, _ = a.chatrooms.Update(tea.KeyMsg{Type: tea.KeyUp}) // select the message
+	cm, _ = cm.Update(keyMsg("d"))                          // open the delete confirm
+	a.chatrooms = cm
+
+	if a.chatrooms.ComposeEmpty() {
+		t.Fatal("setup: expected ComposeEmpty() false while the delete-confirm overlay is open")
+	}
+	_, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyLeft})
+	if consumed {
+		t.Error("expected plain left arrow to NOT be consumed while the delete-confirm overlay is open")
+	}
+}
+
 // C-Mail's compose input is focused for the entire detail view exactly like
 // Chatrooms', and now gets the same background-resume treatment (see
 // TestActivateScreen_CMailConvSurvivesTabSwitch), so it needs the same

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -241,6 +241,19 @@ type ChatroomsModel struct {
 	// when not cycling. See mentionCycle's doc comment.
 	mentionCycle *mentionCycle
 
+	// Message selection ("browsing") + flag/report overlay state.
+	// selectedMsgID == "" is the sentinel for normal typing (input focused,
+	// up/down raw-scroll); non-empty means the input is blurred and up/down/!
+	// act on the selected message instead. Selection is tracked by ID rather
+	// than index since PrependMessages splices older history onto the front
+	// of m.messages, which would silently invalidate a stored index.
+	selectedMsgID       string
+	msgOffsets          []int // start line of m.messages[i]'s rendered block; 1:1 with m.messages
+	msgHeights          []int // rendered line-height of m.messages[i]'s block; 1:1 with m.messages
+	flagPrompt          FlagPrompt
+	flagTargetMsgID     string // message ID being flagged, set right before flagPrompt.Open()
+	confirmingDeleteMsg bool   // true while the y/n delete-confirm overlay for the selected message is showing
+
 	// focused is true while the Chatrooms tab is the one on screen. The RTDB
 	// subscription for an open room stays alive regardless (see
 	// IsRoomStreamMsg), so this only gates whether incoming messages bump
@@ -269,6 +282,7 @@ func NewChatroomsModel(currentUser string, client api.Client) ChatroomsModel {
 		currentUser: currentUser,
 		client:      client,
 		mode:        chatroomModeList,
+		flagPrompt:  NewFlagPrompt(),
 	}
 }
 
@@ -518,10 +532,18 @@ func (m ChatroomsModel) loadOlderRoomMessagesCmd(roomID string, before int64) te
 // InputFocused returns true in detail mode to prevent tab-navigation key capture.
 func (m ChatroomsModel) InputFocused() bool { return m.mode == chatroomModeDetail }
 
-// ComposeEmpty reports whether the compose input has no typed text — used by
-// App to let plain left/right fall through to tab-cycling instead of being
-// captured as cursor movement (see handleKeys' focused-input gate in app.go).
-func (m ChatroomsModel) ComposeEmpty() bool { return m.input.Value() == "" }
+// SelectedMessageID returns the ID of the currently browsed/highlighted
+// message, or "" if none is selected (normal typing state).
+func (m ChatroomsModel) SelectedMessageID() string { return m.selectedMsgID }
+
+// ComposeEmpty reports whether there's no text a bare left/right arrow would
+// need to navigate — app.go uses this to decide whether bare left/right can
+// escape to tab-cycling instead of moving the input cursor. False while the
+// flag/report overlay is open, regardless of the compose box's own value:
+// arrows must move within the reason field then, never escape to tabs.
+func (m ChatroomsModel) ComposeEmpty() bool {
+	return !m.flagPrompt.Active() && !m.confirmingDeleteMsg && m.input.Value() == ""
+}
 
 // IsShowingDetail reports whether the detail view is active.
 func (m ChatroomsModel) IsShowingDetail() bool { return m.mode == chatroomModeDetail }
@@ -619,9 +641,10 @@ func (m ChatroomsModel) enterRoomDetail(idx int, room model.Room) (ChatroomsMode
 	m.historyExhausted = false
 	m.loadingHistory = false
 	m.err = nil
+	m.selectedMsgID = ""
 	m.input.Focus()
 	if m.ready {
-		m.viewport.SetContent(m.renderMessages())
+		m = m.refreshMessages()
 		m.viewport.GotoBottom()
 	}
 	roomID := room.Slug
@@ -638,8 +661,29 @@ func (m ChatroomsModel) AppendMessage(msg model.Message) ChatroomsModel {
 	m.messages = append(m.messages, msg)
 	m.err = nil
 	if m.ready {
-		m.viewport.SetContent(m.renderMessages())
+		m = m.refreshMessages()
 		m.viewport.GotoBottom()
+	}
+	return m
+}
+
+// ApplyMessageDeleted marks an existing message (by ID) as soft-deleted in
+// place — the message stays in the list (per the API: "the message stays in
+// the room so the conversation around it still reads"), just with its body
+// replaced by a tombstone marker. No-op if the ID isn't currently loaded.
+// Used both for the optimistic update after the caller's own delete succeeds
+// and for a delete patch received from the live RTDB stream.
+func (m ChatroomsModel) ApplyMessageDeleted(messageID string) ChatroomsModel {
+	for i, msg := range m.messages {
+		if msg.ID != messageID {
+			continue
+		}
+		m.messages[i].Deleted = true
+		m.messages[i].Body = "[DELETED]"
+		if m.ready {
+			m = m.refreshMessages()
+		}
+		return m
 	}
 	return m
 }
@@ -667,7 +711,7 @@ func (m ChatroomsModel) SetMessages(roomID string, msgs []model.Message) Chatroo
 	m.messages = msgs
 	m.err = nil
 	if m.ready {
-		m.viewport.SetContent(m.renderMessages())
+		m = m.refreshMessages()
 		m.viewport.GotoBottom()
 	}
 	return m
@@ -682,7 +726,7 @@ func (m ChatroomsModel) SetRoomUsers(users []model.RoomUser) ChatroomsModel {
 	if m.ready {
 		msgW, _ := m.panelWidths()
 		m.viewport.Width = msgW
-		m.viewport.SetContent(m.renderMessages())
+		m = m.refreshMessages()
 	}
 	return m
 }
@@ -707,9 +751,9 @@ func (m ChatroomsModel) PrependMessages(roomID string, msgs []model.Message) Cha
 	}
 	m.messages = append(msgs, m.messages...)
 	if m.ready {
-		newContent := m.renderMessages()
-		m.viewport.SetContent(newContent)
-		m.viewport.SetYOffset(oldOffset + lipgloss.Height(newContent) - oldLines)
+		newLines := lipgloss.Height(m.renderMessages())
+		m = m.refreshMessages()
+		m.viewport.SetYOffset(oldOffset + newLines - oldLines)
 	}
 	return m
 }
@@ -729,7 +773,7 @@ func (m ChatroomsModel) SetLocation(loc *time.Location) ChatroomsModel {
 	if m.ready {
 		m.listVP.SetContent(m.renderRoomCards())
 		if m.activeRoom != nil {
-			m.viewport.SetContent(m.renderMessages())
+			m = m.refreshMessages()
 		}
 	}
 	return m
@@ -743,21 +787,20 @@ func (m ChatroomsModel) Update(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		listH := msg.Height - theme.ChromeHeight
-		detailH := msg.Height - theme.ChromeHeight - chatroomDetailChrome
 		msgW, _ := m.panelWidths()
 		if !m.ready {
 			m.listVP = viewport.New(msg.Width, listH)
-			m.viewport = viewport.New(msgW, detailH)
+			m.viewport = viewport.New(msgW, m.viewportHeight())
 			m.listVP.SetContent(m.renderRoomCards())
 			m.ready = true
 		} else {
 			m.listVP.Width = msg.Width
 			m.listVP.Height = listH
 			m.viewport.Width = msgW
-			m.viewport.Height = detailH
+			m.viewport.Height = m.viewportHeight()
 			m.listVP.SetContent(m.renderRoomCards())
 			if m.activeRoom != nil {
-				m.viewport.SetContent(m.renderMessages())
+				m = m.refreshMessages()
 			}
 		}
 		// textinput.View() renders 3 columns wider than Width the instant
@@ -793,9 +836,16 @@ func (m ChatroomsModel) Update(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 		return m.PrependMessages(msg.roomID, msg.msgs), nil
 
 	case roomReceivedMsg:
-		m = m.AppendMessage(msg.msg)
-		if !m.focused {
-			m.unreadCount++
+		if msg.msg.Deleted {
+			// A delete patch — from us in another session, or from another
+			// user — carries only {ID, Deleted}; merge onto the existing
+			// message rather than appending it as a new one.
+			m = m.ApplyMessageDeleted(msg.msg.ID)
+		} else {
+			m = m.AppendMessage(msg.msg)
+			if !m.focused {
+				m.unreadCount++
+			}
 		}
 		if m.sub != nil {
 			return m, waitForRoomMsg(m.sub)
@@ -853,7 +903,7 @@ func (m ChatroomsModel) Update(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 		m.err = msg.err
 		m.loadingHistory = false
 		if m.ready && m.mode == chatroomModeDetail {
-			m.viewport.SetContent(m.renderMessages())
+			m = m.refreshMessages()
 		}
 		return m, nil
 
@@ -958,6 +1008,27 @@ func (m ChatroomsModel) Update(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 		m.presenceReconnectAttempt = 0
 		return m, waitForRoomPresenceMsg(m.presenceSub)
 
+	case FlagSubmitMsg:
+		messageID := m.flagTargetMsgID
+		m.flagTargetMsgID = ""
+		roomID := ""
+		if m.activeRoom != nil {
+			roomID = m.activeRoom.Slug
+		}
+		if m.ready {
+			m.viewport.Height = m.viewportHeight()
+		}
+		return m, func() tea.Msg {
+			return FlagMessageMsg{RoomID: roomID, MessageID: messageID, Reason: msg.Reason}
+		}
+
+	case FlagCancelMsg:
+		m.flagTargetMsgID = ""
+		if m.ready {
+			m.viewport.Height = m.viewportHeight()
+		}
+		return m, nil
+
 	// --- Keyboard ---
 
 	case tea.KeyMsg:
@@ -990,6 +1061,14 @@ func (m ChatroomsModel) Update(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 			}
 
 		case chatroomModeDetail:
+			if m.flagPrompt.Active() {
+				var cmd tea.Cmd
+				m.flagPrompt, cmd = m.flagPrompt.Update(msg)
+				return m, cmd
+			}
+			if m.selectedMsgID != "" {
+				return m.updateBrowsingKey(msg)
+			}
 			// Any key other than Tab or Space ends an in-progress mention
 			// preview: Tab cycles which candidate is shown, Space commits
 			// the current one. Everything else just clears the preview,
@@ -1067,12 +1146,24 @@ func (m ChatroomsModel) Update(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 				}
 				return m, nil
 			case "up":
-				m.viewport.ScrollUp(1)
-				if m.viewport.AtTop() && !m.loadingHistory && !m.historyExhausted &&
-					m.activeRoom != nil && len(m.messages) > 0 {
-					m.loadingHistory = true
-					before := m.messages[0].CreatedAt.UnixMilli()
-					return m, m.loadOlderRoomMessagesCmd(m.activeRoom.Slug, before)
+				sel := selectableMessageIndices(m.messages)
+				if len(sel) == 0 {
+					m.viewport.ScrollUp(1)
+					return m.maybeLoadOlderMessages()
+				}
+				m.input.Blur()
+				m.selectedMsgID = m.messages[sel[len(sel)-1]].ID
+				m = m.refreshMessages()
+				m = m.ensureSelectedMessageVisible()
+				// Only fetch older history here if entering browsing landed
+				// straight on the oldest message (a single-message room) —
+				// otherwise pagination fires once curPos reaches 0 while
+				// already browsing (see updateBrowsingKey's "up" case).
+				// Checking AtTop() here instead would fire on every short
+				// room whose content already fits the viewport, regardless
+				// of which message was just selected.
+				if len(sel) == 1 {
+					return m.maybeLoadOlderMessages()
 				}
 				return m, nil
 			case "down":
@@ -1162,6 +1253,223 @@ func (m ChatroomsModel) renderMessages() string {
 		return theme.Subtle.Render("no messages yet")
 	}
 	return renderCircMessages(m.messages, m.location(), m.timeDisplayFormat, m.viewport.Width, m.currentUser)
+}
+
+// refreshMessages rebuilds the viewport content and the per-message
+// offset/height tables (m.msgOffsets/m.msgHeights) used to keep the selected
+// message in view and to highlight it. Every mutation of m.messages or the
+// viewport's width must call this instead of setting content directly.
+func (m ChatroomsModel) refreshMessages() ChatroomsModel {
+	if len(m.messages) == 0 {
+		m.viewport.SetContent(m.renderMessages())
+		m.msgOffsets, m.msgHeights = nil, nil
+		return m
+	}
+	content, offsets, heights := renderCircMessagesWithSelection(
+		m.messages, m.location(), m.timeDisplayFormat, m.viewport.Width, m.currentUser, m.selectedMsgID)
+	m.viewport.SetContent(content)
+	m.msgOffsets, m.msgHeights = offsets, heights
+	return m
+}
+
+// selectableMessageIndices returns the indices into msgs of messages that can
+// be selected/flagged: a real (non-system) message with a stable ID. System
+// notices (AppendSystemMessage) have no ID and are never selectable.
+func selectableMessageIndices(msgs []model.Message) []int {
+	var sel []int
+	for i, msg := range msgs {
+		if !msg.IsSystem && msg.ID != "" {
+			sel = append(sel, i)
+		}
+	}
+	return sel
+}
+
+// selectablePos returns the position within sel whose message ID matches id,
+// or -1 if id is empty or not found (e.g. it scrolled out of the loaded
+// window, or — in the future — was deleted).
+func selectablePos(msgs []model.Message, sel []int, id string) int {
+	if id == "" {
+		return -1
+	}
+	for pos, idx := range sel {
+		if msgs[idx].ID == id {
+			return pos
+		}
+	}
+	return -1
+}
+
+// findMessageByID returns the message with the given ID and whether it was found.
+func findMessageByID(msgs []model.Message, id string) (model.Message, bool) {
+	for _, msg := range msgs {
+		if msg.ID == id {
+			return msg, true
+		}
+	}
+	return model.Message{}, false
+}
+
+// selOffsets/selHeights project m.msgOffsets/m.msgHeights through sel (the
+// selectable-only index list), for feeding into millerPageNav.
+func selOffsets(m ChatroomsModel, sel []int) []int {
+	out := make([]int, len(sel))
+	for i, idx := range sel {
+		out[i] = m.msgOffsets[idx]
+	}
+	return out
+}
+
+func selHeights(m ChatroomsModel, sel []int) []int {
+	out := make([]int, len(sel))
+	for i, idx := range sel {
+		out[i] = m.msgHeights[idx]
+	}
+	return out
+}
+
+// ensureSelectedMessageVisible scrolls the viewport the minimum amount so the
+// selected message is fully visible, mirroring PostDetailModel's
+// ensureSelectedVisible.
+func (m ChatroomsModel) ensureSelectedMessageVisible() ChatroomsModel {
+	if !m.ready {
+		return m
+	}
+	for i, msg := range m.messages {
+		if msg.ID != m.selectedMsgID {
+			continue
+		}
+		itemStart := m.msgOffsets[i]
+		itemEnd := itemStart + m.msgHeights[i] - 1
+		if itemStart < m.viewport.YOffset {
+			m.viewport.SetYOffset(itemStart)
+		} else if itemEnd >= m.viewport.YOffset+m.viewport.Height {
+			m.viewport.SetYOffset(itemEnd - m.viewport.Height + 1)
+		}
+		return m
+	}
+	return m
+}
+
+// maybeLoadOlderMessages fires the older-history fetch once scrolled to the
+// very top of loaded messages. Shared by both places 'up' can reach the top:
+// raw scroll from the sentinel, and paging further up while already browsing.
+func (m ChatroomsModel) maybeLoadOlderMessages() (ChatroomsModel, tea.Cmd) {
+	if m.viewport.AtTop() && !m.loadingHistory && !m.historyExhausted &&
+		m.activeRoom != nil && len(m.messages) > 0 {
+		m.loadingHistory = true
+		before := m.messages[0].CreatedAt.UnixMilli()
+		return m, m.loadOlderRoomMessagesCmd(m.activeRoom.Slug, before)
+	}
+	return m, nil
+}
+
+// updateBrowsingKey handles keys while a message is selected
+// (m.selectedMsgID != ""): up/down move the selection, esc returns to
+// typing, '!' reports the selected message. Everything else is swallowed
+// rather than typed, since the input is blurred for the duration of
+// browsing — see the 'up' case in the typing-mode switch, the only place
+// browsing is entered.
+func (m ChatroomsModel) updateBrowsingKey(msg tea.KeyMsg) (ChatroomsModel, tea.Cmd) {
+	if m.confirmingDeleteMsg {
+		switch msg.String() {
+		case "y":
+			messageID := m.selectedMsgID
+			roomID := ""
+			if m.activeRoom != nil {
+				roomID = m.activeRoom.Slug
+			}
+			m.confirmingDeleteMsg = false
+			m.viewport.Height = m.viewportHeight()
+			return m, func() tea.Msg {
+				return DeleteRoomMessageMsg{RoomID: roomID, MessageID: messageID}
+			}
+		case "n", "esc":
+			m.confirmingDeleteMsg = false
+			m.viewport.Height = m.viewportHeight()
+		}
+		return m, nil
+	}
+	sel := selectableMessageIndices(m.messages)
+	curPos := selectablePos(m.messages, sel, m.selectedMsgID)
+	if curPos < 0 {
+		// The selected message no longer exists — fall back to typing.
+		m.selectedMsgID = ""
+		m.input.Focus()
+		return m.refreshMessages(), nil
+	}
+	switch msg.String() {
+	case "esc":
+		m.selectedMsgID = ""
+		m.input.Focus()
+		m = m.refreshMessages()
+		m.viewport.GotoBottom()
+		return m, nil
+	case "up":
+		if curPos == 0 {
+			return m.maybeLoadOlderMessages()
+		}
+		newPos, newOffset := millerPageNav(-1, m.viewport.Height, 0,
+			selOffsets(m, sel), selHeights(m, sel), curPos, m.viewport.YOffset)
+		if newPos < 0 {
+			newPos = 0
+		}
+		m.selectedMsgID = m.messages[sel[newPos]].ID
+		m.viewport.SetYOffset(newOffset)
+		m = m.refreshMessages()
+		if newPos == 0 {
+			return m.maybeLoadOlderMessages()
+		}
+		return m, nil
+	case "down":
+		if curPos >= len(sel)-1 {
+			m.selectedMsgID = ""
+			m.input.Focus()
+			m = m.refreshMessages()
+			m.viewport.GotoBottom()
+			return m, nil
+		}
+		newPos, newOffset := millerPageNav(+1, m.viewport.Height, 0,
+			selOffsets(m, sel), selHeights(m, sel), curPos, m.viewport.YOffset)
+		m.selectedMsgID = m.messages[sel[newPos]].ID
+		m.viewport.SetYOffset(newOffset)
+		return m.refreshMessages(), nil
+	case "!":
+		targetMsg, ok := findMessageByID(m.messages, m.selectedMsgID)
+		if !ok || targetMsg.Deleted || targetMsg.From.Username == m.currentUser {
+			return m, nil
+		}
+		m.flagTargetMsgID = m.selectedMsgID
+		var cmd tea.Cmd
+		m.flagPrompt, cmd = m.flagPrompt.Open(FlagKindMessage)
+		m.viewport.Height = m.viewportHeight()
+		return m, cmd
+	case "d":
+		targetMsg, ok := findMessageByID(m.messages, m.selectedMsgID)
+		if !ok || targetMsg.Deleted || targetMsg.From.Username != m.currentUser {
+			return m, nil
+		}
+		m.confirmingDeleteMsg = true
+		m.viewport.Height = m.viewportHeight()
+		return m, nil
+	}
+	return m, nil
+}
+
+// viewportHeight returns the message-history viewport height in rows,
+// shrinking to make room for the flag/report overlay when it's open.
+func (m ChatroomsModel) viewportHeight() int {
+	h := m.height - theme.ChromeHeight - chatroomDetailChrome
+	if m.flagPrompt.Active() {
+		h -= m.flagPrompt.Height()
+	}
+	if m.confirmingDeleteMsg {
+		h -= confirmBoxHeight
+	}
+	if h < 1 {
+		h = 1
+	}
+	return h
 }
 
 // Panel sizing: the users panel is pinned to a preferred width that
@@ -1433,6 +1741,16 @@ func (m ChatroomsModel) View() string {
 			messageArea = lipgloss.JoinHorizontal(lipgloss.Top, messageArea, sep, panel)
 		}
 		divider := theme.Subtle.Render(strings.Repeat("─", max(m.width, 0)))
+		if m.flagPrompt.Active() {
+			return lipgloss.JoinVertical(lipgloss.Left, header, divider, messageArea, m.flagPrompt.View(m.width), inputBox)
+		}
+		if m.confirmingDeleteMsg {
+			prompt := theme.Error.Render("Delete this message?") + "  " +
+				theme.Base.Render("[y]es") + "  " +
+				theme.Subtle.Render("[n]o / esc")
+			promptView := theme.ActiveBorder.Width(m.width - 2).Render(prompt)
+			return lipgloss.JoinVertical(lipgloss.Left, header, divider, messageArea, promptView, inputBox)
+		}
 		return lipgloss.JoinVertical(lipgloss.Left, header, divider, messageArea, inputBox)
 	default: // chatroomModeList
 		if !m.ready {

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -1,8 +1,10 @@
 package screens
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -852,6 +854,48 @@ func TestMentionGhostText_RendersAdjacentToCursorAtConstantWidth(t *testing.T) {
 	}
 	if !strings.Contains(content, "hey @alice") {
 		t.Errorf("expected the typed text and ghost to read as an unbroken %q with the cursor overlaying its first character, got: %q", "hey @alice", content)
+	}
+}
+
+// TestChatrooms_Esc_WhileBrowsing_ResetsViewportToBottom guards a real bug
+// found in manual testing: esc while browsing cleared the selection and
+// refocused the input, but — unlike the "down past the newest message"
+// exit path — left the viewport wherever browsing had scrolled it, instead
+// of also jumping back to the live tail.
+func TestChatrooms_Esc_WhileBrowsing_ResetsViewportToBottom(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+
+	var msgs []model.Message
+	for i := 1; i <= 30; i++ {
+		msgs = append(msgs, model.Message{
+			ID:        fmt.Sprintf("m%d", i),
+			From:      model.User{Username: "molly"},
+			Body:      fmt.Sprintf("message %d", i),
+			CreatedAt: time.Now().Add(time.Duration(i) * time.Minute),
+		})
+	}
+	m = m.SetMessages("zion", msgs)
+	if !m.viewport.AtBottom() {
+		t.Fatal("setup: expected the viewport to start at the bottom after SetMessages")
+	}
+
+	for i := 0; i < len(msgs); i++ {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	}
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q after paging all the way up, want m1", m.selectedMsgID)
+	}
+	if m.viewport.AtBottom() {
+		t.Fatal("setup: expected paging up through browsing to leave the bottom")
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if m.selectedMsgID != "" {
+		t.Errorf("selectedMsgID = %q, want cleared after esc", m.selectedMsgID)
+	}
+	if !m.viewport.AtBottom() {
+		t.Errorf("expected esc to reset the viewport to the bottom, YOffset=%d maxYOffset≈%d", m.viewport.YOffset, m.viewport.Height)
 	}
 }
 

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -87,24 +87,28 @@ type FeedModel struct {
 	currentUsername  string // set after login; used to guard the delete key
 	confirmingDelete bool   // true while the delete-post confirmation overlay is shown
 
+	flagPrompt       FlagPrompt // active while reporting the selected post
+	flagTargetPostID string
+
 	bookmarkedPostIDs map[string]struct{}
 	watchedPostIDs    map[string]struct{}
 	filterNSFW        bool
 
 	// Miller reading pane: replies for the currently selected post.
-	detailPostID     string
-	detailReplies    []model.Reply
-	detailFlatTree   []replyNode // DFS-ordered tree built from detailReplies
-	detailReplyIndex int         // -1 = post selected; 0+ = index into detailFlatTree
-	detailScrollOffset int       // raw line offset for pager scrolling in the detail pane
-	detailLoading    bool
-	maxThreadDepth   int
+	detailPostID       string
+	detailReplies      []model.Reply
+	detailFlatTree     []replyNode // DFS-ordered tree built from detailReplies
+	detailReplyIndex   int         // -1 = post selected; 0+ = index into detailFlatTree
+	detailScrollOffset int         // raw line offset for pager scrolling in the detail pane
+	detailLoading      bool
+	maxThreadDepth     int
 }
 
 func NewFeedModel() FeedModel {
 	return FeedModel{
 		panel:            NewPostComposePanel(0),
 		detailReplyIndex: -1,
+		flagPrompt:       NewFlagPrompt(),
 	}
 }
 
@@ -300,10 +304,16 @@ func (m FeedModel) ensureSelectedVisible() FeedModel {
 	return m
 }
 
-// ComposeActive reports whether the new-post compose panel is open.
-func (m FeedModel) ComposeActive() bool            { return m.panel.IsActive() }
-func (m FeedModel) ComposeHeight() int             { return m.panel.PanelHeight() }
-func (m FeedModel) ComposeView(width int) string   { return m.panel.SetWidth(width).View() }
+// ComposeActive reports whether the new-post compose panel, the flag/report
+// overlay, or the delete-confirmation overlay is open. Every screen-owned
+// overlay that intercepts keys first in Update (see the top of the
+// tea.KeyMsg case) must be OR'd in here — app.go's global shortcuts fire
+// instead of reaching Update whenever this returns false.
+func (m FeedModel) ComposeActive() bool {
+	return m.panel.IsActive() || m.flagPrompt.Active() || m.confirmingDelete
+}
+func (m FeedModel) ComposeHeight() int           { return m.panel.PanelHeight() }
+func (m FeedModel) ComposeView(width int) string { return m.panel.SetWidth(width).View() }
 
 func (m FeedModel) Init() tea.Cmd { return nil }
 
@@ -400,7 +410,24 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		m = m.closeCompose()
 		return m, nil
 
+	case FlagSubmitMsg:
+		postID := m.flagTargetPostID
+		m.flagTargetPostID = ""
+		m.viewport.Height = m.viewportHeight()
+		return m, func() tea.Msg { return FlagPostMsg{PostID: postID, Reason: msg.Reason} }
+
+	case FlagCancelMsg:
+		m.flagTargetPostID = ""
+		m.viewport.Height = m.viewportHeight()
+		return m, nil
+
 	case tea.KeyMsg:
+		// Flag overlay intercepts all keys while active.
+		if m.flagPrompt.Active() {
+			var cmd tea.Cmd
+			m.flagPrompt, cmd = m.flagPrompt.Update(msg)
+			return m, cmd
+		}
 		// Confirmation overlay intercepts all keys while active.
 		if m.confirmingDelete {
 			switch msg.String() {
@@ -485,6 +512,16 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 				m.viewport.Height = m.viewportHeight()
 			}
 			return m, nil
+		case "!":
+			if visible := m.visiblePosts(); len(visible) > 0 && m.selectedIndex < len(visible) &&
+				visible[m.selectedIndex].AuthorUsername != m.currentUsername {
+				m.flagTargetPostID = visible[m.selectedIndex].ID
+				var cmd tea.Cmd
+				m.flagPrompt, cmd = m.flagPrompt.Open(FlagKindPost)
+				m.viewport.Height = m.viewportHeight()
+				return m, cmd
+			}
+			return m, nil
 		case "n":
 			var cmd tea.Cmd
 			m.panel, cmd = m.panel.Open(m.defaultPublicPost)
@@ -532,6 +569,9 @@ func (m FeedModel) viewportHeight() int {
 	}
 	if m.confirmingDelete {
 		h -= confirmBoxHeight
+	}
+	if m.flagPrompt.Active() {
+		h -= m.flagPrompt.Height()
 	}
 	if h < 1 {
 		h = 1
@@ -739,7 +779,7 @@ func ansiTruncate(s string, maxWidth int) string {
 }
 
 func (m FeedModel) IsCompactListActive() bool { return true }
-func (m FeedModel) ListTitle() string          { return "posts" }
+func (m FeedModel) ListTitle() string         { return "posts" }
 
 // CompactListView returns the compact single-line post list for the Miller reading pane.
 // It calculates a sticky-scroll window of height rows without storing extra state.
@@ -874,6 +914,13 @@ func (m FeedModel) View() string {
 		return lipgloss.JoinVertical(lipgloss.Left,
 			m.viewport.View(),
 			promptView,
+		)
+	}
+
+	if m.flagPrompt.Active() {
+		return lipgloss.JoinVertical(lipgloss.Left,
+			m.viewport.View(),
+			m.flagPrompt.View(m.width),
 		)
 	}
 

--- a/internal/ui/screens/feed_test.go
+++ b/internal/ui/screens/feed_test.go
@@ -96,3 +96,106 @@ func TestFeed_FilterNSFW_Off_ShowsAll(t *testing.T) {
 		t.Errorf("expected p2 (nsfw), got %s", sp.Post.ID)
 	}
 }
+
+// --- Flag / report ---
+
+func keyRune(s string) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)} }
+
+func TestFeed_FlagKey_OnOwnPost_DoesNothing(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "mine"},
+	}, "")
+	m = m.SetCurrentUsername("alice")
+
+	_, cmd := m.Update(keyRune("!"))
+	if cmd != nil {
+		t.Fatal("expected no cmd when flagging own post")
+	}
+}
+
+func TestFeed_FlagKey_OnOtherPost_FullFlowEmitsFlagPostMsg(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "bob", Content: "not mine"},
+	}, "")
+	m = m.SetCurrentUsername("alice")
+
+	m, cmd := m.Update(keyRune("!"))
+	if cmd == nil {
+		t.Fatal("expected Open() to return a focus cmd")
+	}
+
+	for _, r := range "spam" {
+		m, _ = m.Update(keyRune(string(r)))
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd = m.Update(keyRune("y"))
+	if cmd == nil {
+		t.Fatal("expected a cmd after confirming")
+	}
+	// The real runtime feeds the cmd's message back through Update; do the same here.
+	m, cmd = m.Update(cmd())
+	if cmd == nil {
+		t.Fatal("expected a cmd after routing FlagSubmitMsg through Update")
+	}
+	msg, ok := cmd().(screens.FlagPostMsg)
+	if !ok {
+		t.Fatalf("expected FlagPostMsg, got %T", cmd())
+	}
+	if msg.PostID != "p1" {
+		t.Errorf("PostID = %q, want p1", msg.PostID)
+	}
+	if msg.Reason != "spam" {
+		t.Errorf("Reason = %q, want spam", msg.Reason)
+	}
+}
+
+func TestFeed_FlagKey_Cancel_EmitsNoFlagMsg(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "bob", Content: "not mine"},
+	}, "")
+	m = m.SetCurrentUsername("alice")
+
+	m, _ = m.Update(keyRune("!"))
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		if _, ok := cmd().(screens.FlagPostMsg); ok {
+			t.Fatal("esc should not emit FlagPostMsg")
+		}
+	}
+}
+
+func TestFeed_ComposeActive_TrueWhileFlagPromptOpen(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "bob", Content: "not mine"},
+	}, "")
+	m = m.SetCurrentUsername("alice")
+
+	if m.ComposeActive() {
+		t.Fatal("setup: expected ComposeActive false before opening the flag prompt")
+	}
+	m, _ = m.Update(keyRune("!"))
+	if !m.ComposeActive() {
+		t.Error("expected ComposeActive to report true while the flag/report overlay is open")
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.ComposeActive() {
+		t.Error("expected ComposeActive to go false again once the flag prompt is cancelled")
+	}
+}
+
+func TestFeed_ComposeActive_TrueWhileConfirmingDelete(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "mine"},
+	}, "")
+	m = m.SetCurrentUsername("alice")
+
+	m, _ = m.Update(keyRune("d"))
+	if !m.ComposeActive() {
+		t.Error("expected ComposeActive to report true while the delete-confirm overlay is open")
+	}
+}

--- a/internal/ui/screens/feed_test.go
+++ b/internal/ui/screens/feed_test.go
@@ -135,7 +135,7 @@ func TestFeed_FlagKey_OnOtherPost_FullFlowEmitsFlagPostMsg(t *testing.T) {
 		t.Fatal("expected a cmd after confirming")
 	}
 	// The real runtime feeds the cmd's message back through Update; do the same here.
-	m, cmd = m.Update(cmd())
+	_, cmd = m.Update(cmd())
 	if cmd == nil {
 		t.Fatal("expected a cmd after routing FlagSubmitMsg through Update")
 	}
@@ -159,7 +159,7 @@ func TestFeed_FlagKey_Cancel_EmitsNoFlagMsg(t *testing.T) {
 	m = m.SetCurrentUsername("alice")
 
 	m, _ = m.Update(keyRune("!"))
-	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if cmd != nil {
 		if _, ok := cmd().(screens.FlagPostMsg); ok {
 			t.Fatal("esc should not emit FlagPostMsg")

--- a/internal/ui/screens/flagprompt.go
+++ b/internal/ui/screens/flagprompt.go
@@ -1,0 +1,130 @@
+package screens
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
+)
+
+const flagReasonCharLimit = 500
+
+// FlagKind distinguishes what a FlagPrompt is reporting, for its confirm text.
+type FlagKind int
+
+const (
+	FlagKindPost FlagKind = iota
+	FlagKindReply
+)
+
+// FlagSubmitMsg is emitted once the user confirms a report.
+type FlagSubmitMsg struct {
+	Reason string
+}
+
+// FlagCancelMsg is emitted when the user backs out of the flag flow entirely.
+type FlagCancelMsg struct{}
+
+// FlagPrompt is a two-step overlay for reporting a post or reply: type an
+// optional reason, then confirm y/n before the report (idempotent but
+// un-withdrawable) is sent. Shared by the feed and post-detail screens.
+type FlagPrompt struct {
+	active     bool
+	confirming bool // true once the reason step is done and a y/n confirm is showing
+	kind       FlagKind
+	reason     textinput.Model
+}
+
+func NewFlagPrompt() FlagPrompt {
+	ti := textinput.New()
+	ti.Placeholder = "reason (optional)"
+	ti.CharLimit = flagReasonCharLimit
+	return FlagPrompt{reason: ti}
+}
+
+// Open starts the flag flow, focusing the reason input.
+func (m FlagPrompt) Open(kind FlagKind) (FlagPrompt, tea.Cmd) {
+	m.active = true
+	m.confirming = false
+	m.kind = kind
+	m.reason.SetValue("")
+	return m, m.reason.Focus()
+}
+
+func (m FlagPrompt) Active() bool { return m.active }
+
+// Height returns the number of rows the prompt overlay consumes, for
+// viewport sizing — same footprint as the delete-confirm box.
+func (m FlagPrompt) Height() int { return confirmBoxHeight }
+
+func (m FlagPrompt) close() FlagPrompt {
+	m.active = false
+	m.confirming = false
+	m.reason.Blur()
+	return m
+}
+
+// Update handles a key while the prompt is active. Callers should route
+// tea.KeyMsg to this only when Active() is true, and treat all other
+// message types as opaque (not consumed here).
+func (m FlagPrompt) Update(msg tea.KeyMsg) (FlagPrompt, tea.Cmd) {
+	if m.confirming {
+		switch msg.String() {
+		case "y":
+			reason := strings.TrimSpace(m.reason.Value())
+			m = m.close()
+			return m, func() tea.Msg { return FlagSubmitMsg{Reason: reason} }
+		case "n":
+			m.confirming = false
+			return m, m.reason.Focus()
+		case "esc":
+			m = m.close()
+			return m, func() tea.Msg { return FlagCancelMsg{} }
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "esc":
+		m = m.close()
+		return m, func() tea.Msg { return FlagCancelMsg{} }
+	case "enter":
+		m.confirming = true
+		m.reason.Blur()
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.reason, cmd = m.reason.Update(msg)
+	return m, cmd
+}
+
+func (m FlagPrompt) label() string {
+	if m.kind == FlagKindReply {
+		return "reply"
+	}
+	return "post"
+}
+
+// View renders the overlay box at the given width (matching the viewport it
+// sits below).
+func (m FlagPrompt) View(width int) string {
+	m.reason.TextStyle = theme.Base
+	m.reason.PlaceholderStyle = theme.Subtle
+
+	var content string
+	if m.confirming {
+		reasonDesc := theme.Subtle.Render("(no reason)")
+		if v := strings.TrimSpace(m.reason.Value()); v != "" {
+			reasonDesc = theme.Base.Render(`"` + v + `"`)
+		}
+		content = theme.Error.Render("Report this "+m.label()+"?") + " " + reasonDesc + "  " +
+			theme.Base.Render("[y]es") + "  " +
+			theme.Subtle.Render("[n]o back / esc cancel")
+	} else {
+		content = theme.Base.Render("Report this "+m.label()+" — reason: ") + m.reason.View() + "  " +
+			theme.Subtle.Render("enter to continue / esc to cancel")
+	}
+	return theme.ActiveBorder.Width(width - 2).Render(content)
+}

--- a/internal/ui/screens/flagprompt.go
+++ b/internal/ui/screens/flagprompt.go
@@ -17,6 +17,7 @@ type FlagKind int
 const (
 	FlagKindPost FlagKind = iota
 	FlagKindReply
+	FlagKindMessage
 )
 
 // FlagSubmitMsg is emitted once the user confirms a report.
@@ -101,10 +102,14 @@ func (m FlagPrompt) Update(msg tea.KeyMsg) (FlagPrompt, tea.Cmd) {
 }
 
 func (m FlagPrompt) label() string {
-	if m.kind == FlagKindReply {
+	switch m.kind {
+	case FlagKindReply:
 		return "reply"
+	case FlagKindMessage:
+		return "message"
+	default:
+		return "post"
 	}
-	return "post"
 }
 
 // View renders the overlay box at the given width (matching the viewport it

--- a/internal/ui/screens/flagprompt_test.go
+++ b/internal/ui/screens/flagprompt_test.go
@@ -1,0 +1,76 @@
+package screens_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ragnar/cyber-tui/internal/ui/screens"
+)
+
+func typeKey(m screens.FlagPrompt, s string) (screens.FlagPrompt, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)})
+}
+
+func TestFlagPrompt_EnterThenYes_SubmitsTypedReason(t *testing.T) {
+	m := screens.NewFlagPrompt()
+	m, _ = m.Open(screens.FlagKindPost)
+	if !m.Active() {
+		t.Fatal("expected prompt to be active after Open")
+	}
+
+	for _, r := range "spam" {
+		m, _ = typeKey(m, string(r))
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	if m.Active() {
+		t.Error("expected prompt to close after confirming")
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd on confirm")
+	}
+	msg, ok := cmd().(screens.FlagSubmitMsg)
+	if !ok {
+		t.Fatalf("expected FlagSubmitMsg, got %T", cmd())
+	}
+	if msg.Reason != "spam" {
+		t.Errorf("Reason = %q, want %q", msg.Reason, "spam")
+	}
+}
+
+func TestFlagPrompt_NoAtConfirm_ReturnsToEditing(t *testing.T) {
+	m := screens.NewFlagPrompt()
+	m, _ = m.Open(screens.FlagKindReply)
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	if !m.Active() {
+		t.Error("expected prompt to remain active after 'n' at confirm step")
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd to re-focus the reason input")
+	}
+
+	// Still editable: typing now should not be swallowed as a y/n answer.
+	m, _ = typeKey(m, "x")
+	if !m.Active() {
+		t.Error("expected prompt to still be active while editing")
+	}
+}
+
+func TestFlagPrompt_EscAnyStage_CancelsAndCloses(t *testing.T) {
+	m := screens.NewFlagPrompt()
+	m, _ = m.Open(screens.FlagKindPost)
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if m.Active() {
+		t.Error("expected prompt to close on esc")
+	}
+	if cmd == nil {
+		t.Fatal("expected a cancel cmd on esc")
+	}
+	if _, ok := cmd().(screens.FlagCancelMsg); !ok {
+		t.Fatalf("expected FlagCancelMsg, got %T", cmd())
+	}
+}

--- a/internal/ui/screens/flagprompt_test.go
+++ b/internal/ui/screens/flagprompt_test.go
@@ -1,6 +1,7 @@
 package screens_test
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -56,6 +57,14 @@ func TestFlagPrompt_NoAtConfirm_ReturnsToEditing(t *testing.T) {
 	m, _ = typeKey(m, "x")
 	if !m.Active() {
 		t.Error("expected prompt to still be active while editing")
+	}
+}
+
+func TestFlagPrompt_FlagKindMessage_ShowsMessageWording(t *testing.T) {
+	m := screens.NewFlagPrompt()
+	m, _ = m.Open(screens.FlagKindMessage)
+	if !strings.Contains(m.View(80), "Report this message") {
+		t.Errorf("View() = %q, want it to mention 'Report this message'", m.View(80))
 	}
 }
 

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -158,6 +158,21 @@ type FlagReplyMsg struct {
 	Reason  string
 }
 
+// FlagMessageMsg is emitted by ChatroomsModel when the user confirms
+// reporting a cIRC message. Reason is optional (max 500 chars).
+type FlagMessageMsg struct {
+	RoomID    string
+	MessageID string
+	Reason    string
+}
+
+// DeleteRoomMessageMsg is emitted by ChatroomsModel when the user confirms
+// deleting their own cIRC message.
+type DeleteRoomMessageMsg struct {
+	RoomID    string
+	MessageID string
+}
+
 // ShowProfilePostMsg is emitted by ProfileModel when the user opens a post from
 // the Posts sub-tab. Handled by App in handleProfile (sets return to screenProfile).
 type ShowProfilePostMsg struct{ Post model.Post }

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -143,6 +143,21 @@ type DeleteReplyMsg struct {
 	PostID  string
 }
 
+// FlagPostMsg is emitted by FeedModel or PostDetailModel when the user
+// confirms reporting a post. Reason is optional (max 500 chars).
+type FlagPostMsg struct {
+	PostID string
+	Reason string
+}
+
+// FlagReplyMsg is emitted by PostDetailModel when the user confirms
+// reporting a reply. Reason is optional (max 500 chars).
+type FlagReplyMsg struct {
+	ReplyID string
+	PostID  string
+	Reason  string
+}
+
 // ShowProfilePostMsg is emitted by ProfileModel when the user opens a post from
 // the Posts sub-tab. Handled by App in handleProfile (sets return to screenProfile).
 type ShowProfilePostMsg struct{ Post model.Post }

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -127,6 +127,10 @@ type PostDetailModel struct {
 	confirming      pdConfirmKind // pending delete confirmation
 	maxThreadDepth  int           // max visual nesting depth; 0 treated as 3
 
+	flagPrompt        FlagPrompt // active while reporting the selected post or reply
+	flagTargetPostID  string     // set when flagging the post itself
+	flagTargetReplyID string     // set when flagging a reply (flagTargetPostID also set, as the reply's parent)
+
 	bookmarkedPostIDs  map[string]struct{}
 	bookmarkedReplyIDs map[string]struct{}
 	watchedPostIDs     map[string]struct{}
@@ -134,7 +138,8 @@ type PostDetailModel struct {
 
 func NewPostDetailModel() PostDetailModel {
 	return PostDetailModel{
-		compose: NewComposeModel(0),
+		compose:    NewComposeModel(0),
+		flagPrompt: NewFlagPrompt(),
 	}
 }
 
@@ -178,6 +183,8 @@ func (m PostDetailModel) Close() PostDetailModel {
 	m.err = nil
 	m.compose = m.compose.Close()
 	m.confirming = pdConfirmNone
+	m.flagPrompt = NewFlagPrompt()
+	m.flagTargetPostID, m.flagTargetReplyID = "", ""
 	return m
 }
 
@@ -240,8 +247,13 @@ func (m PostDetailModel) SelectedReplyID() string {
 // Ready reports whether the viewport has been initialised (i.e. a WindowSizeMsg was received).
 func (m PostDetailModel) Ready() bool { return m.ready }
 
-// ComposeActive reports whether the compose box is currently open.
-func (m PostDetailModel) ComposeActive() bool { return m.compose.IsActive() }
+// ComposeActive reports whether the compose box, the flag/report overlay, or
+// the delete-confirmation overlay is open. Every screen-owned overlay that
+// intercepts keys first in Update must be OR'd in here — app.go's global
+// shortcuts fire instead of reaching Update whenever this returns false.
+func (m PostDetailModel) ComposeActive() bool {
+	return m.compose.IsActive() || m.flagPrompt.Active() || m.confirming != pdConfirmNone
+}
 
 func (m PostDetailModel) SetError(err error) PostDetailModel {
 	m.err = err
@@ -337,6 +349,9 @@ func (m PostDetailModel) viewportHeight() int {
 	}
 	if m.confirming != pdConfirmNone {
 		h -= confirmBoxHeight
+	}
+	if m.flagPrompt.Active() {
+		h -= m.flagPrompt.Height()
 	}
 	if h < 1 {
 		h = 1
@@ -455,7 +470,33 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case FlagSubmitMsg:
+		postID, replyID := m.flagTargetPostID, m.flagTargetReplyID
+		m.flagTargetPostID, m.flagTargetReplyID = "", ""
+		if m.ready {
+			m.viewport.Height = m.viewportHeight()
+		}
+		if replyID != "" {
+			return m, func() tea.Msg {
+				return FlagReplyMsg{ReplyID: replyID, PostID: postID, Reason: msg.Reason}
+			}
+		}
+		return m, func() tea.Msg { return FlagPostMsg{PostID: postID, Reason: msg.Reason} }
+
+	case FlagCancelMsg:
+		m.flagTargetPostID, m.flagTargetReplyID = "", ""
+		if m.ready {
+			m.viewport.Height = m.viewportHeight()
+		}
+		return m, nil
+
 	case tea.KeyMsg:
+		// Flag overlay intercepts all keys while active.
+		if m.flagPrompt.Active() {
+			var cmd tea.Cmd
+			m.flagPrompt, cmd = m.flagPrompt.Update(msg)
+			return m, cmd
+		}
 		// Confirmation overlay intercepts all keys while active.
 		if m.confirming != pdConfirmNone {
 			switch msg.String() {
@@ -509,6 +550,27 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 				if m.flatTree[m.selectedReply].Reply.AuthorUsername == m.currentUsername {
 					m.confirming = pdConfirmDeleteReply
 					m.viewport.Height = m.viewportHeight()
+				}
+			}
+			return m, nil
+		case "!":
+			if m.selectedReply == -1 {
+				if m.post.ID != "" && m.post.AuthorUsername != m.currentUsername {
+					m.flagTargetPostID = m.post.ID
+					var cmd tea.Cmd
+					m.flagPrompt, cmd = m.flagPrompt.Open(FlagKindPost)
+					m.viewport.Height = m.viewportHeight()
+					return m, cmd
+				}
+			} else if m.selectedReply >= 0 && m.selectedReply < len(m.flatTree) {
+				reply := m.flatTree[m.selectedReply].Reply
+				if reply.AuthorUsername != m.currentUsername {
+					m.flagTargetPostID = m.post.ID
+					m.flagTargetReplyID = reply.ID
+					var cmd tea.Cmd
+					m.flagPrompt, cmd = m.flagPrompt.Open(FlagKindReply)
+					m.viewport.Height = m.viewportHeight()
+					return m, cmd
 				}
 			}
 			return m, nil
@@ -808,6 +870,13 @@ func (m PostDetailModel) View() string {
 		return lipgloss.JoinVertical(lipgloss.Left,
 			m.viewport.View(),
 			promptView,
+		)
+	}
+
+	if m.flagPrompt.Active() {
+		return lipgloss.JoinVertical(lipgloss.Left,
+			m.viewport.View(),
+			m.flagPrompt.View(m.width),
 		)
 	}
 

--- a/internal/ui/screens/postdetail_test.go
+++ b/internal/ui/screens/postdetail_test.go
@@ -342,7 +342,7 @@ func TestPostDetail_FlagKey_Cancel_EmitsNoFlagMsg(t *testing.T) {
 	m = m.SetPost(pdPost("p1"))
 
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
-	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if cmd != nil {
 		if _, ok := cmd().(screens.FlagPostMsg); ok {
 			t.Fatal("esc should not emit FlagPostMsg")

--- a/internal/ui/screens/postdetail_test.go
+++ b/internal/ui/screens/postdetail_test.go
@@ -241,3 +241,136 @@ func TestPostDetail_DepthCap(t *testing.T) {
 		}
 	}
 }
+
+// --- Flag / report ---
+
+func TestPostDetail_FlagKey_OnOwnPost_DoesNothing(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetCurrentUsername("op")
+	m = m.SetPost(pdPost("p1")) // pdPost author is "op"
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	if cmd != nil {
+		t.Fatal("expected no cmd when flagging own post")
+	}
+}
+
+func TestPostDetail_FlagKey_OnOtherPost_EmitsFlagPostMsg(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetCurrentUsername("alice")
+	m = m.SetPost(pdPost("p1")) // author "op" != "alice"
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	if cmd == nil {
+		t.Fatal("expected a focus cmd from opening the flag prompt")
+	}
+	for _, r := range "bad take" {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(string(r))})
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd == nil {
+		t.Fatal("expected a cmd after confirming")
+	}
+	_, cmd = m.Update(cmd())
+	if cmd == nil {
+		t.Fatal("expected a cmd after routing FlagSubmitMsg through Update")
+	}
+	msg, ok := cmd().(screens.FlagPostMsg)
+	if !ok {
+		t.Fatalf("expected FlagPostMsg, got %T", cmd())
+	}
+	if msg.PostID != "p1" {
+		t.Errorf("PostID = %q, want p1", msg.PostID)
+	}
+	if msg.Reason != "bad take" {
+		t.Errorf("Reason = %q, want %q", msg.Reason, "bad take")
+	}
+}
+
+func TestPostDetail_FlagKey_OnOwnReply_DoesNothing(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetCurrentUsername("alice")
+	m = m.SetPost(pdPost("p1"))
+	m = m.SetReplies([]model.Reply{pdReply("r1", "", "alice", time.Now())})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}) // select r1 (own reply)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	if cmd != nil {
+		t.Fatal("expected no cmd when flagging own reply")
+	}
+}
+
+func TestPostDetail_FlagKey_OnOtherReply_EmitsFlagReplyMsg(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetCurrentUsername("alice")
+	m = m.SetPost(pdPost("p1"))
+	m = m.SetReplies([]model.Reply{pdReply("r1", "", "bob", time.Now())})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}) // select r1 (bob's reply)
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	if cmd == nil {
+		t.Fatal("expected a focus cmd from opening the flag prompt")
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter}) // empty reason
+	m, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd == nil {
+		t.Fatal("expected a cmd after confirming")
+	}
+	_, cmd = m.Update(cmd())
+	if cmd == nil {
+		t.Fatal("expected a cmd after routing FlagSubmitMsg through Update")
+	}
+	msg, ok := cmd().(screens.FlagReplyMsg)
+	if !ok {
+		t.Fatalf("expected FlagReplyMsg, got %T", cmd())
+	}
+	if msg.ReplyID != "r1" {
+		t.Errorf("ReplyID = %q, want r1", msg.ReplyID)
+	}
+	if msg.PostID != "p1" {
+		t.Errorf("PostID = %q, want p1", msg.PostID)
+	}
+	if msg.Reason != "" {
+		t.Errorf("Reason = %q, want empty", msg.Reason)
+	}
+}
+
+func TestPostDetail_FlagKey_Cancel_EmitsNoFlagMsg(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetCurrentUsername("alice")
+	m = m.SetPost(pdPost("p1"))
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		if _, ok := cmd().(screens.FlagPostMsg); ok {
+			t.Fatal("esc should not emit FlagPostMsg")
+		}
+	}
+}
+
+func TestPostDetail_ComposeActive_TrueWhileFlagPromptOpen(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetCurrentUsername("alice")
+	m = m.SetPost(pdPost("p1")) // author "op" != "alice"
+
+	if m.ComposeActive() {
+		t.Fatal("setup: expected ComposeActive false before opening the flag prompt")
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	if !m.ComposeActive() {
+		t.Error("expected ComposeActive to report true while the flag/report overlay is open")
+	}
+}
+
+func TestPostDetail_ComposeActive_TrueWhileConfirmingDelete(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetCurrentUsername("op")
+	m = m.SetPost(pdPost("p1")) // author "op" == "op", so delete is allowed
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	if !m.ComposeActive() {
+		t.Error("expected ComposeActive to report true while the delete-confirm overlay is open")
+	}
+}

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/ragnar/cyber-tui/internal/model"
 	"github.com/ragnar/cyber-tui/internal/sanitize"
 	"github.com/ragnar/cyber-tui/internal/ui/markdown"
@@ -210,6 +211,11 @@ func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFor
 		ts := displayTime(msg.CreatedAt, loc, timeDisplayFormat, true)
 		tsWidth := lipgloss.Width(ts)
 
+		if msg.Deleted {
+			sb.WriteString(renderDeletedTombstone(msg.From.Username, ts, viewportWidth))
+			continue
+		}
+
 		if msg.IsAction {
 			sb.WriteString(renderActionLine(msg.From.Username, msg.Body, ts, viewportWidth, currentUser))
 			continue
@@ -244,6 +250,64 @@ func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFor
 		}
 	}
 	return sb.String()
+}
+
+// renderDeletedTombstone renders a soft-deleted cIRC message: the author and
+// original timestamp stay (per the API), but the body is replaced with a
+// muted "[DELETED]" marker — no markdown, no attachments, no text style.
+func renderDeletedTombstone(username, ts string, viewportWidth int) string {
+	const tsGap = 2 // minimum space between the body and the timestamp
+	const plainBody = "[DELETED]"
+	tsWidth := lipgloss.Width(ts)
+	prefix := "<" + theme.Subtle.Render(username) + ">  "
+	rawPrefixWidth := len(username) + 4
+	// Match renderCircMessages' layout exactly: reserve an elastic body field
+	// of bodyFieldWidth (not the [DELETED] marker's own short width), so the
+	// timestamp lands at the same right-aligned column as every other line.
+	bodyFieldWidth := max(viewportWidth-rawPrefixWidth-tsWidth-tsGap, len(plainBody))
+	pad := max(bodyFieldWidth-len(plainBody), 0) + tsGap
+	return prefix + theme.Subtle.Render(plainBody) + strings.Repeat(" ", pad) + theme.Subtle.Render(ts) + "\n"
+}
+
+// renderCircMessagesWithSelection renders msgs exactly like renderCircMessages
+// (byte-identical when selectedID == ""), additionally returning each
+// message's start-line offset and rendered line-height (1:1 with msgs, so
+// indices stay aligned even though system notices are never selectable), and
+// highlighting the message whose ID matches selectedID with theme.SelectedRow.
+//
+// The highlight can't simply wrap the normally-styled block: theme.Highlight/
+// theme.MeHighlight/markdown.RenderInline already emit their own ANSI reset
+// codes, which would terminate an outer background style mid-line. Instead,
+// the selected message's block is stripped back to plain text (ansi.Strip)
+// and only that plain text is wrapped in theme.SelectedRow — the same
+// approach settings.go uses for its selected-row highlight.
+func renderCircMessagesWithSelection(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, selectedID string) (content string, offsets []int, heights []int) {
+	offsets = make([]int, len(msgs))
+	heights = make([]int, len(msgs))
+	var sb strings.Builder
+	var lineCount int
+	for i, msg := range msgs {
+		rendered := renderCircMessages([]model.Message{msg}, loc, timeDisplayFormat, viewportWidth, currentUser)
+		if selectedID != "" && msg.ID == selectedID {
+			plain := strings.TrimSuffix(ansi.Strip(rendered), "\n")
+			rendered = theme.SelectedRow.Width(viewportWidth).Render(plain) + "\n"
+		}
+		offsets[i] = lineCount
+		// Not lipgloss.Height: it's strings.Count(s, "\n")+1, which treats
+		// rendered's own trailing "\n" as a phantom extra line. That's right
+		// for a whole-content string measured once, but wrong per-message
+		// here — concatenating N such strings and re-splitting on "\n" (as
+		// the viewport does) yields N real lines + 1 trailing empty line
+		// total, not N*(realLines+1). Summing the inflated per-message
+		// heights desyncs these offsets from the viewport's actual line
+		// count, which silently breaks scrolling (millerPageNav computes a
+		// YOffset the viewport's own maxYOffset() clamps right back down).
+		h := strings.Count(rendered, "\n")
+		heights[i] = h
+		lineCount += h
+		sb.WriteString(rendered)
+	}
+	return sb.String(), offsets, heights
 }
 
 // renderActionLine renders a /me-style action message in classic IRC form:

--- a/internal/ui/screens/render_test.go
+++ b/internal/ui/screens/render_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/termenv"
 	"github.com/ragnar/cyber-tui/internal/model"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
@@ -114,6 +115,64 @@ func TestRenderCircMessages_SystemNotice(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected the regular message after the system notice to still render")
+	}
+}
+
+// TestRenderCircMessages_DeletedTombstone confirms a soft-deleted message
+// renders as a muted "[DELETED]" tombstone, keeping the author and
+// timestamp (per the API's "your name and the original timestamp stay"),
+// but never the original body text.
+func TestRenderCircMessages_DeletedTombstone(t *testing.T) {
+	const width = 60
+	deleted := model.Message{
+		ID:        "m1",
+		From:      model.User{Username: "molly"},
+		Body:      "this secret sauce recipe leaked",
+		Deleted:   true,
+		CreatedAt: circMsgTime,
+	}
+
+	out := renderCircMessages([]model.Message{deleted}, time.UTC, "datetime", width, "")
+
+	if !strings.Contains(out, "<molly>") {
+		t.Errorf("expected the author to still be shown, got: %q", out)
+	}
+	if !strings.Contains(out, "[DELETED]") {
+		t.Errorf("expected a [DELETED] marker, got: %q", out)
+	}
+	if strings.Contains(out, "secret sauce") {
+		t.Errorf("expected the original body to NOT appear, got: %q", out)
+	}
+}
+
+// TestRenderCircMessages_DeletedTombstone_TimestampAlignsWithNormalMessage
+// guards a real bug found in manual testing: the tombstone's timestamp
+// landed two columns left of where every other message's timestamp sits,
+// because its gap math used the "[DELETED]" marker's own short width
+// instead of the same elastic body-field width renderCircMessages reserves
+// for normal messages.
+func TestRenderCircMessages_DeletedTombstone_TimestampAlignsWithNormalMessage(t *testing.T) {
+	const width = 60
+	normal := circMsg("molly", "hello there")
+	deleted := model.Message{
+		ID:        "m1",
+		From:      model.User{Username: "molly"},
+		Body:      "irrelevant once deleted",
+		Deleted:   true,
+		CreatedAt: circMsgTime,
+	}
+
+	normalLine := strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{normal}, time.UTC, "datetime", width, "")), "\n")
+	deletedLine := strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{deleted}, time.UTC, "datetime", width, "")), "\n")
+
+	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
+	normalIdx := strings.Index(normalLine, ts)
+	deletedIdx := strings.Index(deletedLine, ts)
+	if normalIdx == -1 || deletedIdx == -1 {
+		t.Fatalf("timestamp %q not found: normal=%q deleted=%q", ts, normalLine, deletedLine)
+	}
+	if normalIdx != deletedIdx {
+		t.Errorf("tombstone timestamp starts at column %d, want %d (same as a normal message)", deletedIdx, normalIdx)
 	}
 }
 

--- a/internal/ui/screens/screens_test.go
+++ b/internal/ui/screens/screens_test.go
@@ -741,7 +741,7 @@ func TestChatrooms_FlagKey_OnOtherMessage_FullFlowEmitsFlagMessageMsg(t *testing
 		t.Fatal("expected a cmd after confirming")
 	}
 	// The real runtime feeds the cmd's message back through Update; do the same here.
-	m, cmd = m.Update(cmd())
+	_, cmd = m.Update(cmd())
 	if cmd == nil {
 		t.Fatal("expected a cmd after routing FlagSubmitMsg through Update")
 	}

--- a/internal/ui/screens/screens_test.go
+++ b/internal/ui/screens/screens_test.go
@@ -2,6 +2,7 @@ package screens_test
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -460,6 +461,33 @@ func TestChatrooms_UpAtTop_TriggersHistoryLoadThenGuards(t *testing.T) {
 	}
 }
 
+// TestChatrooms_Up_MultiMessageRoomThatFits_NoSpuriousHistoryLoad guards a
+// bug found in manual testing: a short room's content already fits within
+// the viewport, so the viewport is trivially "at top" (YOffset 0) from the
+// moment it renders — checking viewport.AtTop() right after entering
+// browsing fired a history-load on essentially every first "up" press,
+// regardless of which message got selected. Pagination should only fire
+// once the selection actually reaches the oldest loaded message.
+func TestChatrooms_Up_MultiMessageRoomThatFits_NoSpuriousHistoryLoad(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "first", CreatedAt: time.Now()},
+		{ID: "m2", From: model.User{Username: "wintermute"}, Body: "second", CreatedAt: time.Now()},
+		{ID: "m3", From: model.User{Username: "molly"}, Body: "third", CreatedAt: time.Now()},
+	})
+
+	m, cmd := sendChatroomSpecialKey(m, tea.KeyUp) // enter browsing, select m3 (newest)
+	if cmd != nil {
+		t.Error("expected no history-load command when entering browsing on a multi-message room")
+	}
+	if m.SelectedMessageID() != "m3" {
+		t.Fatalf("SelectedMessageID() = %q, want m3", m.SelectedMessageID())
+	}
+}
+
 func TestChatrooms_UpAtTop_NoMessagesNoCmd(t *testing.T) {
 	m := screens.NewChatroomsModel("neuromancer", nil)
 	m = m.SetRooms(sampleRooms())
@@ -468,6 +496,411 @@ func TestChatrooms_UpAtTop_NoMessagesNoCmd(t *testing.T) {
 	_, cmd := sendChatroomSpecialKey(m, tea.KeyUp)
 	if cmd != nil {
 		t.Error("expected no history-load command with no messages loaded")
+	}
+}
+
+// --- ChatroomsModel: per-message selection ("browsing") + flag/report ---
+
+func TestChatrooms_Up_EntersBrowsing_SelectsNewest(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "first", CreatedAt: time.Now()},
+		{ID: "m2", From: model.User{Username: "wintermute"}, Body: "second", CreatedAt: time.Now()},
+	})
+
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+	if m.SelectedMessageID() != "m2" {
+		t.Errorf("SelectedMessageID() = %q, want m2 (newest)", m.SelectedMessageID())
+	}
+}
+
+func TestChatrooms_Up_SkipsSystemMessages(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "first", CreatedAt: time.Now()},
+	})
+	m = m.AppendSystemMessage("zion", "*** a local notice")
+
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+	if m.SelectedMessageID() != "m1" {
+		t.Errorf("SelectedMessageID() = %q, want m1 (system notice must never be selectable)", m.SelectedMessageID())
+	}
+}
+
+func TestChatrooms_Esc_WhileBrowsing_ClearsSelectionWithoutLeavingRoom(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "first", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+	if m.SelectedMessageID() == "" {
+		t.Fatal("setup: expected a selection after up")
+	}
+
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEsc)
+	if m.SelectedMessageID() != "" {
+		t.Error("expected esc to clear the selection")
+	}
+	if !m.IsShowingDetail() {
+		t.Error("expected esc while browsing to stay in the room, not leave it")
+	}
+}
+
+func TestChatrooms_Down_PastNewest_ExitsBrowsing(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "first", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp) // select the only (newest) message
+
+	m, _ = sendChatroomSpecialKey(m, tea.KeyDown)
+	if m.SelectedMessageID() != "" {
+		t.Error("expected down past the newest message to exit browsing")
+	}
+}
+
+func TestChatrooms_WhileBrowsing_OtherKeysAreSwallowed_NotTypedIntoCompose(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "first", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+
+	m, _ = sendChatroomKey(m, "q")
+	m, _ = sendChatroomKey(m, "1")
+	if m.SelectedMessageID() == "" {
+		t.Error("expected selection to remain active after unrelated keys")
+	}
+
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEsc)
+	if !m.ComposeEmpty() {
+		t.Error("expected compose box to remain empty — browsing must not type into it")
+	}
+}
+
+func TestChatrooms_DraftPreserved_AcrossBrowsingRoundTrip(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "first", CreatedAt: time.Now()},
+	})
+	for _, r := range "hello" {
+		m, _ = sendChatroomKey(m, string(r))
+	}
+	if m.ComposeEmpty() {
+		t.Fatal("setup: expected a draft before browsing")
+	}
+
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)  // enter browsing
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEsc) // back to typing
+
+	if m.ComposeEmpty() {
+		t.Error("expected the draft to survive a trip into browsing and back")
+	}
+}
+
+func TestChatrooms_Up_WhileBrowsingAtOldest_StillTriggersHistoryLoad(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	// A short viewport (2 message-history rows) so 3 one-line messages don't
+	// all fit at once — otherwise the viewport is trivially "at top" the
+	// instant any message renders, regardless of which one is selected, and
+	// this test couldn't distinguish "browsing" from "reached the oldest".
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 10})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "first", CreatedAt: time.Now()},
+		{ID: "m2", From: model.User{Username: "wintermute"}, Body: "second", CreatedAt: time.Now()},
+		{ID: "m3", From: model.User{Username: "molly"}, Body: "third", CreatedAt: time.Now()},
+	})
+
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp) // enter browsing, select m3 (newest)
+	if m.SelectedMessageID() != "m3" {
+		t.Fatalf("setup: SelectedMessageID() = %q, want m3", m.SelectedMessageID())
+	}
+	m, cmd := sendChatroomSpecialKey(m, tea.KeyUp) // move to m2 (middle — not the oldest yet)
+	if cmd != nil {
+		t.Fatal("expected no history-load cmd yet — not at the oldest message")
+	}
+	if m.SelectedMessageID() != "m2" {
+		t.Fatalf("SelectedMessageID() = %q, want m2", m.SelectedMessageID())
+	}
+
+	_, cmd = sendChatroomSpecialKey(m, tea.KeyUp) // reaches m1 (oldest) — pagination fires
+	if cmd == nil {
+		t.Error("expected a history-load command when browsing reaches the oldest loaded message")
+	}
+}
+
+// TestChatrooms_DownThroughManyMessages_ReachesNewestAndExits guards a real
+// bug found in manual testing: with more messages than fit in the viewport,
+// 'down' got permanently stuck partway through and never reached the newest
+// message or exited browsing. Root cause was in renderCircMessagesWithSelection
+// (render.go): each message's height was measured with lipgloss.Height,
+// which is strings.Count(s, "\n")+1 — correct once for a whole multi-line
+// string, but wrong when applied per-message and summed, since it counts
+// each message's own trailing "\n" as a phantom extra line. The summed
+// (inflated) offsets desynced from the viewport's real line count, so
+// millerPageNav kept computing a YOffset the viewport's own maxYOffset()
+// clamped right back down — an invisible deadlock.
+func TestChatrooms_DownThroughManyMessages_ReachesNewestAndExits(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 14}) // small: forces real scrolling
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+
+	var msgs []model.Message
+	for i := 1; i <= 10; i++ {
+		msgs = append(msgs, model.Message{
+			ID:        fmt.Sprintf("m%d", i),
+			From:      model.User{Username: "molly"},
+			Body:      fmt.Sprintf("message number %d", i),
+			CreatedAt: time.Now().Add(time.Duration(i) * time.Minute),
+		})
+	}
+	m = m.SetMessages("zion", msgs)
+
+	// Walk all the way up to the oldest message first (m1), then test that
+	// 'down' can walk all the way back down without getting stuck.
+	for i := 0; i < 10; i++ {
+		m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+	}
+	if m.SelectedMessageID() != "m1" {
+		t.Fatalf("setup: SelectedMessageID() = %q after walking up, want m1 (oldest)", m.SelectedMessageID())
+	}
+
+	for i := 0; i < 9; i++ {
+		m, _ = sendChatroomSpecialKey(m, tea.KeyDown)
+		if m.SelectedMessageID() == "" {
+			t.Fatalf("down got stuck or exited early after %d presses (expected still browsing)", i+1)
+		}
+	}
+	if m.SelectedMessageID() != "m10" {
+		t.Fatalf("SelectedMessageID() = %q after 9 downs from m1, want m10 (newest)", m.SelectedMessageID())
+	}
+
+	m, _ = sendChatroomSpecialKey(m, tea.KeyDown) // one more: past newest, exits browsing
+	if m.SelectedMessageID() != "" {
+		t.Errorf("expected browsing to exit after 'down' past the newest message, got selected=%q", m.SelectedMessageID())
+	}
+}
+
+func TestChatrooms_FlagKey_OnOwnMessage_DoesNothing(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "neuromancer"}, Body: "mine", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+
+	_, cmd := sendChatroomKey(m, "!")
+	if cmd != nil {
+		t.Error("expected no cmd when flagging own message")
+	}
+}
+
+func TestChatrooms_FlagKey_OnOtherMessage_FullFlowEmitsFlagMessageMsg(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "not mine", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+
+	m, cmd := sendChatroomKey(m, "!")
+	if cmd == nil {
+		t.Fatal("expected a focus cmd from opening the flag prompt")
+	}
+	for _, r := range "spam" {
+		m, _ = sendChatroomKey(m, string(r))
+	}
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m, cmd = sendChatroomKey(m, "y")
+	if cmd == nil {
+		t.Fatal("expected a cmd after confirming")
+	}
+	// The real runtime feeds the cmd's message back through Update; do the same here.
+	m, cmd = m.Update(cmd())
+	if cmd == nil {
+		t.Fatal("expected a cmd after routing FlagSubmitMsg through Update")
+	}
+	msg, ok := cmd().(screens.FlagMessageMsg)
+	if !ok {
+		t.Fatalf("expected FlagMessageMsg, got %T", cmd())
+	}
+	if msg.MessageID != "m1" {
+		t.Errorf("MessageID = %q, want m1", msg.MessageID)
+	}
+	if msg.RoomID != "zion" {
+		t.Errorf("RoomID = %q, want zion", msg.RoomID)
+	}
+	if msg.Reason != "spam" {
+		t.Errorf("Reason = %q, want spam", msg.Reason)
+	}
+}
+
+func TestChatrooms_DeleteKey_OnOwnMessage_OpensConfirm(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "neuromancer"}, Body: "mine", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+
+	m, _ = sendChatroomKey(m, "d")
+	if m.ComposeEmpty() {
+		t.Error("expected the delete-confirm overlay to be open after 'd' on your own message")
+	}
+}
+
+func TestChatrooms_DeleteKey_OnOtherMessage_DoesNothing(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "not mine", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+
+	m, cmd := sendChatroomKey(m, "d")
+	if cmd != nil {
+		t.Error("expected no cmd when deleting someone else's message")
+	}
+	if !m.ComposeEmpty() {
+		t.Error("expected no delete-confirm overlay for someone else's message")
+	}
+}
+
+func TestChatrooms_DeleteKey_OnAlreadyDeletedMessage_DoesNothing(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "neuromancer"}, Body: "[DELETED]", Deleted: true, CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+
+	m, _ = sendChatroomKey(m, "d")
+	if !m.ComposeEmpty() {
+		t.Error("expected no delete-confirm overlay for an already-deleted message")
+	}
+}
+
+func TestChatrooms_FlagKey_OnAlreadyDeletedMessage_DoesNothing(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "[DELETED]", Deleted: true, CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+
+	_, cmd := sendChatroomKey(m, "!")
+	if cmd != nil {
+		t.Error("expected no cmd when flagging an already-deleted message")
+	}
+}
+
+func TestChatrooms_DeleteConfirm_Yes_EmitsDeleteRoomMessageMsg(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "neuromancer"}, Body: "mine", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+	m, _ = sendChatroomKey(m, "d")
+
+	m, cmd := sendChatroomKey(m, "y")
+	if cmd == nil {
+		t.Fatal("expected a cmd after confirming delete")
+	}
+	msg, ok := cmd().(screens.DeleteRoomMessageMsg)
+	if !ok {
+		t.Fatalf("expected DeleteRoomMessageMsg, got %T", cmd())
+	}
+	if msg.MessageID != "m1" {
+		t.Errorf("MessageID = %q, want m1", msg.MessageID)
+	}
+	if msg.RoomID != "zion" {
+		t.Errorf("RoomID = %q, want zion", msg.RoomID)
+	}
+	if !m.ComposeEmpty() {
+		t.Error("expected the delete-confirm overlay to close after confirming")
+	}
+}
+
+func TestChatrooms_DeleteConfirm_No_Cancels(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "neuromancer"}, Body: "mine", CreatedAt: time.Now()},
+	})
+	m, _ = sendChatroomSpecialKey(m, tea.KeyUp)
+	m, _ = sendChatroomKey(m, "d")
+
+	m, cmd := sendChatroomKey(m, "n")
+	if cmd != nil {
+		t.Error("expected no cmd when declining the delete confirmation")
+	}
+	if !m.ComposeEmpty() {
+		t.Error("expected the delete-confirm overlay to close after declining")
+	}
+	if m.SelectedMessageID() != "m1" {
+		t.Errorf("expected the selection to remain on m1 after declining, got %q", m.SelectedMessageID())
+	}
+}
+
+func TestChatrooms_ApplyMessageDeleted_RendersTombstoneInPlace(t *testing.T) {
+	m := screens.NewChatroomsModel("neuromancer", nil)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetRooms(sampleRooms())
+	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter)
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "top secret plans", CreatedAt: time.Now()},
+		{ID: "m2", From: model.User{Username: "wintermute"}, Body: "unrelated message", CreatedAt: time.Now()},
+	})
+
+	m = m.ApplyMessageDeleted("m1")
+
+	view := m.View()
+	if !strings.Contains(view, "[DELETED]") {
+		t.Errorf("expected a [DELETED] tombstone in the view, got: %q", view)
+	}
+	if strings.Contains(view, "top secret plans") {
+		t.Errorf("expected the original body to be gone, got: %q", view)
+	}
+	if !strings.Contains(view, "unrelated message") {
+		t.Errorf("expected the other message to be unaffected, got: %q", view)
 	}
 }
 
@@ -744,4 +1177,3 @@ func resolveMsgs(cmd tea.Cmd) []tea.Msg {
 	}
 	return []tea.Msg{msg}
 }
-


### PR DESCRIPTION
## Summary
- Adds flagging (report for moderation review) for posts, replies, and cIRC chat messages, matching the newly documented `POST .../flag` endpoints (idempotent, optional reason, blocked on your own content).
- Adds per-message navigation to cIRC chat rooms (`up`/`down` to browse, `esc` to return to typing) as the mechanism both flagging and delete act on.
- Adds deleting your own cIRC message (`d`), including live propagation to other clients in the room via a previously-unhandled RTDB `patch` event.
- Several bugs found via manual/tmux testing along the way, each fixed with a regression test (see commit messages for full root-cause writeups): global-shortcut keys hijacking the flag-reason/delete-confirm input fields, `up` firing a spurious history-load on nearly every press in a short room, `down` getting permanently stuck in a long room (an offset-measurement bug), the deleted-message tombstone's timestamp being misaligned, and `esc` not returning the viewport to the live tail.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green
- [x] New unit/regression tests for every fix and every new code path (API client, render, screen state machine, app-level key routing)
- [x] Manually verified live in `tmux` against the mock client: flagging a post/reply/message end-to-end, deleting a message and seeing the tombstone render correctly, typing (including `!`) unaffected outside browsing, arrow keys editing the reason/confirm overlays instead of switching tabs, `esc` returning to the live tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)