### PR TITLE
feat: implement gifUrl, imageUrl, audioAttachment, and message styles

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -154,13 +154,13 @@ Both cIRC and C-Mail support IRC-style slash commands expanded server-side: `/me
 
 ### Message attachments & styles (new in v0.8)
 
-cIRC/C-Mail messages can now carry `imageUrl`, `gifUrl` (`/gif <url>`), `audioAttachment` (`/song ... — supporter-only`), `style` (chainable text styles via `/blink`, `/l33t`, `/comic`, `/cursive`, `/times`, `/rainbow`, `/flip`, `/quiet`, `/slow`, `/glitch`, `/spoiler`, `/wave`), and ASCII art (`/art`, cIRC-only, base64-encoded `content` when `style: "art"`). `/mute`/`/unmute`/`/muted`/`/unmuteall` manage a per-room, client-side-enforced mute list (also stored in `mutedUsersByRoom` under Settings — currently intentionally omitted from the TUI per the Settings row below). None of this is implemented client-side yet; `content` can now legitimately be empty when an attachment is the whole message.
+cIRC/C-Mail messages can now carry `imageUrl`, `gifUrl` (`/gif <url>`), `audioAttachment` (`/song ... — supporter-only`), `style` (chainable text styles via `/blink`, `/l33t`, `/comic`, `/cursive`, `/times`, `/rainbow`, `/flip`, `/quiet`, `/slow`, `/glitch`, `/spoiler`, `/wave`), and ASCII art (`/art`, cIRC-only, base64-encoded `content` when `style: "art"`). `/mute`/`/unmute`/`/muted`/`/unmuteall` manage a per-room, client-side-enforced mute list (also stored in `mutedUsersByRoom` under Settings — currently intentionally omitted from the TUI per the Settings row below).
 
 | Area | Description | Priority |
 |---|---|---|
-| `gifUrl`, `audioAttachment`, `style`, chained styles | Render/decode in message view; `style: "art"` needs base64 decode | Not implemented |
+| `gifUrl`, `audioAttachment`, `style`, chained styles | Render/decode in message view; `style: "art"` needs base64 decode | **Done** — wire/model fields across all four message shapes, attachment badges reusing `renderAttachments`, and a middle-fidelity style pipeline (ANSI attributes for blink/quiet/rainbow, Unicode substitution for l33t/cursive/flip, ASCII-safe jitter for glitch, `tea.Tick`-driven slow/wave/glitch animation, select-to-reveal spoiler in cIRC only — see `internal/ui/screens/chatstyle.go`) |
 | `/mute` family + `mutedUsersByRoom` | Client-side message filtering by muted user | Not implemented |
-| Empty `content` with attachment-only messages | Message rendering must not assume non-empty `content` | Not implemented |
+| Empty `content` with attachment-only messages | Message rendering must not assume non-empty `content` | **Done** — covered by the same change; `messageDisplayBody` skips duplicate URL text and empty bodies render without assuming non-empty `content` |
 
 ### Auth (new in v0.8)
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -76,6 +78,36 @@ type wireAttachment struct {
 	Artist string `json:"artist,omitempty"`
 	Title  string `json:"title,omitempty"`
 	Genre  string `json:"genre,omitempty"`
+}
+
+// wireStyle decodes a message's `style` field, sent as either a single
+// string or an array of strings for chained styles (e.g. "rainbow" or
+// ["comic","rainbow"]).
+type wireStyle []string
+
+func (s *wireStyle) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || string(b) == "null" {
+		*s = nil
+		return nil
+	}
+	if b[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal(b, &arr); err != nil {
+			return err
+		}
+		*s = arr
+		return nil
+	}
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return err
+	}
+	if str != "" {
+		*s = []string{str}
+	} else {
+		*s = nil
+	}
+	return nil
 }
 
 // apiTimestamp decodes a JSON value that may be an RFC3339 string (the
@@ -445,14 +477,18 @@ type wireRTDBPresenceEntry struct {
 
 // wireCircMessage is a single message from GET /v1/circ/:roomId.
 type wireCircMessage struct {
-	ID          string `json:"id"`
-	UserID      string `json:"userId"`
-	Username    string `json:"username"`
-	IsChatAdmin bool   `json:"isChatAdmin"`
-	IsAction    bool   `json:"isAction"` // undocumented; true for /me and other emote commands
-	Content     string `json:"content"`
-	Timestamp   int64  `json:"timestamp"` // epoch ms
-	Deleted     bool   `json:"deleted"`
+	ID              string          `json:"id"`
+	UserID          string          `json:"userId"`
+	Username        string          `json:"username"`
+	IsChatAdmin     bool            `json:"isChatAdmin"`
+	IsAction        bool            `json:"isAction"` // undocumented; true for /me and other emote commands
+	Content         string          `json:"content"`
+	Timestamp       int64           `json:"timestamp"` // epoch ms
+	Deleted         bool            `json:"deleted"`
+	ImageUrl        string          `json:"imageUrl,omitempty"`
+	GifUrl          string          `json:"gifUrl,omitempty"`
+	AudioAttachment *wireAttachment `json:"audioAttachment,omitempty"`
+	Style           wireStyle       `json:"style,omitempty"`
 }
 
 // --- C-Mail wire types ---
@@ -473,12 +509,16 @@ type wireCMailConversation struct {
 
 // wireCMailMessage is a single message from GET /v1/cmail/:id.
 type wireCMailMessage struct {
-	ID             string `json:"id"`
-	SenderID       string `json:"senderId"`
-	SenderUsername string `json:"senderUsername"`
-	IsAction       bool   `json:"isAction"` // undocumented; true for /me and other emote commands
-	Content        string `json:"content"`
-	Timestamp      int64  `json:"timestamp"` // epoch ms
+	ID              string          `json:"id"`
+	SenderID        string          `json:"senderId"`
+	SenderUsername  string          `json:"senderUsername"`
+	IsAction        bool            `json:"isAction"` // undocumented; true for /me and other emote commands
+	Content         string          `json:"content"`
+	Timestamp       int64           `json:"timestamp"` // epoch ms
+	ImageUrl        string          `json:"imageUrl,omitempty"`
+	GifUrl          string          `json:"gifUrl,omitempty"`
+	AudioAttachment *wireAttachment `json:"audioAttachment,omitempty"`
+	Style           wireStyle       `json:"style,omitempty"`
 }
 
 // wireCMailStartResponse is returned by POST /v1/cmail.
@@ -505,24 +545,32 @@ type wireRTDBTypingEntry struct {
 
 // wireRTDBMessage is the Firebase shape for a DM message in /dm_messages/<convId>/<msgId>.
 type wireRTDBMessage struct {
-	SenderID       string  `json:"senderId"`
-	SenderUsername string  `json:"senderUsername"`
-	IsAction       bool    `json:"isAction"` // undocumented; true for /me and other emote commands
-	Content        string  `json:"content"`
-	Timestamp      float64 `json:"timestamp"` // epoch ms as a Firebase number
-	Read           bool    `json:"read"`
+	SenderID        string          `json:"senderId"`
+	SenderUsername  string          `json:"senderUsername"`
+	IsAction        bool            `json:"isAction"` // undocumented; true for /me and other emote commands
+	Content         string          `json:"content"`
+	Timestamp       float64         `json:"timestamp"` // epoch ms as a Firebase number
+	Read            bool            `json:"read"`
+	ImageUrl        string          `json:"imageUrl,omitempty"`
+	GifUrl          string          `json:"gifUrl,omitempty"`
+	AudioAttachment *wireAttachment `json:"audioAttachment,omitempty"`
+	Style           wireStyle       `json:"style,omitempty"`
 }
 
 // wireRTDBCircMessage is the Firebase shape for a CIRC chatroom message in /chat_messages/<roomId>/<msgId>.
 // Field names differ from DM messages (userId/username vs senderId/senderUsername).
 type wireRTDBCircMessage struct {
-	UserID      string  `json:"userId"`
-	Username    string  `json:"username"`
-	IsChatAdmin bool    `json:"isChatAdmin"`
-	IsAction    bool    `json:"isAction"` // undocumented; true for /me and other emote commands
-	Content     string  `json:"content"`
-	Timestamp   float64 `json:"timestamp"` // epoch ms as a Firebase number
-	Deleted     bool    `json:"deleted"`
+	UserID          string          `json:"userId"`
+	Username        string          `json:"username"`
+	IsChatAdmin     bool            `json:"isChatAdmin"`
+	IsAction        bool            `json:"isAction"` // undocumented; true for /me and other emote commands
+	Content         string          `json:"content"`
+	Timestamp       float64         `json:"timestamp"` // epoch ms as a Firebase number
+	Deleted         bool            `json:"deleted"`
+	ImageUrl        string          `json:"imageUrl,omitempty"`
+	GifUrl          string          `json:"gifUrl,omitempty"`
+	AudioAttachment *wireAttachment `json:"audioAttachment,omitempty"`
+	Style           wireStyle       `json:"style,omitempty"`
 }
 
 // wireRTDBSSEData is the outer wrapper of a Firebase "put" SSE event's data field.
@@ -811,6 +859,39 @@ func wireAttachmentsToModel(ws []wireAttachment) []model.Attachment {
 		}
 	}
 	return out
+}
+
+// wireAudioAttachmentToModel converts a message's optional audioAttachment
+// object to the model type. Returns nil when w is nil.
+func wireAudioAttachmentToModel(w *wireAttachment) *model.Attachment {
+	if w == nil {
+		return nil
+	}
+	return &model.Attachment{
+		Type:   "audio",
+		Src:    w.Src,
+		Origin: w.Origin,
+		Artist: w.Artist,
+		Title:  w.Title,
+		Genre:  w.Genre,
+	}
+}
+
+// decodeArtBody base64-decodes content when styles contains "art" (the
+// /art command's response shape sends its ASCII art body base64-encoded).
+// Returns content unchanged otherwise. An undecodable payload falls back to
+// the raw string rather than dropping the message — same "never break the
+// rest of the decode" philosophy as apiTimestamp's unrecognized-shape fallback.
+func decodeArtBody(content string, styles []string) string {
+	if !slices.Contains(styles, "art") {
+		return content
+	}
+	decoded, err := base64.StdEncoding.DecodeString(content)
+	if err != nil {
+		log.Printf("api: decodeArtBody: bad base64 for art message")
+		return content
+	}
+	return string(decoded)
 }
 
 func wirePostToModel(w wirePost) model.Post {
@@ -1622,13 +1703,17 @@ func (c *HTTPClient) GetRoomMessages(roomID string, limit int, before int64) ([]
 func wireCircMessageToModel(w wireCircMessage) model.Message {
 	sanitize.Strings(&w)
 	return model.Message{
-		ID:          w.ID,
-		From:        model.User{ID: w.UserID, Username: w.Username},
-		Body:        w.Content,
-		CreatedAt:   time.UnixMilli(w.Timestamp),
-		IsChatAdmin: w.IsChatAdmin,
-		IsAction:    w.IsAction,
-		Deleted:     w.Deleted,
+		ID:              w.ID,
+		From:            model.User{ID: w.UserID, Username: w.Username},
+		Body:            decodeArtBody(w.Content, w.Style),
+		CreatedAt:       time.UnixMilli(w.Timestamp),
+		IsChatAdmin:     w.IsChatAdmin,
+		IsAction:        w.IsAction,
+		Deleted:         w.Deleted,
+		ImageUrl:        w.ImageUrl,
+		GifUrl:          w.GifUrl,
+		AudioAttachment: wireAudioAttachmentToModel(w.AudioAttachment),
+		Style:           []string(w.Style),
 	}
 }
 
@@ -1983,11 +2068,15 @@ func (c *HTTPClient) rtdbOrErr() (*rtdb.Client, error) {
 func wireRTDBMessageToModel(id string, wm wireRTDBMessage) model.Message {
 	sanitize.Strings(&wm)
 	return model.Message{
-		ID:        id,
-		From:      model.User{ID: wm.SenderID, Username: wm.SenderUsername},
-		Body:      wm.Content,
-		CreatedAt: time.UnixMilli(int64(wm.Timestamp)),
-		IsAction:  wm.IsAction,
+		ID:              id,
+		From:            model.User{ID: wm.SenderID, Username: wm.SenderUsername},
+		Body:            decodeArtBody(wm.Content, wm.Style),
+		CreatedAt:       time.UnixMilli(int64(wm.Timestamp)),
+		IsAction:        wm.IsAction,
+		ImageUrl:        wm.ImageUrl,
+		GifUrl:          wm.GifUrl,
+		AudioAttachment: wireAudioAttachmentToModel(wm.AudioAttachment),
+		Style:           []string(wm.Style),
 	}
 }
 
@@ -1995,13 +2084,17 @@ func wireRTDBMessageToModel(id string, wm wireRTDBMessage) model.Message {
 func wireRTDBCircMessageToModel(id string, wm wireRTDBCircMessage) model.Message {
 	sanitize.Strings(&wm)
 	return model.Message{
-		ID:          id,
-		From:        model.User{ID: wm.UserID, Username: wm.Username},
-		Body:        wm.Content,
-		CreatedAt:   time.UnixMilli(int64(wm.Timestamp)),
-		IsChatAdmin: wm.IsChatAdmin,
-		IsAction:    wm.IsAction,
-		Deleted:     wm.Deleted,
+		ID:              id,
+		From:            model.User{ID: wm.UserID, Username: wm.Username},
+		Body:            decodeArtBody(wm.Content, wm.Style),
+		CreatedAt:       time.UnixMilli(int64(wm.Timestamp)),
+		IsChatAdmin:     wm.IsChatAdmin,
+		IsAction:        wm.IsAction,
+		Deleted:         wm.Deleted,
+		ImageUrl:        wm.ImageUrl,
+		GifUrl:          wm.GifUrl,
+		AudioAttachment: wireAudioAttachmentToModel(wm.AudioAttachment),
+		Style:           []string(wm.Style),
 	}
 }
 
@@ -2056,11 +2149,15 @@ func (c *HTTPClient) GetMessages(conversationID string, limit int, before int64)
 func wireCMailMessageToModel(w wireCMailMessage) model.Message {
 	sanitize.Strings(&w)
 	return model.Message{
-		ID:        w.ID,
-		From:      model.User{ID: w.SenderID, Username: w.SenderUsername},
-		Body:      w.Content,
-		CreatedAt: time.UnixMilli(w.Timestamp),
-		IsAction:  w.IsAction,
+		ID:              w.ID,
+		From:            model.User{ID: w.SenderID, Username: w.SenderUsername},
+		Body:            decodeArtBody(w.Content, w.Style),
+		CreatedAt:       time.UnixMilli(w.Timestamp),
+		IsAction:        w.IsAction,
+		ImageUrl:        w.ImageUrl,
+		GifUrl:          w.GifUrl,
+		AudioAttachment: wireAudioAttachmentToModel(w.AudioAttachment),
+		Style:           []string(w.Style),
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -715,6 +715,38 @@ func TestHTTPSubscribeDMs_SanitizesControlChars(t *testing.T) {
 	}
 }
 
+// TestHTTPSubscribeDMs_ParsesAttachmentsAndStyle confirms the RTDB DM wire
+// struct decodes imageUrl/gifUrl/audioAttachment/style the same as the REST path.
+func TestHTTPSubscribeDMs_ParsesAttachmentsAndStyle(t *testing.T) {
+	c, _ := newClientWithRTDB(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeSSEEvent(w, "put", `{"path":"/msg1","data":{"senderId":"u2","senderUsername":"molly","content":"hi","timestamp":1700000001000,`+
+			`"gifUrl":"https://cyberspace.online/a.gif","style":["wave","rainbow"]}}`)
+	}))
+
+	ch, cancel, err := c.SubscribeDMs(context.Background(), "conv1")
+	if err != nil {
+		t.Fatalf("SubscribeDMs error: %v", err)
+	}
+	defer cancel()
+
+	select {
+	case msg, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before delivering message")
+		}
+		if msg.GifUrl != "https://cyberspace.online/a.gif" {
+			t.Errorf("msg.GifUrl = %q", msg.GifUrl)
+		}
+		if len(msg.Style) != 2 || msg.Style[0] != "wave" || msg.Style[1] != "rainbow" {
+			t.Errorf("msg.Style = %v, want [wave rainbow]", msg.Style)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
 // TestHTTPSubscribeDMs_CancelClosesChannel verifies that calling cancel stops the stream.
 func TestHTTPSubscribeDMs_CancelClosesChannel(t *testing.T) {
 	c, _ := newClientWithRTDB(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -824,6 +856,38 @@ func TestHTTPSubscribeRoom_SanitizesControlChars(t *testing.T) {
 		}
 		if strings.ContainsRune(msg.Body, 0x1b) {
 			t.Errorf("msg.Body contains unstripped ESC: %q", msg.Body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+}
+
+// TestHTTPSubscribeRoom_ParsesAttachmentsAndStyle confirms the RTDB cIRC wire
+// struct decodes imageUrl/gifUrl/audioAttachment/style the same as the REST path.
+func TestHTTPSubscribeRoom_ParsesAttachmentsAndStyle(t *testing.T) {
+	c, _ := newClientWithRTDB(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeSSEEvent(w, "put", `{"path":"/msg1","data":{"userId":"u2","username":"molly","content":"hi","timestamp":1700000001000,`+
+			`"imageUrl":"https://cyberspace.online/img.png","style":"l33t"}}`)
+	}))
+
+	ch, cancel, err := c.SubscribeRoom(context.Background(), "zion")
+	if err != nil {
+		t.Fatalf("SubscribeRoom error: %v", err)
+	}
+	defer cancel()
+
+	select {
+	case msg, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before delivering message")
+		}
+		if msg.ImageUrl != "https://cyberspace.online/img.png" {
+			t.Errorf("msg.ImageUrl = %q", msg.ImageUrl)
+		}
+		if len(msg.Style) != 1 || msg.Style[0] != "l33t" {
+			t.Errorf("msg.Style = %v, want [l33t]", msg.Style)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for message")
@@ -1071,6 +1135,70 @@ func TestHTTPGetRoomMessages_ParsesIsAction(t *testing.T) {
 	}
 }
 
+// TestHTTPGetRoomMessages_ParsesAttachmentsAndStyle covers imageUrl, gifUrl,
+// audioAttachment, and both the single-string and array shapes of style.
+func TestHTTPGetRoomMessages_ParsesAttachmentsAndStyle(t *testing.T) {
+	c := newClient(t, authHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, []map[string]any{
+			{"id": "m1", "userId": "u1", "username": "case", "content": "hi", "timestamp": 1700000001000,
+				"imageUrl": "https://cyberspace.online/img.png", "style": "blink"},
+			{"id": "m2", "userId": "u2", "username": "molly", "content": "hey", "timestamp": 1700000002000,
+				"gifUrl": "https://cyberspace.online/a.gif", "style": []string{"comic", "rainbow"}},
+			{"id": "m3", "userId": "u3", "username": "case", "content": "tune", "timestamp": 1700000003000,
+				"audioAttachment": map[string]any{"src": "https://cyberspace.online/song.mp3", "artist": "case", "title": "run", "genre": "synthwave"}},
+		})
+	})))
+	c.LoginWithRefreshToken("tok")
+	msgs, err := c.GetRoomMessages("general", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("len(msgs) = %d, want 3", len(msgs))
+	}
+	if msgs[0].ImageUrl != "https://cyberspace.online/img.png" {
+		t.Errorf("msgs[0].ImageUrl = %q", msgs[0].ImageUrl)
+	}
+	if len(msgs[0].Style) != 1 || msgs[0].Style[0] != "blink" {
+		t.Errorf("msgs[0].Style = %v, want [blink]", msgs[0].Style)
+	}
+	if msgs[1].GifUrl != "https://cyberspace.online/a.gif" {
+		t.Errorf("msgs[1].GifUrl = %q", msgs[1].GifUrl)
+	}
+	if len(msgs[1].Style) != 2 || msgs[1].Style[0] != "comic" || msgs[1].Style[1] != "rainbow" {
+		t.Errorf("msgs[1].Style = %v, want [comic rainbow]", msgs[1].Style)
+	}
+	if msgs[2].AudioAttachment == nil {
+		t.Fatal("msgs[2].AudioAttachment is nil")
+	}
+	if msgs[2].AudioAttachment.Type != "audio" || msgs[2].AudioAttachment.Src != "https://cyberspace.online/song.mp3" ||
+		msgs[2].AudioAttachment.Artist != "case" || msgs[2].AudioAttachment.Title != "run" || msgs[2].AudioAttachment.Genre != "synthwave" {
+		t.Errorf("msgs[2].AudioAttachment = %+v", msgs[2].AudioAttachment)
+	}
+}
+
+// TestHTTPGetRoomMessages_DecodesArtBody covers the style:"art" special case
+// where content is base64-encoded ASCII art, plus the malformed-base64 fallback.
+func TestHTTPGetRoomMessages_DecodesArtBody(t *testing.T) {
+	c := newClient(t, authHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, []map[string]any{
+			{"id": "m1", "userId": "u1", "username": "case", "content": "aGVsbG8=", "timestamp": 1700000001000, "style": "art"},
+			{"id": "m2", "userId": "u1", "username": "case", "content": "not-base64!!", "timestamp": 1700000002000, "style": "art"},
+		})
+	})))
+	c.LoginWithRefreshToken("tok")
+	msgs, err := c.GetRoomMessages("general", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msgs[0].Body != "hello" {
+		t.Errorf("msgs[0].Body = %q, want decoded %q", msgs[0].Body, "hello")
+	}
+	if msgs[1].Body != "not-base64!!" {
+		t.Errorf("msgs[1].Body = %q, want raw fallback %q", msgs[1].Body, "not-base64!!")
+	}
+}
+
 // TestHTTPGetRoomMessages_SanitizesControlChars guards against a regression
 // of the 2026-07-24 review's sanitize-bypass finding for cIRC room history.
 func TestHTTPGetRoomMessages_SanitizesControlChars(t *testing.T) {
@@ -1159,6 +1287,33 @@ func TestHTTPGetMessages_ParsesIsAction(t *testing.T) {
 	}
 	if !msgs[0].IsAction || msgs[0].Body != "waves" {
 		t.Errorf("msgs[0] = %+v, want IsAction=true Body=waves", msgs[0])
+	}
+}
+
+// TestHTTPGetMessages_ParsesAttachmentsAndStyle covers imageUrl, gifUrl,
+// audioAttachment, and style on C-Mail messages.
+func TestHTTPGetMessages_ParsesAttachmentsAndStyle(t *testing.T) {
+	c := newClient(t, authHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeOK(t, w, []map[string]any{
+			{"id": "m1", "senderId": "u1", "senderUsername": "case", "content": "hi", "timestamp": 1700000001000,
+				"imageUrl": "https://cyberspace.online/img.png", "gifUrl": "https://cyberspace.online/a.gif",
+				"style": []string{"quiet"},
+				"audioAttachment": map[string]any{"src": "https://cyberspace.online/song.mp3", "artist": "case"}},
+		})
+	})))
+	c.LoginWithRefreshToken("tok")
+	msgs, err := c.GetMessages("c1", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msgs[0].ImageUrl != "https://cyberspace.online/img.png" || msgs[0].GifUrl != "https://cyberspace.online/a.gif" {
+		t.Errorf("msgs[0] ImageUrl/GifUrl = %q/%q", msgs[0].ImageUrl, msgs[0].GifUrl)
+	}
+	if len(msgs[0].Style) != 1 || msgs[0].Style[0] != "quiet" {
+		t.Errorf("msgs[0].Style = %v, want [quiet]", msgs[0].Style)
+	}
+	if msgs[0].AudioAttachment == nil || msgs[0].AudioAttachment.Src != "https://cyberspace.online/song.mp3" {
+		t.Errorf("msgs[0].AudioAttachment = %+v", msgs[0].AudioAttachment)
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -125,6 +125,12 @@ type Message struct {
 	IsAction    bool // true for /me and other emote-style commands (undocumented API field);
 	// Body is just the action text with no username baked in — render as "* username body *"
 	Deleted bool // CIRC only: message was soft-deleted by its author; Body is "[DELETED]", render as a tombstone
+
+	ImageUrl        string      // direct image URL attached to the message; "" when absent
+	GifUrl          string      // direct animated GIF URL attached via /gif; "" when absent
+	AudioAttachment *Attachment // jukebox track attached via /song; nil when absent, Type is "audio"
+	Style           []string    // text-style command name(s), e.g. "rainbow", "blink"; nil when unstyled.
+	// "art" is a special case, not a text style: Body is ASCII art, already base64-decoded.
 }
 
 type Conversation struct {

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -3,6 +3,7 @@ package screens
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -253,6 +254,21 @@ type ChatroomsModel struct {
 	flagPrompt          FlagPrompt
 	flagTargetMsgID     string // message ID being flagged, set right before flagPrompt.Open()
 	confirmingDeleteMsg bool   // true while the y/n delete-confirm overlay for the selected message is showing
+
+	// revealed tracks which spoiler- or l33t-styled messages (keyed by ID)
+	// the user has toggled to their original text via the browsing-mode
+	// reveal key (enter). Unset/false means still obscured (spoiler: masked;
+	// l33t: substituted). Only cIRC has this today — see chatstyle.go's
+	// maskSpoilerBody doc comment.
+	revealed map[string]bool
+
+	// styleAnimFrame/styleAnimRunning drive the slow/wave/glitch animated
+	// styles: frame increments on every styleAnimTickMsg, and running guards
+	// against stacking multiple concurrent tickers. Coarse-scoped — see the
+	// plan's Trade-offs section: the ticker runs whenever any animated-style
+	// message is loaded in the room, not only while one is visible on screen.
+	styleAnimFrame   int
+	styleAnimRunning bool
 
 	// focused is true while the Chatrooms tab is the one on screen. The RTDB
 	// subscription for an open room stays alive regardless (see
@@ -567,7 +583,7 @@ func (m ChatroomsModel) GetFocusedURLs() []string {
 	}
 	var urls []string
 	for _, msg := range m.messages {
-		urls = append(urls, extractURLs(msg.Body)...)
+		urls = append(urls, messageURLs(msg)...)
 	}
 	return dedupeURLs(urls)
 }
@@ -781,8 +797,50 @@ func (m ChatroomsModel) SetLocation(loc *time.Location) ChatroomsModel {
 
 func (m ChatroomsModel) Init() tea.Cmd { return textinput.Blink }
 
+// Update processes msg via updateInner, then (re)arms the style-animation
+// ticker (see maybeStartStyleAnim) if a loaded message needs one. Wrapping
+// the whole switch this way — rather than threading a tea.Cmd return through
+// refreshMessages and its many call sites, several of which are public
+// mutators also called directly from app.go outside of Update (e.g.
+// AppendSystemMessage/ApplyMessageDeleted) — keeps the coarse-scoped
+// animation check to a single choke point instead of a cascading signature
+// change.
 func (m ChatroomsModel) Update(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
+	m, cmd := m.updateInner(msg)
+	var tickCmd tea.Cmd
+	m, tickCmd = m.maybeStartStyleAnim()
+	if tickCmd != nil {
+		cmd = tea.Batch(cmd, tickCmd)
+	}
+	return m, cmd
+}
+
+// maybeStartStyleAnim starts the slow/wave/glitch animation ticker if any
+// currently loaded message needs one and it isn't already running. Coarse-
+// scoped: it checks every loaded message in the room, not just ones visible
+// in the viewport — see the plan's Trade-offs section for the rationale and
+// upgrade path. Returns a nil tea.Cmd when no start is needed.
+func (m ChatroomsModel) maybeStartStyleAnim() (ChatroomsModel, tea.Cmd) {
+	if m.styleAnimRunning || m.mode != chatroomModeDetail {
+		return m, nil
+	}
+	for _, msg := range m.messages {
+		if hasAnimatedStyle(msg.Style) {
+			m.styleAnimRunning = true
+			return m, styleAnimTickCmd()
+		}
+	}
+	return m, nil
+}
+
+func (m ChatroomsModel) updateInner(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 	switch msg := msg.(type) {
+	case styleAnimTickMsg:
+		m.styleAnimFrame++
+		m.styleAnimRunning = false
+		m = m.refreshMessages()
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -1266,7 +1324,8 @@ func (m ChatroomsModel) refreshMessages() ChatroomsModel {
 		return m
 	}
 	content, offsets, heights := renderCircMessagesWithSelection(
-		m.messages, m.location(), m.timeDisplayFormat, m.viewport.Width, m.currentUser, m.selectedMsgID)
+		m.messages, m.location(), m.timeDisplayFormat, m.viewport.Width, m.currentUser, m.selectedMsgID,
+		m.revealed, m.styleAnimFrame)
 	m.viewport.SetContent(content)
 	m.msgOffsets, m.msgHeights = offsets, heights
 	return m
@@ -1366,7 +1425,8 @@ func (m ChatroomsModel) maybeLoadOlderMessages() (ChatroomsModel, tea.Cmd) {
 
 // updateBrowsingKey handles keys while a message is selected
 // (m.selectedMsgID != ""): up/down move the selection, esc returns to
-// typing, '!' reports the selected message. Everything else is swallowed
+// typing, '!' reports the selected message, enter toggles a spoiler- or
+// l33t-styled message's reveal state. Everything else is swallowed
 // rather than typed, since the input is blurred for the duration of
 // browsing — see the 'up' case in the typing-mode switch, the only place
 // browsing is entered.
@@ -1433,6 +1493,16 @@ func (m ChatroomsModel) updateBrowsingKey(msg tea.KeyMsg) (ChatroomsModel, tea.C
 			selOffsets(m, sel), selHeights(m, sel), curPos, m.viewport.YOffset)
 		m.selectedMsgID = m.messages[sel[newPos]].ID
 		m.viewport.SetYOffset(newOffset)
+		return m.refreshMessages(), nil
+	case "enter":
+		targetMsg, ok := findMessageByID(m.messages, m.selectedMsgID)
+		if !ok || (!slices.Contains(targetMsg.Style, styleSpoiler) && !slices.Contains(targetMsg.Style, styleL33t)) {
+			return m, nil
+		}
+		if m.revealed == nil {
+			m.revealed = make(map[string]bool)
+		}
+		m.revealed[m.selectedMsgID] = !m.revealed[m.selectedMsgID]
 		return m.refreshMessages(), nil
 	case "!":
 		targetMsg, ok := findMessageByID(m.messages, m.selectedMsgID)

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -916,3 +916,141 @@ func TestMentionGhostText_CursorOverlayUsesGhostColor(t *testing.T) {
 		t.Errorf("expected the cursor-overlaid character styled in ghost color (%q) somewhere in the view, got:\n%s", wantChar, view)
 	}
 }
+
+// --- style animation ticker (coarse-scoped, see maybeStartStyleAnim) ---
+
+func TestUpdate_StartsStyleAnimTickerWhenAnimatedMessageArrives(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+
+	m, cmd := m.Update(roomReceivedMsg{msg: model.Message{ID: "m1", Body: "hi", Style: []string{"wave"}}})
+
+	if !m.styleAnimRunning {
+		t.Error("expected styleAnimRunning = true after an animated-style message arrived")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil tea.Cmd to start the animation ticker")
+	}
+}
+
+func TestUpdate_NoStyleAnimTickerForPlainMessage(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+
+	m, _ = m.Update(roomReceivedMsg{msg: model.Message{ID: "m1", Body: "hi"}})
+
+	if m.styleAnimRunning {
+		t.Error("expected styleAnimRunning = false for a message with no animated style")
+	}
+}
+
+func TestUpdate_StyleAnimTick_AdvancesFrameAndRearms(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m, _ = m.Update(roomReceivedMsg{msg: model.Message{ID: "m1", Body: "hi", Style: []string{"glitch"}}})
+	if !m.styleAnimRunning {
+		t.Fatal("setup: expected styleAnimRunning = true")
+	}
+
+	m, cmd := m.Update(styleAnimTickMsg{})
+
+	if m.styleAnimFrame != 1 {
+		t.Errorf("styleAnimFrame = %d, want 1", m.styleAnimFrame)
+	}
+	if !m.styleAnimRunning {
+		t.Error("expected styleAnimRunning to stay true (rearmed) while the glitch message is still loaded")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil tea.Cmd to rearm the ticker")
+	}
+}
+
+// --- spoiler reveal (see updateBrowsingKey's "enter" case) ---
+
+func TestBrowsing_Enter_TogglesSpoilerReveal(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "the ending is a twist", Style: []string{"spoiler"}, CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+	renderedWithReveal := func(m ChatroomsModel) string {
+		content, _, _ := renderCircMessagesWithSelection(m.messages, m.location(), m.timeDisplayFormat,
+			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame)
+		return content
+	}
+	if strings.Contains(renderedWithReveal(m), "the ending is a twist") {
+		t.Fatal("setup: expected spoiler body to start masked")
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.revealed["m1"] {
+		t.Error("expected revealed[m1] = true after enter")
+	}
+	if !strings.Contains(renderedWithReveal(m), "the ending is a twist") {
+		t.Errorf("expected spoiler body revealed after enter, got: %q", renderedWithReveal(m))
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.revealed["m1"] {
+		t.Error("expected revealed[m1] = false after a second enter (toggle back off)")
+	}
+	if strings.Contains(renderedWithReveal(m), "the ending is a twist") {
+		t.Error("expected spoiler body masked again after toggling off")
+	}
+}
+
+func TestBrowsing_Enter_NoOpForNonSpoilerMessage(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "hi", CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.revealed["m1"] {
+		t.Error("expected enter on a non-spoiler message to be a no-op")
+	}
+}
+
+// TestBrowsing_Enter_TogglesL33tReveal confirms l33t-styled messages use the
+// same reveal toggle as spoiler: substituted text by default, enter reveals
+// the original unsubstituted text, a second enter re-obscures it.
+func TestBrowsing_Enter_TogglesL33tReveal(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "elite", Style: []string{"l33t"}, CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+
+	renderedWithReveal := func(m ChatroomsModel) string {
+		content, _, _ := renderCircMessagesWithSelection(m.messages, m.location(), m.timeDisplayFormat,
+			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame)
+		return content
+	}
+	if !strings.Contains(renderedWithReveal(m), "3l173") {
+		t.Fatalf("setup: expected l33t-substituted text before reveal, got: %q", renderedWithReveal(m))
+	}
+	if strings.Contains(renderedWithReveal(m), "elite") {
+		t.Fatal("setup: did not expect original text visible before reveal")
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.revealed["m1"] {
+		t.Error("expected revealed[m1] = true after enter")
+	}
+	if !strings.Contains(renderedWithReveal(m), "elite") {
+		t.Errorf("expected original text revealed after enter, got: %q", renderedWithReveal(m))
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.revealed["m1"] {
+		t.Error("expected revealed[m1] = false after a second enter (toggle back off)")
+	}
+	if !strings.Contains(renderedWithReveal(m), "3l173") {
+		t.Error("expected l33t-substituted text again after toggling off")
+	}
+}

--- a/internal/ui/screens/chatstyle.go
+++ b/internal/ui/screens/chatstyle.go
@@ -38,18 +38,33 @@ const (
 )
 
 // hasAnimatedStyle reports whether styles contains a frame-driven style
-// (slow, wave, glitch) that needs a running tea.Tick to progress.
+// (blink, wave, glitch) that needs a running tea.Tick to progress. slow is
+// a static, one-shot substitution (see applySlowDots) and doesn't need one.
 func hasAnimatedStyle(styles []string) bool {
-	return slices.Contains(styles, styleSlow) || slices.Contains(styles, styleWave) || slices.Contains(styles, styleGlitch)
+	return slices.Contains(styles, styleBlink) || slices.Contains(styles, styleWave) || slices.Contains(styles, styleGlitch)
 }
 
-// styleAnimTickMsg drives the frame counter for slow/wave/glitch styles.
+// styleAnimTickMsg drives the frame counter for blink/wave/glitch styles.
 type styleAnimTickMsg struct{}
 
 const styleAnimInterval = 150 * time.Millisecond
 
 func styleAnimTickCmd() tea.Cmd {
 	return tea.Tick(styleAnimInterval, func(time.Time) tea.Msg { return styleAnimTickMsg{} })
+}
+
+// blinkPhaseFrames is how many animation ticks each blink phase (visible or
+// hidden) lasts — 4 ticks * styleAnimInterval (150ms) ≈ 600ms per phase,
+// close to a typical terminal cursor blink rate.
+const blinkPhaseFrames = 4
+
+// blinkVisible reports whether a blink-styled message should show its real
+// content this frame, alternating every blinkPhaseFrames ticks. App-driven
+// rather than the ANSI blink SGR attribute (which some terminals/multiplexers
+// ignore or disable) — this guarantees the same behavior everywhere at the
+// cost of the message needing a running ticker, same as wave/glitch.
+func blinkVisible(frame int) bool {
+	return (frame/blinkPhaseFrames)%2 == 0
 }
 
 // --- character substitution (l33t, cursive, flip, glitch) ---
@@ -157,11 +172,53 @@ func glitchHash(msgID string, index, frame int) uint32 {
 	return h.Sum32()
 }
 
+// applyWave flips the case of a single rune position that sweeps
+// left-to-right across body, advancing one position per animation frame —
+// the same case-toggle mechanism as applyGlitch, but restricted to one
+// moving position instead of jittering ~1/3 of all letters at once. Sweeping
+// onto a non-letter (space, punctuation) is a no-op that frame, same as the
+// wave passing invisibly through whitespace.
+func applyWave(body string, frame int) string {
+	runes := []rune(body)
+	if len(runes) == 0 {
+		return body
+	}
+	pos := frame % len(runes)
+	r := runes[pos]
+	if unicode.IsUpper(r) {
+		runes[pos] = unicode.ToLower(r)
+	} else if unicode.IsLower(r) {
+		runes[pos] = unicode.ToUpper(r)
+	}
+	return string(runes)
+}
+
+// slowDot is a middle dot (·, U+00B7) rather than a period, so /slow reads
+// as a deliberate visual spacing effect instead of looking like punctuation.
+const slowDot = '·'
+
+// applySlowDots inserts slowDot between every character — a static, one-shot
+// transform (not frame-animated) evoking a stretched-out reading pace.
+func applySlowDots(body string) string {
+	runes := []rune(body)
+	if len(runes) < 2 {
+		return body
+	}
+	var sb strings.Builder
+	for i, r := range runes {
+		sb.WriteRune(r)
+		if i != len(runes)-1 {
+			sb.WriteRune(slowDot)
+		}
+	}
+	return sb.String()
+}
+
 // substituteChars applies the character-substitution styles (l33t, cursive,
-// flip, glitch) to raw message text, before markdown rendering — the
-// substituted characters are plain runes markdown treats literally. msgID
-// and frame are only used by glitch. No-op when none of these styles are
-// present.
+// flip, slow, wave, glitch) to raw message text, before markdown rendering —
+// the substituted characters are plain runes markdown treats literally.
+// msgID and frame are only used by wave and glitch. No-op when none of these
+// styles are present.
 func substituteChars(body, msgID string, styles []string, frame int) string {
 	out := body
 	if slices.Contains(styles, styleL33t) {
@@ -173,13 +230,23 @@ func substituteChars(body, msgID string, styles []string, frame int) string {
 	if slices.Contains(styles, styleFlip) {
 		out = applyFlip(out)
 	}
+	if slices.Contains(styles, styleSlow) {
+		out = applySlowDots(out)
+	}
+	if slices.Contains(styles, styleWave) {
+		out = applyWave(out, frame)
+	}
 	if slices.Contains(styles, styleGlitch) {
 		out = applyGlitch(out, msgID, frame)
 	}
 	return out
 }
 
-// --- attribute styles (blink, quiet, rainbow) ---
+// --- attribute styles (quiet, rainbow) ---
+// blink is handled separately (see blinkVisible) as a post-wrap visibility
+// toggle rather than a strip-and-restyle attribute, so it can blank already
+// word-wrapped lines without risking a rewrap on the blanked text — see the
+// blink toggle in renderCircMessagesStyled/renderChatMessagesStyled.
 
 var rainbowPalette = []lipgloss.Color{
 	theme.ColorRed, theme.ColorYellow, theme.ColorGreen,
@@ -187,10 +254,10 @@ var rainbowPalette = []lipgloss.Color{
 }
 
 func hasAttributeStyle(styles []string) bool {
-	return slices.Contains(styles, styleBlink) || slices.Contains(styles, styleQuiet) || slices.Contains(styles, styleRainbow)
+	return slices.Contains(styles, styleQuiet) || slices.Contains(styles, styleRainbow)
 }
 
-// applyAttributeStyle applies blink/quiet/rainbow to already-markdown-rendered
+// applyAttributeStyle applies quiet/rainbow to already-markdown-rendered
 // text. It strips existing ANSI first and restyles the plain text — the same
 // technique renderCircMessagesWithSelection uses for theme.SelectedRow —
 // because wrapping already-styled text in another style would terminate the
@@ -203,9 +270,6 @@ func applyAttributeStyle(rendered string, styles []string) string {
 	}
 	plain := ansi.Strip(rendered)
 	base := lipgloss.NewStyle()
-	if slices.Contains(styles, styleBlink) {
-		base = base.Blink(true)
-	}
 	if slices.Contains(styles, styleQuiet) {
 		base = base.Faint(true).Foreground(theme.ColorMuted)
 	}

--- a/internal/ui/screens/chatstyle.go
+++ b/internal/ui/screens/chatstyle.go
@@ -1,0 +1,258 @@
+package screens
+
+import (
+	"hash/fnv"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
+)
+
+// Style command names from the /style-family commands (see
+// docs/00-latest-api-reference.md's Commands table). "art" is handled
+// separately (see decodeArtBody in internal/api/client.go and
+// renderArtMessage below) — it marks the body as base64 ASCII art, not a
+// text style. "comic" and "times" name font-family changes that have no
+// terminal equivalent (a terminal renders one monospace font app-wide) and
+// are intentionally no-ops here.
+const (
+	styleBlink   = "blink"
+	styleL33t    = "l33t"
+	styleComic   = "comic"
+	styleCursive = "cursive"
+	styleTimes   = "times"
+	styleRainbow = "rainbow"
+	styleFlip    = "flip"
+	styleQuiet   = "quiet"
+	styleSlow    = "slow"
+	styleGlitch  = "glitch"
+	styleSpoiler = "spoiler"
+	styleWave    = "wave"
+	styleArt     = "art"
+)
+
+// hasAnimatedStyle reports whether styles contains a frame-driven style
+// (slow, wave, glitch) that needs a running tea.Tick to progress.
+func hasAnimatedStyle(styles []string) bool {
+	return slices.Contains(styles, styleSlow) || slices.Contains(styles, styleWave) || slices.Contains(styles, styleGlitch)
+}
+
+// styleAnimTickMsg drives the frame counter for slow/wave/glitch styles.
+type styleAnimTickMsg struct{}
+
+const styleAnimInterval = 150 * time.Millisecond
+
+func styleAnimTickCmd() tea.Cmd {
+	return tea.Tick(styleAnimInterval, func(time.Time) tea.Msg { return styleAnimTickMsg{} })
+}
+
+// --- character substitution (l33t, cursive, flip, glitch) ---
+
+var l33tTable = map[rune]rune{
+	'a': '4', 'A': '4',
+	'e': '3', 'E': '3',
+	'i': '1', 'I': '1',
+	'o': '0', 'O': '0',
+	's': '5', 'S': '5',
+	't': '7', 'T': '7',
+}
+
+// cursiveTable maps ASCII letters to Unicode mathematical script letters.
+// A handful of code points in that block are unassigned ("holes") and alias
+// to older letterlike-symbol compatibility characters instead (e.g. script
+// capital B is U+212C, not U+1D49B+1). Rendering quality depends on the
+// terminal font having glyph coverage for this range — an accepted, explicit
+// trade-off (see the plan's Trade-offs section), not a bug.
+var cursiveTable = buildCursiveTable()
+
+func buildCursiveTable() map[rune]rune {
+	m := make(map[rune]rune, 52)
+	for i := rune(0); i < 26; i++ {
+		m['A'+i] = 0x1D49C + i
+	}
+	for i := rune(0); i < 26; i++ {
+		m['a'+i] = 0x1D4B6 + i
+	}
+	// Holes in the Mathematical Script block, aliased to Letterlike Symbols.
+	holes := map[rune]rune{
+		'B': 0x212C, 'E': 0x2130, 'F': 0x2131, 'H': 0x210B,
+		'I': 0x2110, 'L': 0x2112, 'M': 0x2133, 'R': 0x211B,
+		'e': 0x212F, 'g': 0x210A, 'o': 0x2134,
+	}
+	for r, v := range holes {
+		m[r] = v
+	}
+	return m
+}
+
+// flipTable maps ASCII letters to their conventional "upside-down text"
+// lookalikes. Uppercase letters are folded to lowercase first — a faithful
+// per-case upside-down mapping is font-dependent and inconsistent across
+// terminals, so this codebase accepts the lowercase-only rendering rather
+// than chase an unreliable uppercase table.
+var flipTable = map[rune]rune{
+	'a': 'ɐ', 'b': 'q', 'c': 'ɔ', 'd': 'p', 'e': 'ǝ', 'f': 'ɟ', 'g': 'ƃ',
+	'h': 'ɥ', 'i': 'ᴉ', 'j': 'ɾ', 'k': 'ʞ', 'l': 'l', 'm': 'ɯ', 'n': 'u',
+	'o': 'o', 'p': 'd', 'q': 'b', 'r': 'ɹ', 's': 's', 't': 'ʇ', 'u': 'n',
+	'v': 'ʌ', 'w': 'ʍ', 'x': 'x', 'y': 'ʎ', 'z': 'z',
+}
+
+func applyTable(body string, table map[rune]rune) string {
+	return strings.Map(func(r rune) rune {
+		if v, ok := table[r]; ok {
+			return v
+		}
+		return r
+	}, body)
+}
+
+func applyFlip(body string) string {
+	runes := []rune(strings.ToLower(body))
+	slices.Reverse(runes)
+	for i, r := range runes {
+		if v, ok := flipTable[r]; ok {
+			runes[i] = v
+		}
+	}
+	return string(runes)
+}
+
+// applyGlitch jitters roughly a third of the letters in body by toggling
+// their case, deterministically per (msgID, rune index, frame) so unrelated
+// re-renders within the same frame (e.g. a selection change) stay
+// byte-identical. Deliberately ASCII-safe — no combining marks — since this
+// codebase relies on runewidth-based column-width math elsewhere (see
+// shared.go) that zalgo-style stacked diacritics would break.
+func applyGlitch(body, msgID string, frame int) string {
+	runes := []rune(body)
+	for i, r := range runes {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		if glitchHash(msgID, i, frame)%3 != 0 {
+			continue
+		}
+		if unicode.IsUpper(r) {
+			runes[i] = unicode.ToLower(r)
+		} else {
+			runes[i] = unicode.ToUpper(r)
+		}
+	}
+	return string(runes)
+}
+
+func glitchHash(msgID string, index, frame int) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(msgID))
+	h.Write([]byte(":"))
+	h.Write([]byte(strconv.Itoa(index)))
+	h.Write([]byte(":"))
+	h.Write([]byte(strconv.Itoa(frame)))
+	return h.Sum32()
+}
+
+// substituteChars applies the character-substitution styles (l33t, cursive,
+// flip, glitch) to raw message text, before markdown rendering — the
+// substituted characters are plain runes markdown treats literally. msgID
+// and frame are only used by glitch. No-op when none of these styles are
+// present.
+func substituteChars(body, msgID string, styles []string, frame int) string {
+	out := body
+	if slices.Contains(styles, styleL33t) {
+		out = applyTable(out, l33tTable)
+	}
+	if slices.Contains(styles, styleCursive) {
+		out = applyTable(out, cursiveTable)
+	}
+	if slices.Contains(styles, styleFlip) {
+		out = applyFlip(out)
+	}
+	if slices.Contains(styles, styleGlitch) {
+		out = applyGlitch(out, msgID, frame)
+	}
+	return out
+}
+
+// --- attribute styles (blink, quiet, rainbow) ---
+
+var rainbowPalette = []lipgloss.Color{
+	theme.ColorRed, theme.ColorYellow, theme.ColorGreen,
+	theme.ColorCyan, theme.ColorWhite,
+}
+
+func hasAttributeStyle(styles []string) bool {
+	return slices.Contains(styles, styleBlink) || slices.Contains(styles, styleQuiet) || slices.Contains(styles, styleRainbow)
+}
+
+// applyAttributeStyle applies blink/quiet/rainbow to already-markdown-rendered
+// text. It strips existing ANSI first and restyles the plain text — the same
+// technique renderCircMessagesWithSelection uses for theme.SelectedRow —
+// because wrapping already-styled text in another style would terminate the
+// outer style's codes mid-line. This means a styled message trades away
+// inline markdown decoration (bold, mentions) within the styled span, an
+// accepted trade-off (see the plan's Trade-offs section).
+func applyAttributeStyle(rendered string, styles []string) string {
+	if !hasAttributeStyle(styles) {
+		return rendered
+	}
+	plain := ansi.Strip(rendered)
+	base := lipgloss.NewStyle()
+	if slices.Contains(styles, styleBlink) {
+		base = base.Blink(true)
+	}
+	if slices.Contains(styles, styleQuiet) {
+		base = base.Faint(true).Foreground(theme.ColorMuted)
+	}
+	if slices.Contains(styles, styleRainbow) {
+		var sb strings.Builder
+		i := 0
+		for _, r := range plain {
+			sb.WriteString(base.Foreground(rainbowPalette[i%len(rainbowPalette)]).Render(string(r)))
+			i++
+		}
+		return sb.String()
+	}
+	return base.Render(plain)
+}
+
+// --- spoiler ---
+
+// maskSpoilerBody replaces every non-space rune with a block character,
+// preserving whitespace so word-wrapped layout doesn't shift. A pure
+// function with no dependency on chatrooms.go's message-selection state, so
+// it can be reused once C-Mail gets its own spoiler-reveal mechanism —
+// C-Mail doesn't have one yet, see the plan's Trade-offs section.
+func maskSpoilerBody(body string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return r
+		}
+		return '░'
+	}, body)
+}
+
+// --- art ---
+
+// renderArtMessage renders a style:"art" message's already-decoded body
+// verbatim: no word-wrap, no markdown, matching renderDeletedTombstone's
+// dedicated-builder convention. ASCII art is column-sensitive, so wrapping
+// or markdown-escaping it would corrupt the picture.
+func renderArtMessage(username, body, ts string, viewportWidth int) string {
+	const tsGap = 2 // matches renderCircMessages/renderDeletedTombstone's minimum gap
+	tsWidth := lipgloss.Width(ts)
+	rawPrefixWidth := len(username) + 4 // "<username>  ", same accounting as renderCircMessages' styledPrefix
+	pad := max(viewportWidth-rawPrefixWidth-tsWidth, 0) + tsGap
+	header := "<" + theme.Highlight.Render(username) + ">" + strings.Repeat(" ", pad) + theme.Subtle.Render(ts)
+	var sb strings.Builder
+	sb.WriteString(header + "\n")
+	for line := range strings.SplitSeq(strings.TrimRight(body, "\n"), "\n") {
+		sb.WriteString(line + "\n")
+	}
+	return sb.String()
+}

--- a/internal/ui/screens/chatstyle_test.go
+++ b/internal/ui/screens/chatstyle_test.go
@@ -59,6 +59,67 @@ func TestSubstituteChars_Glitch_VariesByFrame(t *testing.T) {
 	}
 }
 
+func TestSubstituteChars_Slow_InsertsMiddleDots(t *testing.T) {
+	got := substituteChars("hi", "m1", []string{styleSlow}, 0)
+	if got != "h·i" {
+		t.Errorf("substituteChars slow = %q, want %q", got, "h·i")
+	}
+}
+
+func TestSubstituteChars_Slow_SingleCharUnchanged(t *testing.T) {
+	got := substituteChars("h", "m1", []string{styleSlow}, 0)
+	if got != "h" {
+		t.Errorf("substituteChars slow on a single char = %q, want unchanged", got)
+	}
+}
+
+func TestSubstituteChars_Slow_SameAcrossFrames(t *testing.T) {
+	a := substituteChars("hello", "m1", []string{styleSlow}, 0)
+	b := substituteChars("hello", "m1", []string{styleSlow}, 7)
+	if a != b {
+		t.Errorf("slow should be static (frame-independent), got %q vs %q", a, b)
+	}
+}
+
+func TestSubstituteChars_Wave_TogglesOneMovingPosition(t *testing.T) {
+	got0 := substituteChars("abc", "m1", []string{styleWave}, 0)
+	if got0 != "Abc" {
+		t.Errorf("substituteChars wave frame=0 = %q, want Abc", got0)
+	}
+	got1 := substituteChars("abc", "m1", []string{styleWave}, 1)
+	if got1 != "aBc" {
+		t.Errorf("substituteChars wave frame=1 = %q, want aBc", got1)
+	}
+	got3 := substituteChars("abc", "m1", []string{styleWave}, 3) // wraps: 3%3 == 0
+	if got3 != "Abc" {
+		t.Errorf("substituteChars wave frame=3 = %q, want Abc (wraps to position 0)", got3)
+	}
+}
+
+func TestSubstituteChars_Wave_EmptyBody(t *testing.T) {
+	got := substituteChars("", "m1", []string{styleWave}, 0)
+	if got != "" {
+		t.Errorf("substituteChars wave on empty body = %q, want empty", got)
+	}
+}
+
+func TestBlinkVisible_TogglesEveryPhase(t *testing.T) {
+	cases := []struct {
+		frame int
+		want  bool
+	}{
+		{0, true}, {1, true}, {3, true},
+		{4, false}, {6, false}, {7, false},
+		{8, true}, {11, true},
+		{12, false},
+	}
+	for _, c := range cases {
+		if got := blinkVisible(c.frame); got != c.want {
+			t.Errorf("blinkVisible(%d) = %v, want %v", c.frame, got, c.want)
+		}
+	}
+}
+
 func TestApplyAttributeStyle_NoStyles_ReturnsUnchanged(t *testing.T) {
 	got := applyAttributeStyle("plain text", nil)
 	if got != "plain text" {
@@ -93,9 +154,9 @@ func TestHasAnimatedStyle(t *testing.T) {
 		want   bool
 	}{
 		{nil, false},
-		{[]string{styleBlink}, false},
+		{[]string{styleSlow}, false},
 		{[]string{styleRainbow, styleQuiet}, false},
-		{[]string{styleSlow}, true},
+		{[]string{styleBlink}, true},
 		{[]string{styleWave}, true},
 		{[]string{styleGlitch}, true},
 		{[]string{styleBlink, styleWave}, true},

--- a/internal/ui/screens/chatstyle_test.go
+++ b/internal/ui/screens/chatstyle_test.go
@@ -1,0 +1,108 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSubstituteChars_L33t(t *testing.T) {
+	got := substituteChars("elite", "m1", []string{styleL33t}, 0)
+	if got != "3l173" {
+		t.Errorf("substituteChars l33t = %q, want 3l173", got)
+	}
+}
+
+func TestSubstituteChars_Cursive(t *testing.T) {
+	got := substituteChars("a", "m1", []string{styleCursive}, 0)
+	if got == "a" {
+		t.Error("substituteChars cursive left input unchanged")
+	}
+	if strings.ContainsRune(got, 'a') {
+		t.Errorf("substituteChars cursive = %q, still contains plain 'a'", got)
+	}
+}
+
+func TestSubstituteChars_Flip(t *testing.T) {
+	got := substituteChars("ab", "m1", []string{styleFlip}, 0)
+	// flip lowercases, maps each rune, and reverses order: "ab" -> "aq" reversed -> "qɐ"
+	want := "qɐ"
+	if got != want {
+		t.Errorf("substituteChars flip = %q, want %q", got, want)
+	}
+}
+
+func TestSubstituteChars_NoStyles_ReturnsUnchanged(t *testing.T) {
+	got := substituteChars("hello world", "m1", nil, 0)
+	if got != "hello world" {
+		t.Errorf("substituteChars with no styles = %q, want unchanged", got)
+	}
+}
+
+func TestSubstituteChars_Glitch_DeterministicAcrossCalls(t *testing.T) {
+	a := substituteChars("hello world", "msg-42", []string{styleGlitch}, 3)
+	b := substituteChars("hello world", "msg-42", []string{styleGlitch}, 3)
+	if a != b {
+		t.Errorf("glitch not deterministic: %q vs %q", a, b)
+	}
+	if len([]rune(a)) != len([]rune("hello world")) {
+		t.Errorf("glitch changed rune count: %q", a)
+	}
+}
+
+func TestSubstituteChars_Glitch_VariesByFrame(t *testing.T) {
+	frames := make(map[string]bool)
+	for frame := 0; frame < 10; frame++ {
+		frames[substituteChars("the quick brown fox", "msg-1", []string{styleGlitch}, frame)] = true
+	}
+	if len(frames) < 2 {
+		t.Error("glitch produced the same output across all frames, expected variation")
+	}
+}
+
+func TestApplyAttributeStyle_NoStyles_ReturnsUnchanged(t *testing.T) {
+	got := applyAttributeStyle("plain text", nil)
+	if got != "plain text" {
+		t.Errorf("applyAttributeStyle with no styles = %q, want unchanged", got)
+	}
+}
+
+func TestApplyAttributeStyle_ChangesOutputWhenStyled(t *testing.T) {
+	withTrueColor(t)
+	got := applyAttributeStyle("hello", []string{styleRainbow})
+	if got == "hello" {
+		t.Error("applyAttributeStyle rainbow left text unstyled")
+	}
+}
+
+func TestMaskSpoilerBody_PreservesWhitespace(t *testing.T) {
+	got := maskSpoilerBody("hi there")
+	if !strings.Contains(got, " ") {
+		t.Errorf("maskSpoilerBody %q lost whitespace", got)
+	}
+	if strings.ContainsAny(got, "hitre") {
+		t.Errorf("maskSpoilerBody %q leaked original letters", got)
+	}
+	if len([]rune(got)) != len([]rune("hi there")) {
+		t.Errorf("maskSpoilerBody %q changed length", got)
+	}
+}
+
+func TestHasAnimatedStyle(t *testing.T) {
+	cases := []struct {
+		styles []string
+		want   bool
+	}{
+		{nil, false},
+		{[]string{styleBlink}, false},
+		{[]string{styleRainbow, styleQuiet}, false},
+		{[]string{styleSlow}, true},
+		{[]string{styleWave}, true},
+		{[]string{styleGlitch}, true},
+		{[]string{styleBlink, styleWave}, true},
+	}
+	for _, c := range cases {
+		if got := hasAnimatedStyle(c.styles); got != c.want {
+			t.Errorf("hasAnimatedStyle(%v) = %v, want %v", c.styles, got, c.want)
+		}
+	}
+}

--- a/internal/ui/screens/cmail.go
+++ b/internal/ui/screens/cmail.go
@@ -208,6 +208,11 @@ type CMailModel struct {
 	lastKeystrokeAt   time.Time          // updated on every keystroke; idle-check compares against this
 	typingHeartbeatMs int                // from AnnounceTyping's response; drives our own re-announce cadence
 	typingAnimFrame   int                // cycles the indicator's animated dot count; free-runs while a conversation is open
+
+	// styleAnimFrame/styleAnimRunning drive the slow/wave/glitch animated
+	// message styles — see maybeStartStyleAnim and chatrooms.go's identical fields.
+	styleAnimFrame   int
+	styleAnimRunning bool
 }
 
 // SendCMailMsg is emitted when the user sends a C-Mail message.
@@ -575,7 +580,7 @@ func (m CMailModel) GetFocusedURLs() []string {
 	}
 	var urls []string
 	for _, msg := range m.activeConv.Messages {
-		urls = append(urls, extractURLs(msg.Body)...)
+		urls = append(urls, messageURLs(msg)...)
 	}
 	return dedupeURLs(urls)
 }
@@ -588,8 +593,47 @@ func (m CMailModel) HasActiveConv() bool { return m.mode == cmailModeDetail }
 
 func (m CMailModel) Init() tea.Cmd { return textinput.Blink }
 
+// Update processes msg via updateInner, then (re)arms the style-animation
+// ticker if a loaded message needs one — same wrap-the-switch shape as
+// chatrooms.go's Update/maybeStartStyleAnim, chosen there to avoid a
+// cascading tea.Cmd-return change through refreshMessages' many call sites.
 func (m CMailModel) Update(msg tea.Msg) (CMailModel, tea.Cmd) {
+	m, cmd := m.updateInner(msg)
+	var tickCmd tea.Cmd
+	m, tickCmd = m.maybeStartStyleAnim()
+	if tickCmd != nil {
+		cmd = tea.Batch(cmd, tickCmd)
+	}
+	return m, cmd
+}
+
+// maybeStartStyleAnim starts the slow/wave/glitch animation ticker if the
+// open conversation has a loaded message that needs one and it isn't already
+// running. Coarse-scoped: checks every loaded message in the conversation,
+// not just ones visible in the viewport — see the plan's Trade-offs section.
+func (m CMailModel) maybeStartStyleAnim() (CMailModel, tea.Cmd) {
+	if m.styleAnimRunning || m.mode != cmailModeDetail || m.activeConv == nil {
+		return m, nil
+	}
+	for _, msg := range m.activeConv.Messages {
+		if hasAnimatedStyle(msg.Style) {
+			m.styleAnimRunning = true
+			return m, styleAnimTickCmd()
+		}
+	}
+	return m, nil
+}
+
+func (m CMailModel) updateInner(msg tea.Msg) (CMailModel, tea.Cmd) {
 	switch msg := msg.(type) {
+	case styleAnimTickMsg:
+		m.styleAnimFrame++
+		m.styleAnimRunning = false
+		if m.mode == cmailModeDetail && m.activeConv != nil {
+			m.viewport.SetContent(m.renderMessages())
+		}
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -1011,7 +1055,7 @@ func (m CMailModel) renderMessages() string {
 		}
 		return theme.Subtle.Render("no messages")
 	}
-	return renderChatMessages(m.activeConv.Messages, m.currentUser, m.location(), m.timeDisplayFormat, m.viewport.Width)
+	return renderChatMessagesStyled(m.activeConv.Messages, m.currentUser, m.location(), m.timeDisplayFormat, m.viewport.Width, m.styleAnimFrame)
 }
 
 func (m CMailModel) location() *time.Location {

--- a/internal/ui/screens/cmail_test.go
+++ b/internal/ui/screens/cmail_test.go
@@ -480,7 +480,7 @@ func TestTypingIndicator_DotsCycleThroughZeroOneTwoThree(t *testing.T) {
 func TestCMailUpdate_StartsStyleAnimTickerWhenAnimatedMessageArrives(t *testing.T) {
 	m := cmailInConversation(api.NewMockClient(), "c1")
 
-	m, cmd := m.Update(dmReceivedMsg{msg: model.Message{ID: "m1", Body: "hi", Style: []string{"slow"}}})
+	m, cmd := m.Update(dmReceivedMsg{msg: model.Message{ID: "m1", Body: "hi", Style: []string{"blink"}}})
 
 	if !m.styleAnimRunning {
 		t.Error("expected styleAnimRunning = true after an animated-style message arrived")

--- a/internal/ui/screens/cmail_test.go
+++ b/internal/ui/screens/cmail_test.go
@@ -474,3 +474,35 @@ func TestTypingIndicator_DotsCycleThroughZeroOneTwoThree(t *testing.T) {
 		}
 	}
 }
+
+// --- style animation ticker (coarse-scoped, see maybeStartStyleAnim) ---
+
+func TestCMailUpdate_StartsStyleAnimTickerWhenAnimatedMessageArrives(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+
+	m, cmd := m.Update(dmReceivedMsg{msg: model.Message{ID: "m1", Body: "hi", Style: []string{"slow"}}})
+
+	if !m.styleAnimRunning {
+		t.Error("expected styleAnimRunning = true after an animated-style message arrived")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil tea.Cmd to start the animation ticker")
+	}
+}
+
+func TestCMailUpdate_StyleAnimTick_AdvancesFrameAndRearms(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	m, _ = m.Update(dmReceivedMsg{msg: model.Message{ID: "m1", Body: "hi", Style: []string{"wave"}}})
+	if !m.styleAnimRunning {
+		t.Fatal("setup: expected styleAnimRunning = true")
+	}
+
+	m, cmd := m.Update(styleAnimTickMsg{})
+
+	if m.styleAnimFrame != 1 {
+		t.Errorf("styleAnimFrame = %d, want 1", m.styleAnimFrame)
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil tea.Cmd to rearm the ticker")
+	}
+}

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -2,6 +2,7 @@ package screens
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -163,6 +164,8 @@ func renderAttachments(attachments []model.Attachment) string {
 		switch a.Type {
 		case "image":
 			lines = append(lines, theme.Subtle.Render("[image]")+"  "+linkStyle.Render(a.Src))
+		case "gif":
+			lines = append(lines, theme.Subtle.Render("[gif]")+"  "+linkStyle.Render(a.Src))
 		case "audio":
 			label := a.Src
 			if a.Artist != "" || a.Title != "" {
@@ -198,6 +201,16 @@ func listFooter(loading, exhausted bool) string {
 // every wrapped line for the timestamp column so long messages never push it
 // off-screen; continuation lines are indented to align under the body.
 func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string) string {
+	return renderCircMessagesStyled(msgs, loc, timeDisplayFormat, viewportWidth, currentUser, nil, 0)
+}
+
+// renderCircMessagesStyled is renderCircMessages plus style/attachment
+// support: revealed gates which spoiler-styled messages show their real
+// body and which l33t-styled messages show their original, unsubstituted
+// text (keyed by message ID; nil means none revealed), and frame drives
+// the slow/wave/glitch animated styles. renderCircMessages is a thin wrapper
+// passing (nil, 0), so its many existing call sites are unaffected.
+func renderCircMessagesStyled(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, revealed map[string]bool, frame int) string {
 	if viewportWidth < 20 {
 		viewportWidth = 80
 	}
@@ -210,6 +223,11 @@ func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFor
 		}
 		ts := displayTime(msg.CreatedAt, loc, timeDisplayFormat, true)
 		tsWidth := lipgloss.Width(ts)
+
+		if slices.Contains(msg.Style, styleArt) {
+			sb.WriteString(renderArtMessage(msg.From.Username, msg.Body, ts, viewportWidth))
+			continue
+		}
 
 		if msg.Deleted {
 			sb.WriteString(renderDeletedTombstone(msg.From.Username, ts, viewportWidth))
@@ -233,8 +251,36 @@ func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFor
 
 		bodyWidth := max(viewportWidth-rawPrefixWidth-tsWidth-tsGap, 10)
 
-		body := markdown.RenderInline(strings.TrimRight(msg.Body, "\n"), currentUser)
-		lines := strings.Split(lipgloss.NewStyle().Width(bodyWidth).Render(body), "\n")
+		displayBody := messageDisplayBody(msg)
+		att := renderAttachments(messageAttachments(msg))
+
+		var lines []string
+		switch {
+		case displayBody == "" && att != "":
+			// Attachment-only message: use the attachment block itself as
+			// the "body" so the username/timestamp land on it directly
+			// instead of leaving a blank-looking line above it. Still runs
+			// through the same Width(bodyWidth).Render wrapping as normal
+			// text bodies — skipping it left long URLs pushing the
+			// timestamp far past viewportWidth instead of wrapping under it.
+			lines = strings.Split(lipgloss.NewStyle().Width(bodyWidth).Render(att), "\n")
+			att = ""
+		case slices.Contains(msg.Style, styleSpoiler) && !revealed[msg.ID]:
+			body := theme.Subtle.Render(maskSpoilerBody(strings.TrimRight(displayBody, "\n")))
+			lines = strings.Split(lipgloss.NewStyle().Width(bodyWidth).Render(body), "\n")
+		default:
+			// l33t substitution is reveal-gated like spoiler's masking; every
+			// other substitution/attribute style (cursive, flip, glitch,
+			// blink, quiet, rainbow) is not, so only l33t is dropped once
+			// the message is revealed.
+			effectiveStyles := msg.Style
+			if revealed[msg.ID] {
+				effectiveStyles = slices.DeleteFunc(slices.Clone(msg.Style), func(s string) bool { return s == styleL33t })
+			}
+			raw := substituteChars(displayBody, msg.ID, effectiveStyles, frame)
+			body := applyAttributeStyle(markdown.RenderInline(strings.TrimRight(raw, "\n"), currentUser), msg.Style)
+			lines = strings.Split(lipgloss.NewStyle().Width(bodyWidth).Render(body), "\n")
+		}
 		last := len(lines) - 1
 
 		for i, line := range lines {
@@ -246,6 +292,12 @@ func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFor
 				sb.WriteString(prefix + line + strings.Repeat(" ", tsGap) + theme.Subtle.Render(ts) + "\n")
 			} else {
 				sb.WriteString(prefix + line + "\n")
+			}
+		}
+
+		if att != "" {
+			for line := range strings.SplitSeq(att, "\n") {
+				sb.WriteString(indent + line + "\n")
 			}
 		}
 	}
@@ -281,13 +333,13 @@ func renderDeletedTombstone(username, ts string, viewportWidth int) string {
 // the selected message's block is stripped back to plain text (ansi.Strip)
 // and only that plain text is wrapped in theme.SelectedRow — the same
 // approach settings.go uses for its selected-row highlight.
-func renderCircMessagesWithSelection(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, selectedID string) (content string, offsets []int, heights []int) {
+func renderCircMessagesWithSelection(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, selectedID string, revealed map[string]bool, frame int) (content string, offsets []int, heights []int) {
 	offsets = make([]int, len(msgs))
 	heights = make([]int, len(msgs))
 	var sb strings.Builder
 	var lineCount int
 	for i, msg := range msgs {
-		rendered := renderCircMessages([]model.Message{msg}, loc, timeDisplayFormat, viewportWidth, currentUser)
+		rendered := renderCircMessagesStyled([]model.Message{msg}, loc, timeDisplayFormat, viewportWidth, currentUser, revealed, frame)
 		if selectedID != "" && msg.ID == selectedID {
 			plain := strings.TrimSuffix(ansi.Strip(rendered), "\n")
 			rendered = theme.SelectedRow.Width(viewportWidth).Render(plain) + "\n"
@@ -388,6 +440,16 @@ func renderSystemNotice(body string, viewportWidth int) string {
 // Others use Border (dim green) on the left.
 // Pass currentUser="" to render all messages left-aligned (chatrooms).
 func renderChatMessages(msgs []model.Message, currentUser string, loc *time.Location, timeDisplayFormat string, viewportWidth int) string {
+	return renderChatMessagesStyled(msgs, currentUser, loc, timeDisplayFormat, viewportWidth, 0)
+}
+
+// renderChatMessagesStyled is renderChatMessages plus style/attachment
+// support; frame drives the slow/wave/glitch animated styles.
+// renderChatMessages is a thin wrapper passing 0, so its existing call sites
+// are unaffected. Unlike cIRC's renderCircMessagesStyled, this has no
+// spoiler or "art" handling — C-Mail doesn't support either yet (see the
+// plan's Trade-offs section).
+func renderChatMessagesStyled(msgs []model.Message, currentUser string, loc *time.Location, timeDisplayFormat string, viewportWidth int, frame int) string {
 	if viewportWidth < 8 {
 		viewportWidth = 80
 	}
@@ -417,17 +479,34 @@ func renderChatMessages(msgs []model.Message, currentUser string, loc *time.Loca
 			header = theme.Highlight.Render("@"+username) + "  " + theme.Subtle.Render(ts)
 		}
 
-		// Natural inner width: widest of the header and each raw body line, capped at max.
+		displayBody := messageDisplayBody(msg)
+		attachments := renderAttachments(messageAttachments(msg))
+
+		// Natural inner width: widest of the header, each raw body line, and
+		// each attachment line, capped at max.
 		naturalW := lipgloss.Width(header)
-		for line := range strings.SplitSeq(msg.Body, "\n") {
+		for line := range strings.SplitSeq(displayBody, "\n") {
+			if w := lipgloss.Width(line); w > naturalW {
+				naturalW = w
+			}
+		}
+		for line := range strings.SplitSeq(attachments, "\n") {
 			if w := lipgloss.Width(line); w > naturalW {
 				naturalW = w
 			}
 		}
 		naturalW = min(naturalW, maxContentW)
 
-		body := strings.TrimRight(markdown.Render(msg.Body, naturalW), "\n")
-		content := lipgloss.JoinVertical(lipgloss.Left, header, body)
+		raw := substituteChars(displayBody, msg.ID, msg.Style, frame)
+		body := applyAttributeStyle(strings.TrimRight(markdown.Render(raw, naturalW), "\n"), msg.Style)
+		rows := []string{header}
+		if body != "" {
+			rows = append(rows, body)
+		}
+		if attachments != "" {
+			rows = append(rows, attachments)
+		}
+		content := lipgloss.JoinVertical(lipgloss.Left, rows...)
 
 		if isMe {
 			bubble := theme.ActiveBorder.Render(content)

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -281,6 +281,17 @@ func renderCircMessagesStyled(msgs []model.Message, loc *time.Location, timeDisp
 			body := applyAttributeStyle(markdown.RenderInline(strings.TrimRight(raw, "\n"), currentUser), msg.Style)
 			lines = strings.Split(lipgloss.NewStyle().Width(bodyWidth).Render(body), "\n")
 		}
+
+		// Blink toggling runs after wrapping, blanking each already-wrapped
+		// line to its own rendered width, so hiding the message never
+		// changes its line count/wrap structure (blanking pre-wrap risks
+		// lipgloss collapsing an all-space string into fewer lines than the
+		// real text wrapped to).
+		if slices.Contains(msg.Style, styleBlink) && !blinkVisible(frame) {
+			for i := range lines {
+				lines[i] = strings.Repeat(" ", lipgloss.Width(lines[i]))
+			}
+		}
 		last := len(lines) - 1
 
 		for i, line := range lines {
@@ -499,6 +510,13 @@ func renderChatMessagesStyled(msgs []model.Message, currentUser string, loc *tim
 
 		raw := substituteChars(displayBody, msg.ID, msg.Style, frame)
 		body := applyAttributeStyle(strings.TrimRight(markdown.Render(raw, naturalW), "\n"), msg.Style)
+		if slices.Contains(msg.Style, styleBlink) && !blinkVisible(frame) {
+			bodyLines := strings.Split(body, "\n")
+			for i := range bodyLines {
+				bodyLines[i] = strings.Repeat(" ", lipgloss.Width(bodyLines[i]))
+			}
+			body = strings.Join(bodyLines, "\n")
+		}
 		rows := []string{header}
 		if body != "" {
 			rows = append(rows, body)

--- a/internal/ui/screens/render_test.go
+++ b/internal/ui/screens/render_test.go
@@ -605,3 +605,41 @@ func TestRenderCircMessages_ArtStyle_TimestampAlignsWithNormalMessage(t *testing
 		t.Errorf("art header timestamp starts at column %d, want %d (same as a normal message)", artIdx, normalIdx)
 	}
 }
+
+// TestRenderCircMessagesStyled_Blink_HidesAndShowsWithoutChangingLineCount
+// confirms blink toggles the body's visibility across animation frames while
+// keeping the same line count and per-line width — blanking must happen
+// after word-wrap, not before, or an all-space string could rewrap to fewer
+// lines than the real text did (see the comment at the blink toggle site).
+func TestRenderCircMessagesStyled_Blink_HidesAndShowsWithoutChangingLineCount(t *testing.T) {
+	const width = 60
+	msg := circMsg("molly", "hello there")
+	msg.Style = []string{"blink"}
+
+	visible := renderCircMessagesStyled([]model.Message{msg}, time.UTC, "datetime", width, "", nil, 0)
+	hidden := renderCircMessagesStyled([]model.Message{msg}, time.UTC, "datetime", width, "", nil, blinkPhaseFrames)
+
+	if !strings.Contains(ansi.Strip(visible), "hello there") {
+		t.Errorf("expected the visible phase to contain the body text, got: %q", visible)
+	}
+	plainHidden := ansi.Strip(hidden)
+	if strings.Contains(plainHidden, "hello") || strings.Contains(plainHidden, "there") {
+		t.Errorf("expected the hidden phase to blank the body text, got: %q", hidden)
+	}
+
+	visibleLines := strings.Split(strings.TrimRight(ansi.Strip(visible), "\n"), "\n")
+	hiddenLines := strings.Split(strings.TrimRight(plainHidden, "\n"), "\n")
+	if len(visibleLines) != len(hiddenLines) {
+		t.Fatalf("line count changed across blink phases: visible=%d hidden=%d", len(visibleLines), len(hiddenLines))
+	}
+	for i := range visibleLines {
+		if lipgloss.Width(visibleLines[i]) != lipgloss.Width(hiddenLines[i]) {
+			t.Errorf("line %d width changed across blink phases: visible=%d hidden=%d", i, lipgloss.Width(visibleLines[i]), lipgloss.Width(hiddenLines[i]))
+		}
+	}
+
+	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
+	if !strings.Contains(plainHidden, ts) {
+		t.Errorf("expected the timestamp to stay visible during the hidden phase, got: %q", hidden)
+	}
+}

--- a/internal/ui/screens/render_test.go
+++ b/internal/ui/screens/render_test.go
@@ -450,3 +450,158 @@ func TestRenderCircMessages_MentionStyleContinuesAfterMultipleWords(t *testing.T
 		t.Errorf("expected '2' to also keep theme.Base styling, not left unstyled by a broken reset, got: %q", out)
 	}
 }
+
+// TestRenderAttachments_GifBadge confirms a "gif" attachment gets its own
+// [gif] badge rather than falling into the generic [attachment] default.
+func TestRenderAttachments_GifBadge(t *testing.T) {
+	out := renderAttachments([]model.Attachment{{Type: "gif", Src: "https://cyberspace.online/a.gif"}})
+	if !strings.Contains(out, "[gif]") {
+		t.Errorf("expected [gif] badge, got: %q", out)
+	}
+	if !strings.Contains(out, "https://cyberspace.online/a.gif") {
+		t.Errorf("expected gif URL in output, got: %q", out)
+	}
+}
+
+// TestRenderCircMessages_AttachmentOnlyBodySkipsDuplicateURL confirms that
+// when Body merely duplicates ImageUrl (an attachment-only message), the URL
+// is shown once via the attachment badge, not a second time as wrapped body text.
+func TestRenderCircMessages_AttachmentOnlyBodySkipsDuplicateURL(t *testing.T) {
+	msg := circMsg("case", "https://cyberspace.online/img.png")
+	msg.ImageUrl = "https://cyberspace.online/img.png"
+
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 60, "")
+
+	if n := strings.Count(out, "https://cyberspace.online/img.png"); n != 1 {
+		t.Errorf("expected the image URL to appear exactly once, got %d times in: %q", n, out)
+	}
+	if !strings.Contains(out, "[image]") {
+		t.Errorf("expected [image] attachment badge, got: %q", out)
+	}
+}
+
+// TestRenderCircMessages_AttachmentOnlyHasNoBlankLine guards against a
+// regression where an attachment-only message (empty display body) rendered
+// a blank-looking line — just the username prefix and timestamp, no visible
+// content — before the attachment badge. The username/timestamp should land
+// directly on the attachment line instead.
+func TestRenderCircMessages_AttachmentOnlyHasNoBlankLine(t *testing.T) {
+	msg := circMsg("case", "https://cyberspace.online/img.png")
+	msg.Body = ""
+	msg.ImageUrl = "https://cyberspace.online/img.png"
+
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 60, "")
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 line for a single attachment-only message, got %d: %q", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "<case>") || !strings.Contains(lines[0], "[image]") {
+		t.Errorf("expected username and [image] badge on the same line, got: %q", lines[0])
+	}
+}
+
+// TestRenderCircMessages_AttachmentOnlyLongURL_TimestampStaysInBounds guards
+// against a regression where an attachment-only message's URL, merged onto
+// the username/timestamp line without going through the same
+// Width(bodyWidth).Render wrapping normal text bodies use, could run well
+// past viewportWidth for a long URL — pushing the timestamp far to the
+// right instead of wrapping the URL underneath it.
+func TestRenderCircMessages_AttachmentOnlyLongURL_TimestampStaysInBounds(t *testing.T) {
+	const width = 60
+	msg := circMsg("case", "")
+	msg.GifUrl = "https://cyberspace.online/uploads/reactions/mind-blown-reaction.gif"
+
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", width, "")
+	plain := ansi.Strip(out)
+
+	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
+	for _, line := range strings.Split(strings.TrimRight(plain, "\n"), "\n") {
+		if lipgloss.Width(line) > width {
+			t.Errorf("line exceeds viewportWidth %d: %q (%d cols)", width, line, lipgloss.Width(line))
+		}
+	}
+	if !strings.Contains(plain, ts) {
+		t.Fatalf("timestamp %q not found anywhere in output: %q", ts, plain)
+	}
+	lastLine := strings.Split(strings.TrimRight(plain, "\n"), "\n")
+	last := lastLine[len(lastLine)-1]
+	if !strings.HasSuffix(strings.TrimRight(last, " "), ts) {
+		t.Errorf("expected the timestamp flush right on the last line, got: %q", last)
+	}
+}
+
+// TestRenderChatMessages_AttachmentOnlyHasNoBlankLine is the C-Mail
+// equivalent of TestRenderCircMessages_AttachmentOnlyHasNoBlankLine: the
+// bordered bubble must not contain a blank row between the header and the
+// attachment block for an attachment-only message.
+func TestRenderChatMessages_AttachmentOnlyHasNoBlankLine(t *testing.T) {
+	msg := circMsg("case", "")
+	msg.ImageUrl = "https://cyberspace.online/img.png"
+
+	out := renderChatMessages([]model.Message{msg}, "", time.UTC, "datetime", 60)
+	plain := ansi.Strip(out)
+
+	// A blank content row inside the bubble would sit between the header
+	// line (contains "case") and the attachment line (contains "[image]");
+	// check there's no all-whitespace line between them.
+	lines := strings.Split(plain, "\n")
+	headerIdx, attIdx := -1, -1
+	for i, line := range lines {
+		if strings.Contains(line, "case") && headerIdx == -1 {
+			headerIdx = i
+		}
+		if strings.Contains(line, "[image]") {
+			attIdx = i
+		}
+	}
+	if headerIdx == -1 || attIdx == -1 {
+		t.Fatalf("expected both a header line and an [image] line, got: %q", plain)
+	}
+	if attIdx != headerIdx+1 {
+		t.Errorf("expected the attachment line immediately after the header with no blank line between, got lines:\n%q", lines[headerIdx:attIdx+1])
+	}
+}
+
+// TestRenderCircMessages_ArtStyleSkipsWrapAndMarkdown confirms a style:"art"
+// message's body is printed verbatim, line for line, with no word-wrap and
+// no markdown reinterpretation of leading spaces (which would otherwise be
+// read as an indented code block and mangle the picture).
+func TestRenderCircMessages_ArtStyleSkipsWrapAndMarkdown(t *testing.T) {
+	art := "  /\\_/\\\n ( o.o )\n  > ^ <"
+	msg := circMsg("case", art)
+	msg.Style = []string{"art"}
+
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 20, "")
+
+	for _, line := range strings.Split(art, "\n") {
+		if !strings.Contains(out, line) {
+			t.Errorf("expected art line %q preserved verbatim, got: %q", line, out)
+		}
+	}
+}
+
+// TestRenderCircMessages_ArtStyle_TimestampAlignsWithNormalMessage guards
+// against a regression where renderArtMessage's header-line width
+// calculation came up 2 columns short of viewportWidth, shifting the
+// timestamp left of where every other message type right-aligns it.
+func TestRenderCircMessages_ArtStyle_TimestampAlignsWithNormalMessage(t *testing.T) {
+	const width = 60
+	normal := circMsg("molly", "hello there")
+	art := circMsg("molly", "  /\\_/\\\n ( o.o )")
+	art.Style = []string{"art"}
+
+	normalLine := strings.Split(strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{normal}, time.UTC, "datetime", width, "")), "\n"), "\n")[0]
+	artLines := strings.Split(strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{art}, time.UTC, "datetime", width, "")), "\n"), "\n")
+	artHeader := artLines[0]
+
+	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
+	normalIdx := strings.Index(normalLine, ts)
+	artIdx := strings.Index(artHeader, ts)
+	if normalIdx == -1 || artIdx == -1 {
+		t.Fatalf("timestamp %q not found: normal=%q art=%q", ts, normalLine, artHeader)
+	}
+	if normalIdx != artIdx {
+		t.Errorf("art header timestamp starts at column %d, want %d (same as a normal message)", artIdx, normalIdx)
+	}
+}

--- a/internal/ui/screens/shared.go
+++ b/internal/ui/screens/shared.go
@@ -60,6 +60,52 @@ func attachmentURLs(attachments []model.Attachment) []string {
 	return out
 }
 
+// messageAttachments builds a []model.Attachment from a chat message's flat
+// ImageUrl/GifUrl/AudioAttachment fields, so the existing renderAttachments
+// (used for post/reply attachments) can render them too.
+func messageAttachments(msg model.Message) []model.Attachment {
+	var out []model.Attachment
+	if msg.ImageUrl != "" {
+		out = append(out, model.Attachment{Type: "image", Src: msg.ImageUrl})
+	}
+	if msg.GifUrl != "" {
+		out = append(out, model.Attachment{Type: "gif", Src: msg.GifUrl})
+	}
+	if msg.AudioAttachment != nil {
+		out = append(out, *msg.AudioAttachment)
+	}
+	return out
+}
+
+// messageURLs returns every openable URL in msg: links in the body plus
+// ImageUrl/GifUrl/AudioAttachment.Src. Not normalized via urlutil.NormalizeURL —
+// matches attachmentURLs' existing behavior for Attachment.Src, which is
+// already an absolute URL per the API spec.
+func messageURLs(msg model.Message) []string {
+	urls := extractURLs(msg.Body)
+	if msg.ImageUrl != "" {
+		urls = append(urls, msg.ImageUrl)
+	}
+	if msg.GifUrl != "" {
+		urls = append(urls, msg.GifUrl)
+	}
+	if msg.AudioAttachment != nil && msg.AudioAttachment.Src != "" {
+		urls = append(urls, msg.AudioAttachment.Src)
+	}
+	return urls
+}
+
+// messageDisplayBody returns "" when Body merely duplicates ImageUrl or
+// GifUrl (an attachment-only message posted with no text), so callers can
+// skip printing a redundant line of URL text next to the attachment badge
+// rendered separately via messageAttachments. Returns Body unchanged otherwise.
+func messageDisplayBody(msg model.Message) string {
+	if msg.Body != "" && (msg.Body == msg.ImageUrl || msg.Body == msg.GifUrl) {
+		return ""
+	}
+	return msg.Body
+}
+
 // dedupeURLs removes repeated URLs while preserving first-seen order. Used by
 // URLProvider implementations that aggregate across many items (e.g. an
 // entire loaded chat history) rather than a single focused one, where the


### PR DESCRIPTION
## Summary
- Adds `imageUrl`, `gifUrl`, `audioAttachment`, and `style` support across all four message wire shapes (REST cIRC, REST C-Mail, RTDB DM, RTDB cIRC) and `model.Message`, closing the "Message attachments & styles" item in `docs/00-api-backlog.md`.
- Renders attachments via the existing post/reply attachment-badge convention (`renderAttachments`), and adds a middle-fidelity terminal treatment for the 12 `style` command names (ANSI attributes for blink/quiet/rainbow, Unicode substitution for l33t/cursive/flip, ASCII-safe jitter for glitch, `tea.Tick`-driven animation for slow/wave/glitch, verbatim rendering for `/art`, no-op for comic/times).
- Adds a select-to-reveal toggle (enter, while a message is selected) for spoiler-masked and l33t-substituted text in cIRC, reusing the same per-message `revealed` state.
- Fixes two rendering bugs found in review: a blank first line on attachment-only messages (cIRC + C-Mail), and a timestamp alignment/overflow bug affecting `/art` headers and long attachment URLs.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] New unit/regression tests for: wire decoding across all four message shapes (incl. `style` string-vs-array and `art` base64 decode), style-transform pure functions, attachment/art/spoiler rendering, animation ticker start/rearm (both screens), spoiler and l33t reveal toggling, attachment-only blank-line and timestamp-overflow regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)