### PR TITLE
feat: animate GIF attachments in the inline terminal image viewer

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -132,7 +132,7 @@ type App struct {
 	// imageCache holds decoded images already fetched during the current
 	// modal's lifetime, keyed by URL, so cycling back to one skips the
 	// network fetch. Cleared whenever the modal closes.
-	imageCache map[string]image.Image
+	imageCache map[string]cachedImage
 
 	// timezone is the active UTC offset label (e.g. "UTC+2"). Empty = UTC.
 	// loc is the parsed *time.Location derived from timezone.
@@ -199,12 +199,12 @@ type App struct {
 
 	// imageModal holds the state for the inline image overlay. When imageModalOpen
 	// is true, View composites the encoded image sequence over the base content.
-	imageModalOpen     bool
-	imageModalEncoded  string
-	imageModalCols     int
-	imageModalRows     int
-	imageNeedsCleanup  bool // true after modal closes until a delete-placement frame reaches the terminal
-	imageFetchGen      int  // bumped on every fetch and on close; stale imageFetchedMsg results are dropped
+	imageModalOpen    bool
+	imageModalEncoded string
+	imageModalCols    int
+	imageModalRows    int
+	imageNeedsCleanup bool // true after modal closes until a delete-placement frame reaches the terminal
+	imageFetchGen     int  // bumped on every fetch and on close; stale imageFetchedMsg results are dropped
 
 	// ephemeral marks an SSH-hosted session whose state must never be read from
 	// or written to the host operator's config file.
@@ -2000,8 +2000,10 @@ func openExternalURL(u string) tea.Cmd {
 
 // openImageInTerminal fetches rawURL, encodes it for the detected graphics
 // protocol, and returns a command that sends an imageFetchedMsg when done.
+// GIF URLs are decoded and encoded frame-by-frame so the modal can animate.
 func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 	proto := a.graphicsProtocol
+	isGIF := urlutil.IsGIFURL(rawURL)
 	displayCols := a.width * 4 / 5
 	displayRows := a.height*4/5 - 2 // reserve 2 rows for the modal border
 	if displayRows < 1 {
@@ -2011,25 +2013,47 @@ func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 	gen := a.imageFetchGen
 	cached, hit := a.imageCache[rawURL]
 	return a, func() tea.Msg {
-		img := cached
+		frames := cached.frames
+		delays := cached.delays
 		if !hit {
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
-			var err error
-			img, err = imgview.Fetch(ctx, rawURL)
-			if err != nil {
-				return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
+			if isGIF {
+				g, err := imgview.FetchGIF(ctx, rawURL)
+				if err != nil {
+					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
+				}
+				frames, delays = imgview.GIFFrames(g)
+			} else {
+				img, err := imgview.Fetch(ctx, rawURL)
+				if err != nil {
+					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
+				}
+				frames = []image.Image{img}
+				delays = nil
 			}
 		}
-		switch proto {
-		case imgview.ProtocolKitty:
-			encoded, cols, rows := imgview.EncodeKitty(img, displayCols, displayRows)
-			return imageFetchedMsg{rawURL: rawURL, gen: gen, decoded: img, encoded: encoded, cols: cols, rows: rows}
-		case imgview.ProtocolITerm2:
-			encoded, cols, rows, err := imgview.EncodeITerm2(img, displayCols, displayRows)
-			return imageFetchedMsg{rawURL: rawURL, gen: gen, decoded: img, encoded: encoded, cols: cols, rows: rows, err: err}
-		default:
-			return imageFetchedMsg{rawURL: rawURL, gen: gen, err: fmt.Errorf("no graphics protocol")}
+		encodedFrames := make([]string, len(frames))
+		var cols, rows int
+		for i, img := range frames {
+			switch proto {
+			case imgview.ProtocolKitty:
+				encodedFrames[i], cols, rows = imgview.EncodeKitty(img, displayCols, displayRows)
+			case imgview.ProtocolITerm2:
+				var err error
+				encodedFrames[i], cols, rows, err = imgview.EncodeITerm2(img, displayCols, displayRows)
+				if err != nil {
+					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
+				}
+			default:
+				return imageFetchedMsg{rawURL: rawURL, gen: gen, err: fmt.Errorf("no graphics protocol")}
+			}
+		}
+		return imageFetchedMsg{
+			rawURL: rawURL, gen: gen,
+			frames: frames, delays: delays,
+			encodedFrames: encodedFrames, encoded: encodedFrames[0],
+			cols: cols, rows: rows,
 		}
 	}
 }
@@ -2058,16 +2082,27 @@ func (a App) handleImageViewer(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.imageModalOpen = true
 		a.imageNeedsCleanup = false
 		if a.imageCache == nil {
-			a.imageCache = make(map[string]image.Image)
+			a.imageCache = make(map[string]cachedImage)
 		}
-		a.imageCache[m.rawURL] = m.decoded
+		a.imageCache[m.rawURL] = cachedImage{frames: m.frames, delays: m.delays}
+		var cmds []tea.Cmd
 		if a.graphicsProtocol == imgview.ProtocolITerm2 && len(a.imageCarouselItems) > 1 {
 			// iTerm2/WezTerm has no Kitty-style delete-all self-heal; force a
 			// full repaint so a cycled-to smaller image can't leave stray
 			// pixels from the previous one in rows the new frame skips.
-			return a, tea.ClearScreen, true
+			cmds = append(cmds, tea.ClearScreen)
 		}
-		return a, nil, true
+		if len(m.encodedFrames) > 1 {
+			cmds = append(cmds, gifFrameTickCmd(m.encodedFrames, m.delays, 1, m.delays[0], m.gen))
+		}
+		return a, tea.Batch(cmds...), true
+	case gifFrameTickMsg:
+		if m.gen != a.imageFetchGen {
+			return a, nil, true // modal closed, cycled, or replaced since this tick was scheduled
+		}
+		a.imageModalEncoded = m.encodedFrames[m.idx]
+		nextIdx := (m.idx + 1) % len(m.encodedFrames)
+		return a, gifFrameTickCmd(m.encodedFrames, m.delays, nextIdx, m.delays[m.idx], m.gen), true
 	}
 	return a, nil, false
 }
@@ -2285,17 +2320,47 @@ type notifPostLoadErrMsg struct{ err error }
 
 // imageFetchedMsg carries the result of fetching and encoding an image for
 // terminal display. err is non-nil when the download or decode failed; rawURL
-// is retained so a failed decode can fall back to opening the browser.
+// is retained so a failed decode can fall back to opening the browser. frames
+// holds every decoded frame (len 1 for a static image); encodedFrames holds
+// each frame pre-encoded for the current graphics protocol, with encoded ==
+// encodedFrames[0] kept for the existing single-frame call sites.
 type imageFetchedMsg struct {
-	rawURL  string
-	gen     int
-	decoded image.Image
-	encoded string
-	cols    int
-	rows    int
-	err     error
+	rawURL        string
+	gen           int
+	frames        []image.Image
+	delays        []time.Duration
+	encoded       string
+	encodedFrames []string
+	cols          int
+	rows          int
+	err           error
 }
 
+// cachedImage holds a fetched/composited image's frames, keyed by URL in
+// imageCache. A static image has len(frames) == 1 and nil delays.
+type cachedImage struct {
+	frames []image.Image
+	delays []time.Duration
+}
+
+// gifFrameTickMsg advances the open image modal to its next pre-encoded GIF
+// frame. gen must match the current imageFetchGen or the tick is dropped —
+// this is how closing the modal, cycling the carousel, or opening a new
+// image stops an in-flight GIF animation with no extra bookkeeping (mirrors
+// the imageFetchedMsg staleness guard above).
+type gifFrameTickMsg struct {
+	gen           int
+	encodedFrames []string
+	delays        []time.Duration
+	idx           int
+}
+
+// gifFrameTickCmd schedules the display of encodedFrames[idx] after delay.
+func gifFrameTickCmd(encodedFrames []string, delays []time.Duration, idx int, delay time.Duration, gen int) tea.Cmd {
+	return tea.Tick(delay, func(time.Time) tea.Msg {
+		return gifFrameTickMsg{gen: gen, encodedFrames: encodedFrames, delays: delays, idx: idx}
+	})
+}
 
 // notifyLevel selects the color of a global notification banner.
 type notifyLevel int
@@ -2309,7 +2374,7 @@ const (
 type logoAnimPhase int
 
 const (
-	logoPhaseIdle         logoAnimPhase = iota
+	logoPhaseIdle logoAnimPhase = iota
 	logoPhaseScrambling
 	logoPhaseHold
 	logoPhaseUnscrambling

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2087,7 +2087,7 @@ func TestUpdate_ImageModal_OtherKey_ClosesAndClearsCarousel(t *testing.T) {
 	a.imageModalOpen = true
 	a.imageCarouselItems = []string{"https://x.com/a.jpg", "https://x.com/b.jpg"}
 	a.imageCarouselIndex = 1
-	a.imageCache = map[string]image.Image{"https://x.com/a.jpg": image.NewRGBA(image.Rect(0, 0, 2, 2))}
+	a.imageCache = map[string]cachedImage{"https://x.com/a.jpg": {frames: []image.Image{image.NewRGBA(image.Rect(0, 0, 2, 2))}}}
 	genBefore := a.imageFetchGen
 
 	m, _ := a.Update(keyMsg("x"))
@@ -2112,7 +2112,7 @@ func TestOpenImageInTerminal_CacheHit_SkipsFetch(t *testing.T) {
 	a := loggedInApp()
 	a.graphicsProtocol = imgview.ProtocolKitty
 	cachedImg := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	a.imageCache = map[string]image.Image{"https://x.com/a.jpg": cachedImg}
+	a.imageCache = map[string]cachedImage{"https://x.com/a.jpg": {frames: []image.Image{cachedImg}}}
 
 	_, cmd := a.openImageInTerminal("https://x.com/a.jpg")
 	if cmd == nil {
@@ -2128,7 +2128,7 @@ func TestOpenImageInTerminal_CacheHit_SkipsFetch(t *testing.T) {
 	if fm.err != nil {
 		t.Errorf("expected no error on a cache hit, got %v", fm.err)
 	}
-	if fm.decoded != cachedImg {
+	if len(fm.frames) != 1 || fm.frames[0] != cachedImg {
 		t.Error("expected the cached image to be reused rather than re-fetched")
 	}
 	if fm.encoded == "" {
@@ -2140,11 +2140,12 @@ func TestHandleImageViewer_Success_PopulatesCache(t *testing.T) {
 	a := loggedInApp()
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 
-	a2, _, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/a.jpg", decoded: img, encoded: "seq", cols: 2, rows: 2})
+	a2, _, ok := a.handleImageViewer(imageFetchedMsg{rawURL: "https://x.com/a.jpg", frames: []image.Image{img}, encoded: "seq", encodedFrames: []string{"seq"}, cols: 2, rows: 2})
 	if !ok {
 		t.Fatal("expected imageFetchedMsg to be handled")
 	}
-	if a2.imageCache["https://x.com/a.jpg"] != img {
+	cached := a2.imageCache["https://x.com/a.jpg"]
+	if len(cached.frames) != 1 || cached.frames[0] != img {
 		t.Error("expected the decoded image to be cached under its URL")
 	}
 }
@@ -2163,6 +2164,68 @@ func TestHandleImageViewer_StaleGeneration_Dropped(t *testing.T) {
 	}
 	if a2.imageModalEncoded != "current" {
 		t.Error("expected a stale (superseded) result to be dropped, not overwrite the current image")
+	}
+}
+
+func TestHandleImageViewer_GIFSuccess_StartsTicker(t *testing.T) {
+	a := loggedInApp()
+	a.imageFetchGen = 5
+
+	a2, cmd, ok := a.handleImageViewer(imageFetchedMsg{
+		rawURL:        "https://x.com/a.gif",
+		gen:           5,
+		encodedFrames: []string{"f0", "f1", "f2"},
+		delays:        []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		encoded:       "f0",
+		cols:          2, rows: 2,
+	})
+	if !ok {
+		t.Fatal("expected imageFetchedMsg to be handled")
+	}
+	if a2.imageModalEncoded != "f0" {
+		t.Errorf("imageModalEncoded = %q, want %q", a2.imageModalEncoded, "f0")
+	}
+	if cmd == nil {
+		t.Error("expected a cmd to schedule the next GIF frame")
+	}
+}
+
+func TestHandleImageViewer_GifFrameTick_AdvancesFrame(t *testing.T) {
+	a := loggedInApp()
+	a.imageFetchGen = 7
+
+	msg := gifFrameTickMsg{
+		gen:           7,
+		encodedFrames: []string{"f0", "f1", "f2"},
+		delays:        []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		idx:           1,
+	}
+	a2, cmd, ok := a.handleImageViewer(msg)
+	if !ok {
+		t.Fatal("expected gifFrameTickMsg to be handled")
+	}
+	if a2.imageModalEncoded != "f1" {
+		t.Errorf("imageModalEncoded = %q, want %q", a2.imageModalEncoded, "f1")
+	}
+	if cmd == nil {
+		t.Error("expected a cmd to schedule the next GIF frame")
+	}
+}
+
+func TestHandleImageViewer_GifFrameTick_StaleGenDropped(t *testing.T) {
+	a := loggedInApp()
+	a.imageFetchGen = 5
+	a.imageModalEncoded = "current"
+
+	a2, cmd, ok := a.handleImageViewer(gifFrameTickMsg{gen: 3, encodedFrames: []string{"f0", "f1"}, delays: []time.Duration{10 * time.Millisecond, 10 * time.Millisecond}, idx: 1})
+	if !ok {
+		t.Fatal("expected gifFrameTickMsg to be handled (and dropped)")
+	}
+	if cmd != nil {
+		t.Error("expected no cmd for a stale tick")
+	}
+	if a2.imageModalEncoded != "current" {
+		t.Error("expected a stale (superseded) tick to be dropped, not overwrite the current frame")
 	}
 }
 

--- a/internal/ui/imgview/fetch.go
+++ b/internal/ui/imgview/fetch.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"image"
-	_ "image/gif"
+	"image/gif"
 	_ "image/jpeg"
 	_ "image/png"
 	"io"
@@ -23,12 +23,22 @@ const maxImageBytes = 10 << 20
 // file claiming huge dimensions cannot drive allocation during decode.
 const maxImagePixels = 50 << 20 // ~52 megapixels
 
+// maxGIFFrames bounds the number of frames a GIF may declare, guarding
+// against a small file claiming an enormous frame count.
+const maxGIFFrames = 512
+
+// maxGIFTotalPixels bounds frames×width×height combined, since every frame
+// is later composited into its own full-canvas RGBA image held in memory
+// simultaneously (see GIFFrames) — maxImagePixels alone only bounds a single
+// canvas, not the multiplied-out worst case across all frames.
+const maxGIFTotalPixels = 64 << 20
+
 // httpClient is dedicated to image fetching so this path never inherits
 // global mutations to http.DefaultClient.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-// Fetch downloads the image at rawURL and decodes it. Supports JPEG, PNG, GIF, and WebP.
-func Fetch(ctx context.Context, rawURL string) (image.Image, error) {
+// fetchBody downloads rawURL, capping the read at maxImageBytes.
+func fetchBody(ctx context.Context, rawURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("imgview: %w", err)
@@ -49,6 +59,16 @@ func Fetch(ctx context.Context, rawURL string) (image.Image, error) {
 	if len(body) > maxImageBytes {
 		return nil, fmt.Errorf("imgview: image exceeds %d MiB size limit", maxImageBytes>>20)
 	}
+	return body, nil
+}
+
+// Fetch downloads the image at rawURL and decodes it. Supports JPEG, PNG, GIF, and WebP.
+// GIFs are decoded to their first frame only — use FetchGIF for all frames.
+func Fetch(ctx context.Context, rawURL string) (image.Image, error) {
+	body, err := fetchBody(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
 	cfg, _, err := image.DecodeConfig(bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("imgview: decode: %w", err)
@@ -61,4 +81,30 @@ func Fetch(ctx context.Context, rawURL string) (image.Image, error) {
 		return nil, fmt.Errorf("imgview: decode: %w", err)
 	}
 	return img, nil
+}
+
+// FetchGIF downloads the GIF at rawURL and decodes all of its frames.
+func FetchGIF(ctx context.Context, rawURL string) (*gif.GIF, error) {
+	body, err := fetchBody(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := gif.DecodeConfig(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("imgview: decode: %w", err)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 || cfg.Width*cfg.Height > maxImagePixels {
+		return nil, fmt.Errorf("imgview: image dimensions %dx%d exceed limit", cfg.Width, cfg.Height)
+	}
+	g, err := gif.DecodeAll(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("imgview: decode: %w", err)
+	}
+	if len(g.Image) > maxGIFFrames {
+		return nil, fmt.Errorf("imgview: gif has %d frames, exceeds %d frame limit", len(g.Image), maxGIFFrames)
+	}
+	if total := len(g.Image) * cfg.Width * cfg.Height; total > maxGIFTotalPixels {
+		return nil, fmt.Errorf("imgview: gif frames×dimensions %d exceed %d pixel budget", total, maxGIFTotalPixels)
+	}
+	return g, nil
 }

--- a/internal/ui/imgview/fetch_test.go
+++ b/internal/ui/imgview/fetch_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"image"
 	"image/color"
+	"image/gif"
 	"image/png"
 	"net/http"
 	"net/http/httptest"
@@ -70,5 +71,64 @@ func TestFetch_RejectsNon200(t *testing.T) {
 	_, err := imgview.Fetch(context.Background(), srv.URL)
 	if err == nil || !strings.Contains(err.Error(), "404") {
 		t.Errorf("err = %v, want 404 error", err)
+	}
+}
+
+// gifBytes encodes an n-frame, wxh GIF, each frame a solid color from
+// palette[i % len(palette)] so frames are visually distinguishable.
+func gifBytes(t *testing.T, w, h, n int) []byte {
+	t.Helper()
+	palette := []color.Color{
+		color.RGBA{R: 255, A: 255},
+		color.RGBA{G: 255, A: 255},
+		color.RGBA{B: 255, A: 255},
+	}
+	g := &gif.GIF{}
+	for i := 0; i < n; i++ {
+		pal := color.Palette{color.RGBA{}, palette[i%len(palette)]}
+		frame := image.NewPaletted(image.Rect(0, 0, w, h), pal)
+		for y := 0; y < h; y++ {
+			for x := 0; x < w; x++ {
+				frame.SetColorIndex(x, y, 1)
+			}
+		}
+		g.Image = append(g.Image, frame)
+		g.Delay = append(g.Delay, 5)
+		g.Disposal = append(g.Disposal, gif.DisposalNone)
+	}
+	var buf bytes.Buffer
+	if err := gif.EncodeAll(&buf, g); err != nil {
+		t.Fatalf("encode gif: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestFetchGIF_DecodesFrames(t *testing.T) {
+	srv := serve(t, http.StatusOK, gifBytes(t, 4, 3, 3))
+	g, err := imgview.FetchGIF(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("FetchGIF: %v", err)
+	}
+	if len(g.Image) != 3 {
+		t.Errorf("frame count = %d, want 3", len(g.Image))
+	}
+}
+
+func TestFetchGIF_RejectsTooManyFrames(t *testing.T) {
+	srv := serve(t, http.StatusOK, gifBytes(t, 1, 1, 513))
+	_, err := imgview.FetchGIF(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "frame limit") {
+		t.Errorf("err = %v, want frame limit error", err)
+	}
+}
+
+func TestFetchGIF_RejectsExcessiveDimensions(t *testing.T) {
+	// GIF89a header declaring a 65535x65535 logical screen (~4.3 gigapixels)
+	// with no pixel data: DecodeConfig reads only the header.
+	header := []byte("GIF89a\xff\xff\xff\xff\x00\x00\x00")
+	srv := serve(t, http.StatusOK, header)
+	_, err := imgview.FetchGIF(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "dimensions") {
+		t.Errorf("err = %v, want dimensions error", err)
 	}
 }

--- a/internal/ui/imgview/frames.go
+++ b/internal/ui/imgview/frames.go
@@ -1,0 +1,35 @@
+package imgview
+
+import (
+	"image"
+	"image/draw"
+	"image/gif"
+	"time"
+)
+
+// GIFFrames composites g's frames onto an accumulating canvas and returns one
+// full-canvas image per frame alongside its display delay.
+//
+// ponytail: does not implement per-frame disposal methods (background-color
+// restore / restore-to-previous) — Over-compositing is correct for GIFs that
+// redraw the full frame or paint additively (the common case), but can show
+// minor ghosting on GIFs relying on DisposalBackground/DisposalPrevious.
+// Upgrade path: branch on g.Disposal[i].
+func GIFFrames(g *gif.GIF) (frames []image.Image, delays []time.Duration) {
+	canvas := image.NewRGBA(image.Rect(0, 0, g.Config.Width, g.Config.Height))
+	frames = make([]image.Image, len(g.Image))
+	delays = make([]time.Duration, len(g.Image))
+	for i, frame := range g.Image {
+		draw.Draw(canvas, frame.Bounds(), frame, frame.Bounds().Min, draw.Over)
+		snap := image.NewRGBA(canvas.Rect)
+		copy(snap.Pix, canvas.Pix)
+		frames[i] = snap
+
+		delayCs := g.Delay[i]
+		if delayCs <= 1 {
+			delayCs = 10 // browser convention: near-zero delays render unwatchably fast
+		}
+		delays[i] = time.Duration(delayCs) * 10 * time.Millisecond
+	}
+	return frames, delays
+}

--- a/internal/ui/imgview/frames_test.go
+++ b/internal/ui/imgview/frames_test.go
@@ -1,0 +1,70 @@
+package imgview_test
+
+import (
+	"image"
+	"image/color"
+	"image/gif"
+	"testing"
+	"time"
+
+	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+)
+
+func TestGIFFrames_CompositesAndClampsDelays(t *testing.T) {
+	red := color.Palette{color.RGBA{}, color.RGBA{R: 255, A: 255}}
+	blue := color.Palette{color.RGBA{}, color.RGBA{B: 255, A: 255}}
+
+	// Frame 0: fully red. Frame 1: only pixel (1,0) painted blue, rest left
+	// transparent so accumulation must be visible if compositing is correct.
+	// Frame 2: same as frame 1, to exercise the delay-clamping branch.
+	f0 := image.NewPaletted(image.Rect(0, 0, 2, 2), red)
+	for y := 0; y < 2; y++ {
+		for x := 0; x < 2; x++ {
+			f0.SetColorIndex(x, y, 1)
+		}
+	}
+	f1 := image.NewPaletted(image.Rect(1, 0, 2, 1), blue)
+	f1.SetColorIndex(1, 0, 1)
+	f2 := image.NewPaletted(image.Rect(1, 0, 2, 1), blue)
+	f2.SetColorIndex(1, 0, 1)
+
+	g := &gif.GIF{
+		Image:  []*image.Paletted{f0, f1, f2},
+		Delay:  []int{0, 1, 5},
+		Config: image.Config{Width: 2, Height: 2},
+	}
+
+	frames, delays := imgview.GIFFrames(g)
+	if len(frames) != 3 || len(delays) != 3 {
+		t.Fatalf("got %d frames, %d delays; want 3, 3", len(frames), len(delays))
+	}
+
+	wantDelays := []time.Duration{100 * time.Millisecond, 100 * time.Millisecond, 50 * time.Millisecond}
+	for i, want := range wantDelays {
+		if delays[i] != want {
+			t.Errorf("delays[%d] = %v, want %v", i, delays[i], want)
+		}
+	}
+
+	// (0,0) was only ever painted red in frame 0 and never touched again —
+	// it must still be red in frame 2, proving accumulation rather than
+	// each frame starting from a blank canvas.
+	r, g2, b, _ := frames[2].At(0, 0).RGBA()
+	if r>>8 != 255 || g2>>8 != 0 || b>>8 != 0 {
+		t.Errorf("frames[2].At(0,0) = (%d,%d,%d), want red carried over from frame 0", r>>8, g2>>8, b>>8)
+	}
+	// (1,0) was painted blue in frame 1 and again in frame 2.
+	r, g2, b, _ = frames[2].At(1, 0).RGBA()
+	if b>>8 != 255 || r>>8 != 0 {
+		t.Errorf("frames[2].At(1,0) = (%d,%d,%d), want blue", r>>8, g2>>8, b>>8)
+	}
+
+	// Mutating frame 0's snapshot must not affect frame 1's — proves the
+	// per-frame copy isn't aliased to the shared accumulation canvas.
+	rgba0 := frames[0].(*image.RGBA)
+	rgba0.Set(0, 0, color.RGBA{G: 255, A: 255})
+	r, _, _, _ = frames[1].At(0, 0).RGBA()
+	if r>>8 != 255 {
+		t.Error("frames[1] was mutated by writing to frames[0]; snapshots are aliased")
+	}
+}

--- a/internal/ui/urlutil/isimage.go
+++ b/internal/ui/urlutil/isimage.go
@@ -22,3 +22,12 @@ func IsImageURL(rawURL string) bool {
 	ext := strings.ToLower(path.Ext(u.Path))
 	return imageExts[ext]
 }
+
+// IsGIFURL reports whether the URL's path ends with a .gif extension.
+func IsGIFURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return strings.ToLower(path.Ext(u.Path)) == ".gif"
+}

--- a/internal/ui/urlutil/isimage_test.go
+++ b/internal/ui/urlutil/isimage_test.go
@@ -32,3 +32,24 @@ func TestIsImageURL(t *testing.T) {
 		}
 	}
 }
+
+func TestIsGIFURL(t *testing.T) {
+	t.Helper()
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"https://example.com/anim.gif", true},
+		{"https://example.com/anim.GIF", true},
+		{"https://example.com/photo.jpg", false},
+		{"https://example.com/post/123", false},
+		{"https://example.com/", false},
+		{"not a url", false},
+	}
+	for _, c := range cases {
+		got := urlutil.IsGIFURL(c.url)
+		if got != c.want {
+			t.Errorf("IsGIFURL(%q) = %v, want %v", c.url, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- GIF attachments opened in the inline Kitty/iTerm2 terminal viewer now animate instead of showing a static first frame — decodes all frames via `image/gif`, composites them with `image/draw`, and cycles the modal through them on a timer using the existing self-rescheduling `tea.Tick` idiom already used elsewhere in the app.
- Adds DoS bounds on GIF decode (frame count cap + combined frame×dimension pixel budget), since each frame becomes a full RGBA image held in memory.
- A native Kitty animation-protocol path (`a=f`/`a=a`) was attempted for flicker-free playback, then reverted: Ghostty doesn't implement that extension, and sending it unsupported commands corrupted its render state badly enough to freeze unrelated animations in the app. The shipped version uses the proven tick-based re-render for both Kitty and iTerm2/WezTerm, which does flicker somewhat but is safe.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Manually verified in Ghostty (CIRC): GIF opens, animates, modal closes cleanly, no input corruption, no lingering freeze of other animations (blink/wave/glitch) after the native-protocol revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)