### PR TITLE
feat: live-refresh cIRC mute state via slash commands

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -18,6 +18,7 @@ These bugs exist in the server — no client-side fix is possible. Report to the
 | `/v1/notifications?type=...` | GET | **Open** | The `type` query param (comma-separated notification-type filter) returns `500 INTERNAL_ERROR` for every value tested live — single types (`type=reply`, `type=chat_mention`, `type=dm_message`) and comma-separated combinations (`type=dm_message,chat_mention`) all fail server-side. Confirmed via `apifetch`. The client's `types []string` param plumbing (`GetNotifications`) is left in place unaffected for when the server bug is fixed; no UI currently sends a non-nil filter, so there's no live-facing regression today. | 2026-07-24 |
 | `/v1/users/me`, `/v1/users/:username` | GET | **Resolved (client-side removal)** | `postsCount` was deprecated and no longer returned reliable data; the field is also absent from the current API docs snapshot (`followersCount`/`followingCount` still present). Removed the `posts` segment from the profile counts line and the `PostsCount` field from `model.User`/`wireUser`. | 2026-07-29 |
 | `/docs.md` | GET | **Resolved** | `docs.md` now reports v0.8 live. `docs/00-latest-api-reference.md` re-fetched and diffed — new surface (flagging, cIRC message delete, message attachments/styles/mute commands, `EMAIL_NOT_VERIFIED`) added to Unimplemented API Features below. | 2026-07-31 |
+| `/v1/notifications` vs `/v1/notifications/unread-count` | GET | **Open (by design, per docs)** | The two endpoints disagree on a fresh, unpaginated session: `unread-count` returned `{"count": 5}` while `?limit=20&read=false` returned only 3 items (2 `thread_reply`, 1 `new_post_following`) — a `new_follower` and a `poke` notification counted in the badge were absent from the list. Confirmed live via `apifetch` 2026-08-03. Matches the documented caveat at `docs/00-latest-api-reference.md:690` ("the count may be slightly higher... which applies additional filtering"), so this is expected server behavior rather than a bug, but it means the TUI's badge and its notification list can legitimately disagree — not a TUI regression. No client-side fix possible; investigated after a user report of "webui shows 5 unread, tui shows 3." | 2026-08-03 |
 
 ---
 
@@ -159,7 +160,7 @@ cIRC/C-Mail messages can now carry `imageUrl`, `gifUrl` (`/gif <url>`), `audioAt
 | Area | Description | Priority |
 |---|---|---|
 | `gifUrl`, `audioAttachment`, `style`, chained styles | Render/decode in message view; `style: "art"` needs base64 decode | **Done** — wire/model fields across all four message shapes, attachment badges reusing `renderAttachments`, and a middle-fidelity style pipeline (ANSI attributes for blink/quiet/rainbow, Unicode substitution for l33t/cursive/flip, ASCII-safe jitter for glitch, `tea.Tick`-driven slow/wave/glitch animation, select-to-reveal spoiler in cIRC only — see `internal/ui/screens/chatstyle.go`) |
-| `/mute` family + `mutedUsersByRoom` | Client-side message filtering by muted user | Not implemented |
+| `/mute` family + `mutedUsersByRoom` | Client-side message filtering by muted user | **Done** — cIRC only (C-Mail 400s per API spec); see `docs/37-circ-mute.md` |
 | Empty `content` with attachment-only messages | Message rendering must not assume non-empty `content` | **Done** — covered by the same change; `messageDisplayBody` skips duplicate URL text and empty bodies render without assuming non-empty `content` |
 
 ### Auth (new in v0.8)
@@ -222,7 +223,7 @@ Notes:
 | --------------- | ------------------------------------- | -------------------------------------------------------------------- |
 | Notes (Journal) | List, create, edit, delete, revision history | — |
 | Profile         | View and edit all fields              | —                                                                    |
-| Settings        | All TUI-relevant fields editable      | `keyboardBindings`, `keyboardPreset`, `mutedUsersByRoom` — web UI concepts with no TUI equivalent; intentionally omitted |
+| Settings        | All TUI-relevant fields editable; `mutedUsersByRoom` read and enforced (feature 37) | `keyboardBindings`, `keyboardPreset` — web UI concepts with no TUI equivalent; intentionally omitted |
 | Follows         | Follow, unfollow, list following and followers | — |
 | Notifications   | All v0.4 types received and displayed with dedicated text and icons | — |
 

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -980,7 +980,7 @@ Release tags follow semver: `git tag -a v0.1.0 -m "v0.1.0"`. The `--version` fla
 |---|---|
 | **Chatrooms API** | UI fully built; REST integration deferred (server paths not finalized) |
 | **HTTPClient thread safety** | Resolved: `tokens` is guarded by a `sync.Mutex` (see `docs/30-security-hardening.md`) |
-| **Settings — deferred fields** | `iconTheme`, `imagePixelSize`, `followedTopics`, `mutedTopics` are read from the API but intentionally excluded from PATCH until the server-side feature is finalized |
+| **Settings — deferred fields** | `iconTheme`, `imagePixelSize`, `followedTopics`, `mutedTopics` are read from the API but intentionally excluded from PATCH until the server-side feature is finalized. `mutedUsersByRoom` is also read but excluded from PATCH for a different reason — it's server-managed via `/mute` slash commands only (see `docs/37-circ-mute.md`), never client-patched |
 | **Journal write operations** | Fully operational. `PATCH /v1/notes/:id` was fixed server-side in API v0.4. |
 | **Post/reply deletion** | Wired and working — `d` key in Feed (own posts) and Post Detail (own posts and replies) |
 | **Attachments** | Image and YouTube audio attachments on posts/replies are not supported in the TUI |

--- a/docs/37-circ-mute.md
+++ b/docs/37-circ-mute.md
@@ -1,0 +1,23 @@
+# Feature 37: cIRC `/mute` family
+
+Client-side per-room message hiding for muted users, driven by `mutedUsersByRoom` on `Settings`.
+
+## How it works
+
+`/mute <username>`, `/unmute <username>`, `/muted`, and `/unmuteall` are ordinary cIRC slash commands — typed into the compose box and sent through the existing `SendRoomMessage` path exactly like `/dice` or `/help`. **cIRC only**: sending any of them in a C-Mail conversation returns `400` from the server (surfaced as the existing generic error banner — no special-casing needed).
+
+The server does all the bookkeeping: each command posts nothing and returns `{"data":{"reply":"..."}}` with confirmation text, which the client already shows as a local system message via the existing `roomCommandReplyMsg`/`AppendSystemMessage` mechanism (the same one `/help` uses) — no new plumbing needed for that part.
+
+**Critically, the server does not filter messages.** `GET /v1/circ/:roomId` still returns a muted user's messages — the API contract explicitly puts filtering on the client. The mute list itself lives in `mutedUsersByRoom` (`map[roomID][]username]`) on `Settings`, shared with the website.
+
+## Implementation
+
+- `model.Settings.MutedUsersByRoom` — new field, decoded from `GET /v1/settings` (`wireSettings`/`wireSettingsToModel` in `internal/api/client.go`). Deliberately **excluded** from `wirePatchSettings`/`UpdateSettings`, same treatment as `mutedTopics` — it's server-managed via the slash commands, never PATCHed by the client.
+- After any room command reply (`roomCommandReplyMsg` in `internal/ui/app.go`), the client re-fetches `Settings` so a `/mute`/`/unmute`/`/unmuteall` takes effect immediately without a relogin. This isn't command-specific — any reply-producing command triggers the refresh, which is cheap and idempotent.
+- `ChatroomsModel` picks up `Settings.MutedUsersByRoom` via the existing `SharedConfigMsg` broadcast and re-renders the active room immediately if one is open.
+- Filtering happens in `renderCircMessagesStyled` (`internal/ui/screens/render.go`): a muted sender's message contributes **zero output**, not a removed slice entry — this keeps `msgOffsets`/`msgHeights` 1:1 with `m.messages`, which selection/scrolling/pagination code depends on. `selectableMessageIndices` also excludes muted senders, so a hidden message can't be selected, flagged, or deleted while muted. Unmuting re-reveals any already-fetched history for free, since nothing was ever removed from `m.messages`.
+
+## Out of scope
+
+- No dedicated keybinding — muting is slash-command-only, matching every other cIRC command (no client-side command parsing/autocomplete exists for any of them).
+- No local-only config file storage — unlike `Timezone` (which has no server equivalent), `mutedUsersByRoom` is genuinely server-synced and shared with the website, so it lives in `model.Settings`.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -424,11 +424,13 @@ type wireSettings struct {
 	ImagePixelSize    string                `json:"imagePixelSize"`
 	TimeDisplayFormat string                `json:"timeDisplayFormat"`
 	DefaultPublicPost bool                  `json:"defaultPublicPost"`
+	MutedUsersByRoom  map[string][]string   `json:"mutedUsersByRoom"`
 }
 
 // wirePatchSettings is the PATCH /v1/settings payload — only the fields the
 // UI manages. Deferred fields (iconTheme, imagePixelSize, followedTopics,
-// mutedTopics) are intentionally excluded so the API never receives them.
+// mutedTopics, mutedUsersByRoom) are intentionally excluded so the API never
+// receives them — mutedUsersByRoom is server-managed via /mute commands, not PATCH.
 type wirePatchSettings struct {
 	Notifications     wireNotificationPrefs `json:"notifications"`
 	FilterNSFW        bool                  `json:"filterNSFW"`
@@ -1024,6 +1026,7 @@ func wireSettingsToModel(w wireSettings) model.Settings {
 		ImagePixelSize:    w.ImagePixelSize,
 		TimeDisplayFormat: w.TimeDisplayFormat,
 		DefaultPublicPost: w.DefaultPublicPost,
+		MutedUsersByRoom:  w.MutedUsersByRoom,
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -2661,6 +2661,29 @@ func TestHTTPGetOwnProfile_ParsesNewFields(t *testing.T) {
 	}
 }
 
+func TestHTTPGetSettings_ParsesMutedUsersByRoom(t *testing.T) {
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/settings" {
+			http.NotFound(w, r)
+			return
+		}
+		writeOK(t, w, map[string]any{
+			"mutedUsersByRoom": map[string][]string{
+				"general": {"alice", "bob"},
+			},
+		})
+	})))
+	c.Login("u@example.com", "pass")
+
+	settings, err := c.GetSettings()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := settings.MutedUsersByRoom["general"]; len(got) != 2 || got[0] != "alice" || got[1] != "bob" {
+		t.Errorf("MutedUsersByRoom[general] = %v, want [alice bob]", got)
+	}
+}
+
 // --- Notes ---
 
 func TestHTTPGetNotes_ParsesList(t *testing.T) {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -177,7 +177,7 @@ type NotificationPrefs struct {
 }
 
 // Settings maps to the fields returned by GET /v1/settings.
-// KeyboardBindings and MutedUsersByRoom are opaque JSON objects — not modelled yet.
+// KeyboardBindings is an opaque JSON object — not modelled yet.
 type Settings struct {
 	Notifications     NotificationPrefs
 	FilterNSFW        bool
@@ -189,6 +189,7 @@ type Settings struct {
 	ImagePixelSize    string // named preset or pixel multiplier, e.g. "sharp", "2"
 	TimeDisplayFormat string // "datetime", "relative", "unix", or "swatch"
 	DefaultPublicPost bool
+	MutedUsersByRoom  map[string][]string // roomID -> muted usernames; server-managed via /mute commands, cIRC only
 }
 
 // Bookmark maps to the shape returned by GET /v1/bookmarks.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -847,7 +847,7 @@ func (a App) handleChatrooms(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, cmd, true
 	case roomCommandReplyMsg:
 		a.chatrooms = a.chatrooms.AppendSystemMessage(msg.roomID, sanitize.Strip(msg.reply))
-		return a, nil, true
+		return a, a.loadSettingsCmd(), true
 	case screens.LeaveChatroomsMsg:
 		a.active = a.chatroomsReturn
 		return a, nil, true

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -201,6 +201,8 @@ type ChatroomsModel struct {
 	client       api.Client
 	err          error // last message-load/subscribe failure for the active room; cleared on success
 
+	mutedUsersByRoom map[string][]string // roomID -> muted usernames, from Settings
+
 	// canGoBack is true when the active room was opened via a deep link
 	// (e.g. a chat_mention notification) rather than by switching to this
 	// tab normally. When true, ESC in detail mode leaves Chatrooms
@@ -874,7 +876,16 @@ func (m ChatroomsModel) updateInner(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 
 	case SharedConfigMsg:
 		m.timeDisplayFormat = msg.Settings.TimeDisplayFormat
+		m.mutedUsersByRoom = msg.Settings.MutedUsersByRoom
 		m = m.SetLocation(msg.Loc)
+		if m.mode == chatroomModeDetail && m.activeRoom != nil {
+			m = m.refreshMessages()
+			if m.selectedMsgID != "" {
+				m = m.ensureSelectedMessageVisible()
+			} else {
+				m.viewport.GotoBottom()
+			}
+		}
 		return m, nil
 
 	// --- CIRC subscription lifecycle ---
@@ -1204,7 +1215,7 @@ func (m ChatroomsModel) updateInner(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 				}
 				return m, nil
 			case "up":
-				sel := selectableMessageIndices(m.messages)
+				sel := selectableMessageIndices(m.messages, m.mutedUsers())
 				if len(sel) == 0 {
 					m.viewport.ScrollUp(1)
 					return m.maybeLoadOlderMessages()
@@ -1303,6 +1314,19 @@ func (m ChatroomsModel) renderRoomCards() string {
 	return sb.String()
 }
 
+// mutedUsers returns the set of usernames muted in the active room, for
+// filtering them out of the rendered message list.
+func (m ChatroomsModel) mutedUsers() map[string]bool {
+	if m.activeRoomID == "" || len(m.mutedUsersByRoom[m.activeRoomID]) == 0 {
+		return nil
+	}
+	muted := make(map[string]bool, len(m.mutedUsersByRoom[m.activeRoomID]))
+	for _, u := range m.mutedUsersByRoom[m.activeRoomID] {
+		muted[strings.ToLower(u)] = true
+	}
+	return muted
+}
+
 func (m ChatroomsModel) renderMessages() string {
 	if len(m.messages) == 0 {
 		if m.err != nil {
@@ -1310,7 +1334,7 @@ func (m ChatroomsModel) renderMessages() string {
 		}
 		return theme.Subtle.Render("no messages yet")
 	}
-	return renderCircMessages(m.messages, m.location(), m.timeDisplayFormat, m.viewport.Width, m.currentUser)
+	return renderCircMessages(m.messages, m.location(), m.timeDisplayFormat, m.viewport.Width, m.currentUser, m.mutedUsers())
 }
 
 // refreshMessages rebuilds the viewport content and the per-message
@@ -1325,7 +1349,7 @@ func (m ChatroomsModel) refreshMessages() ChatroomsModel {
 	}
 	content, offsets, heights := renderCircMessagesWithSelection(
 		m.messages, m.location(), m.timeDisplayFormat, m.viewport.Width, m.currentUser, m.selectedMsgID,
-		m.revealed, m.styleAnimFrame)
+		m.revealed, m.styleAnimFrame, m.mutedUsers())
 	m.viewport.SetContent(content)
 	m.msgOffsets, m.msgHeights = offsets, heights
 	return m
@@ -1333,11 +1357,12 @@ func (m ChatroomsModel) refreshMessages() ChatroomsModel {
 
 // selectableMessageIndices returns the indices into msgs of messages that can
 // be selected/flagged: a real (non-system) message with a stable ID. System
-// notices (AppendSystemMessage) have no ID and are never selectable.
-func selectableMessageIndices(msgs []model.Message) []int {
+// notices (AppendSystemMessage) have no ID and are never selectable. Muted
+// senders are also excluded, since their messages render as hidden/zero-height.
+func selectableMessageIndices(msgs []model.Message, muted map[string]bool) []int {
 	var sel []int
 	for i, msg := range msgs {
-		if !msg.IsSystem && msg.ID != "" {
+		if !msg.IsSystem && msg.ID != "" && !muted[strings.ToLower(msg.From.Username)] {
 			sel = append(sel, i)
 		}
 	}
@@ -1450,7 +1475,7 @@ func (m ChatroomsModel) updateBrowsingKey(msg tea.KeyMsg) (ChatroomsModel, tea.C
 		}
 		return m, nil
 	}
-	sel := selectableMessageIndices(m.messages)
+	sel := selectableMessageIndices(m.messages, m.mutedUsers())
 	curPos := selectablePos(m.messages, sel, m.selectedMsgID)
 	if curPos < 0 {
 		// The selected message no longer exists — fall back to typing.

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -899,6 +899,80 @@ func TestChatrooms_Esc_WhileBrowsing_ResetsViewportToBottom(t *testing.T) {
 	}
 }
 
+// TestChatrooms_SettingsRefresh_WhileTyping_ResetsViewportToBottom guards a
+// real bug: an incoming SharedConfigMsg (e.g. the settings refresh fired
+// after the user's own /mute or /unmute) re-filters and re-renders the
+// message list via refreshMessages(), which changes the rendered line count
+// but never touched viewport.YOffset — leaving the view pinned to a stale
+// raw line number that now maps to different content instead of following
+// the reload, the same class of bug the esc-while-browsing case above guards.
+func TestChatrooms_SettingsRefresh_WhileTyping_ResetsViewportToBottom(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+
+	var msgs []model.Message
+	for i := 1; i <= 30; i++ {
+		msgs = append(msgs, model.Message{
+			ID:        fmt.Sprintf("m%d", i),
+			From:      model.User{Username: "molly"},
+			Body:      fmt.Sprintf("message %d", i),
+			CreatedAt: time.Now().Add(time.Duration(i) * time.Minute),
+		})
+	}
+	m = m.SetMessages("zion", msgs)
+	m.viewport.SetYOffset(0)
+	if m.viewport.AtBottom() {
+		t.Fatal("setup: expected the viewport to start away from the bottom")
+	}
+
+	m, _ = m.Update(SharedConfigMsg{Settings: model.Settings{MutedUsersByRoom: map[string][]string{"zion": {"molly"}}}})
+
+	if !m.viewport.AtBottom() {
+		t.Errorf("expected a settings refresh to reset the viewport to the bottom while typing, YOffset=%d", m.viewport.YOffset)
+	}
+}
+
+// TestChatrooms_SettingsRefresh_WhileBrowsing_KeepsSelectionVisible mirrors
+// the above for the browsing-a-selected-message case: the selected message
+// should stay on screen (not necessarily at the bottom) after the reload.
+func TestChatrooms_SettingsRefresh_WhileBrowsing_KeepsSelectionVisible(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+
+	var msgs []model.Message
+	for i := 1; i <= 30; i++ {
+		msgs = append(msgs, model.Message{
+			ID:        fmt.Sprintf("m%d", i),
+			From:      model.User{Username: "molly"},
+			Body:      fmt.Sprintf("message %d", i),
+			CreatedAt: time.Now().Add(time.Duration(i) * time.Minute),
+		})
+	}
+	m = m.SetMessages("zion", msgs)
+	for i := 0; i < len(msgs); i++ {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	}
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q after paging all the way up, want m1", m.selectedMsgID)
+	}
+
+	m, _ = m.Update(SharedConfigMsg{Settings: model.Settings{MutedUsersByRoom: map[string][]string{"zion": {"someoneElse"}}}})
+
+	idx := -1
+	for i, msg := range m.messages {
+		if msg.ID == m.selectedMsgID {
+			idx = i
+		}
+	}
+	if idx == -1 {
+		t.Fatalf("selected message %q not found after refresh", m.selectedMsgID)
+	}
+	itemStart := m.msgOffsets[idx]
+	itemEnd := itemStart + m.msgHeights[idx] - 1
+	if itemStart < m.viewport.YOffset || itemEnd >= m.viewport.YOffset+m.viewport.Height {
+		t.Errorf("selected message (lines %d-%d) not visible in viewport window [%d, %d)",
+			itemStart, itemEnd, m.viewport.YOffset, m.viewport.YOffset+m.viewport.Height)
+	}
+}
+
 // TestMentionGhostText_CursorOverlayUsesGhostColor guards against the
 // overlaid character rendering in normal text color during the cursor's
 // text-style blink phase, which would make it indistinguishable from
@@ -975,7 +1049,7 @@ func TestBrowsing_Enter_TogglesSpoilerReveal(t *testing.T) {
 	}
 	renderedWithReveal := func(m ChatroomsModel) string {
 		content, _, _ := renderCircMessagesWithSelection(m.messages, m.location(), m.timeDisplayFormat,
-			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame)
+			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame, nil)
 		return content
 	}
 	if strings.Contains(renderedWithReveal(m), "the ending is a twist") {
@@ -1028,7 +1102,7 @@ func TestBrowsing_Enter_TogglesL33tReveal(t *testing.T) {
 
 	renderedWithReveal := func(m ChatroomsModel) string {
 		content, _, _ := renderCircMessagesWithSelection(m.messages, m.location(), m.timeDisplayFormat,
-			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame)
+			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame, nil)
 		return content
 	}
 	if !strings.Contains(renderedWithReveal(m), "3l173") {

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -200,8 +200,8 @@ func listFooter(loading, exhausted bool) string {
 // highlighted. Bodies word-wrap to fit viewportWidth, with room reserved on
 // every wrapped line for the timestamp column so long messages never push it
 // off-screen; continuation lines are indented to align under the body.
-func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string) string {
-	return renderCircMessagesStyled(msgs, loc, timeDisplayFormat, viewportWidth, currentUser, nil, 0)
+func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, muted map[string]bool) string {
+	return renderCircMessagesStyled(msgs, loc, timeDisplayFormat, viewportWidth, currentUser, nil, 0, muted)
 }
 
 // renderCircMessagesStyled is renderCircMessages plus style/attachment
@@ -209,14 +209,19 @@ func renderCircMessages(msgs []model.Message, loc *time.Location, timeDisplayFor
 // body and which l33t-styled messages show their original, unsubstituted
 // text (keyed by message ID; nil means none revealed), and frame drives
 // the slow/wave/glitch animated styles. renderCircMessages is a thin wrapper
-// passing (nil, 0), so its many existing call sites are unaffected.
-func renderCircMessagesStyled(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, revealed map[string]bool, frame int) string {
+// passing (nil, 0), so its many existing call sites are unaffected. muted
+// (username, lowercased -> true) hides a sender's messages entirely — the
+// message contributes no output, keeping msgs/offsets/heights 1:1.
+func renderCircMessagesStyled(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, revealed map[string]bool, frame int, muted map[string]bool) string {
 	if viewportWidth < 20 {
 		viewportWidth = 80
 	}
 	const tsGap = 2 // minimum space between the wrapped text and the timestamp
 	var sb strings.Builder
 	for _, msg := range msgs {
+		if !msg.IsSystem && muted[strings.ToLower(msg.From.Username)] {
+			continue
+		}
 		if msg.IsSystem {
 			sb.WriteString(renderSystemNotice(msg.Body, viewportWidth))
 			continue
@@ -344,13 +349,13 @@ func renderDeletedTombstone(username, ts string, viewportWidth int) string {
 // the selected message's block is stripped back to plain text (ansi.Strip)
 // and only that plain text is wrapped in theme.SelectedRow — the same
 // approach settings.go uses for its selected-row highlight.
-func renderCircMessagesWithSelection(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, selectedID string, revealed map[string]bool, frame int) (content string, offsets []int, heights []int) {
+func renderCircMessagesWithSelection(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, selectedID string, revealed map[string]bool, frame int, muted map[string]bool) (content string, offsets []int, heights []int) {
 	offsets = make([]int, len(msgs))
 	heights = make([]int, len(msgs))
 	var sb strings.Builder
 	var lineCount int
 	for i, msg := range msgs {
-		rendered := renderCircMessagesStyled([]model.Message{msg}, loc, timeDisplayFormat, viewportWidth, currentUser, revealed, frame)
+		rendered := renderCircMessagesStyled([]model.Message{msg}, loc, timeDisplayFormat, viewportWidth, currentUser, revealed, frame, muted)
 		if selectedID != "" && msg.ID == selectedID {
 			plain := strings.TrimSuffix(ansi.Strip(rendered), "\n")
 			rendered = theme.SelectedRow.Width(viewportWidth).Render(plain) + "\n"

--- a/internal/ui/screens/render_test.go
+++ b/internal/ui/screens/render_test.go
@@ -39,7 +39,7 @@ func circMsg(username, body string) model.Message {
 func TestRenderCircMessages_WrapsLongBodyWithinWidth(t *testing.T) {
 	const width = 60
 	body := strings.Repeat("a very long word soup that keeps going and going ", 5)
-	out := renderCircMessages([]model.Message{circMsg("alice", body)}, time.UTC, "datetime", width, "")
+	out := renderCircMessages([]model.Message{circMsg("alice", body)}, time.UTC, "datetime", width, "", nil)
 
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 	if len(lines) < 2 {
@@ -62,7 +62,7 @@ func TestRenderCircMessages_WrapsLongBodyWithinWidth(t *testing.T) {
 // when the last wrapped line runs close to the viewport edge.
 func TestRenderCircMessages_TimestampHasGapFromText(t *testing.T) {
 	const width = 60
-	out := renderCircMessages([]model.Message{circMsg("bob", "short reply")}, time.UTC, "datetime", width, "")
+	out := renderCircMessages([]model.Message{circMsg("bob", "short reply")}, time.UTC, "datetime", width, "", nil)
 
 	line := strings.TrimRight(out, "\n")
 	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
@@ -93,7 +93,7 @@ func TestRenderCircMessages_SystemNotice(t *testing.T) {
 	}
 	regular := circMsg("bob", "hi")
 
-	out := renderCircMessages([]model.Message{sys, regular}, time.UTC, "datetime", width, "")
+	out := renderCircMessages([]model.Message{sys, regular}, time.UTC, "datetime", width, "", nil)
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 
 	if !strings.HasPrefix(lines[0], "***") {
@@ -132,7 +132,7 @@ func TestRenderCircMessages_DeletedTombstone(t *testing.T) {
 		CreatedAt: circMsgTime,
 	}
 
-	out := renderCircMessages([]model.Message{deleted}, time.UTC, "datetime", width, "")
+	out := renderCircMessages([]model.Message{deleted}, time.UTC, "datetime", width, "", nil)
 
 	if !strings.Contains(out, "<molly>") {
 		t.Errorf("expected the author to still be shown, got: %q", out)
@@ -162,8 +162,8 @@ func TestRenderCircMessages_DeletedTombstone_TimestampAlignsWithNormalMessage(t 
 		CreatedAt: circMsgTime,
 	}
 
-	normalLine := strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{normal}, time.UTC, "datetime", width, "")), "\n")
-	deletedLine := strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{deleted}, time.UTC, "datetime", width, "")), "\n")
+	normalLine := strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{normal}, time.UTC, "datetime", width, "", nil)), "\n")
+	deletedLine := strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{deleted}, time.UTC, "datetime", width, "", nil)), "\n")
 
 	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
 	normalIdx := strings.Index(normalLine, ts)
@@ -202,7 +202,7 @@ func TestRenderCircMessages_ActionLine(t *testing.T) {
 	action.IsAction = true
 	regular := circMsg("bob", "hi there")
 
-	out := renderCircMessages([]model.Message{action, regular}, time.UTC, "datetime", width, "")
+	out := renderCircMessages([]model.Message{action, regular}, time.UTC, "datetime", width, "", nil)
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 
 	if !strings.HasPrefix(lines[0], "* ragnar tests the plumbing") {
@@ -245,7 +245,7 @@ func TestRenderCircMessages_ActionLineWrapsCorrectly(t *testing.T) {
 	action := circMsg("ragnar", strings.Repeat("does a very long dramatic action sequence ", 5))
 	action.IsAction = true
 
-	out := renderCircMessages([]model.Message{action}, time.UTC, "datetime", width, "")
+	out := renderCircMessages([]model.Message{action}, time.UTC, "datetime", width, "", nil)
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 	if len(lines) < 2 {
 		t.Fatalf("expected the long action to wrap onto multiple lines, got %d line(s)", len(lines))
@@ -278,7 +278,7 @@ func TestRenderCircMessages_MarkdownEmphasisBoldCode(t *testing.T) {
 		circMsg("bob", "this is **bold** text"),
 		circMsg("carol", "run `go test` please"),
 	}
-	out := renderCircMessages(msgs, time.UTC, "datetime", width, "")
+	out := renderCircMessages(msgs, time.UTC, "datetime", width, "", nil)
 
 	if !strings.Contains(out, "emphasis") || strings.Contains(out, "*emphasis*") {
 		t.Errorf("expected *emphasis* to be styled, not left as raw markdown: %q", out)
@@ -299,7 +299,7 @@ func TestRenderCircMessages_MarkdownLinkAndBareURL(t *testing.T) {
 		circMsg("alice", "see [the docs](https://example.com/docs)"),
 		circMsg("bob", "check https://example.com/path for details"),
 	}
-	out := renderCircMessages(msgs, time.UTC, "datetime", width, "")
+	out := renderCircMessages(msgs, time.UTC, "datetime", width, "", nil)
 
 	if !strings.Contains(out, "the docs") || strings.Contains(out, "[the docs](") {
 		t.Errorf("expected markdown link syntax to be rendered, not left raw: %q", out)
@@ -321,7 +321,7 @@ func TestRenderCircMessages_LeadingBlockCharsStayLiteral(t *testing.T) {
 		circMsg("bob", "# thoughts for today"),
 		circMsg("carol", "> what did you say"),
 	}
-	out := renderCircMessages(msgs, time.UTC, "datetime", width, "")
+	out := renderCircMessages(msgs, time.UTC, "datetime", width, "", nil)
 
 	for _, want := range []string{"- get milk", "# thoughts for today", "> what did you say"} {
 		if !strings.Contains(out, want) {
@@ -340,7 +340,7 @@ func TestRenderCircMessages_ActionLineWithAsteriskBody(t *testing.T) {
 	action := circMsg("ragnar", "throws a *loud* party")
 	action.IsAction = true
 
-	out := renderCircMessages([]model.Message{action}, time.UTC, "datetime", width, "")
+	out := renderCircMessages([]model.Message{action}, time.UTC, "datetime", width, "", nil)
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 
 	if !strings.HasPrefix(lines[0], "* ragnar throws a ") {
@@ -389,7 +389,7 @@ func TestRenderCircMessages_OwnUsernameUsesMeHighlight(t *testing.T) {
 	mine := circMsg("ragnar", "hi all")
 	other := circMsg("bob", "hello")
 
-	out := renderCircMessages([]model.Message{mine, other}, time.UTC, "datetime", width, "ragnar")
+	out := renderCircMessages([]model.Message{mine, other}, time.UTC, "datetime", width, "ragnar", nil)
 
 	if !strings.Contains(out, "<"+theme.MeHighlight.Render("ragnar")+">") {
 		t.Errorf("expected own username styled with MeHighlight, got: %q", out)
@@ -411,7 +411,7 @@ func TestRenderCircMessages_MentionHighlighted(t *testing.T) {
 	const width = 60
 	msg := circMsg("bob", "hey @Ragnar and ragnarwessels, is ragnar around?")
 
-	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", width, "ragnar")
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", width, "ragnar", nil)
 
 	if !strings.Contains(out, theme.MeHighlight.Render("@Ragnar")) {
 		t.Errorf("expected case-insensitive @mention to be highlighted, got: %q", out)
@@ -438,7 +438,7 @@ func TestRenderCircMessages_MentionStyleContinuesAfterMultipleWords(t *testing.T
 	const width = 60
 	msg := circMsg("bob", "@ragnar 1 2")
 
-	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", width, "ragnar")
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", width, "ragnar", nil)
 
 	if !strings.Contains(out, theme.MeHighlight.Render("@ragnar")) {
 		t.Errorf("expected @ragnar to be highlighted, got: %q", out)
@@ -470,7 +470,7 @@ func TestRenderCircMessages_AttachmentOnlyBodySkipsDuplicateURL(t *testing.T) {
 	msg := circMsg("case", "https://cyberspace.online/img.png")
 	msg.ImageUrl = "https://cyberspace.online/img.png"
 
-	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 60, "")
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 60, "", nil)
 
 	if n := strings.Count(out, "https://cyberspace.online/img.png"); n != 1 {
 		t.Errorf("expected the image URL to appear exactly once, got %d times in: %q", n, out)
@@ -490,7 +490,7 @@ func TestRenderCircMessages_AttachmentOnlyHasNoBlankLine(t *testing.T) {
 	msg.Body = ""
 	msg.ImageUrl = "https://cyberspace.online/img.png"
 
-	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 60, "")
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 60, "", nil)
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 
 	if len(lines) != 1 {
@@ -512,7 +512,7 @@ func TestRenderCircMessages_AttachmentOnlyLongURL_TimestampStaysInBounds(t *test
 	msg := circMsg("case", "")
 	msg.GifUrl = "https://cyberspace.online/uploads/reactions/mind-blown-reaction.gif"
 
-	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", width, "")
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", width, "", nil)
 	plain := ansi.Strip(out)
 
 	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
@@ -572,7 +572,7 @@ func TestRenderCircMessages_ArtStyleSkipsWrapAndMarkdown(t *testing.T) {
 	msg := circMsg("case", art)
 	msg.Style = []string{"art"}
 
-	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 20, "")
+	out := renderCircMessages([]model.Message{msg}, time.UTC, "datetime", 20, "", nil)
 
 	for _, line := range strings.Split(art, "\n") {
 		if !strings.Contains(out, line) {
@@ -591,8 +591,8 @@ func TestRenderCircMessages_ArtStyle_TimestampAlignsWithNormalMessage(t *testing
 	art := circMsg("molly", "  /\\_/\\\n ( o.o )")
 	art.Style = []string{"art"}
 
-	normalLine := strings.Split(strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{normal}, time.UTC, "datetime", width, "")), "\n"), "\n")[0]
-	artLines := strings.Split(strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{art}, time.UTC, "datetime", width, "")), "\n"), "\n")
+	normalLine := strings.Split(strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{normal}, time.UTC, "datetime", width, "", nil)), "\n"), "\n")[0]
+	artLines := strings.Split(strings.TrimRight(ansi.Strip(renderCircMessages([]model.Message{art}, time.UTC, "datetime", width, "", nil)), "\n"), "\n")
 	artHeader := artLines[0]
 
 	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
@@ -616,8 +616,8 @@ func TestRenderCircMessagesStyled_Blink_HidesAndShowsWithoutChangingLineCount(t 
 	msg := circMsg("molly", "hello there")
 	msg.Style = []string{"blink"}
 
-	visible := renderCircMessagesStyled([]model.Message{msg}, time.UTC, "datetime", width, "", nil, 0)
-	hidden := renderCircMessagesStyled([]model.Message{msg}, time.UTC, "datetime", width, "", nil, blinkPhaseFrames)
+	visible := renderCircMessagesStyled([]model.Message{msg}, time.UTC, "datetime", width, "", nil, 0, nil)
+	hidden := renderCircMessagesStyled([]model.Message{msg}, time.UTC, "datetime", width, "", nil, blinkPhaseFrames, nil)
 
 	if !strings.Contains(ansi.Strip(visible), "hello there") {
 		t.Errorf("expected the visible phase to contain the body text, got: %q", visible)
@@ -641,5 +641,51 @@ func TestRenderCircMessagesStyled_Blink_HidesAndShowsWithoutChangingLineCount(t 
 	ts := displayTime(circMsgTime, time.UTC, "datetime", true)
 	if !strings.Contains(plainHidden, ts) {
 		t.Errorf("expected the timestamp to stay visible during the hidden phase, got: %q", hidden)
+	}
+}
+
+// TestRenderCircMessages_MutedSenderHidden confirms a muted sender's messages
+// are dropped entirely from output, while other senders' messages still render.
+func TestRenderCircMessages_MutedSenderHidden(t *testing.T) {
+	const width = 60
+	msgs := []model.Message{circMsg("alice", "hi from alice"), circMsg("bob", "hi from bob")}
+	muted := map[string]bool{"alice": true}
+
+	out := renderCircMessages(msgs, time.UTC, "datetime", width, "", muted)
+
+	if strings.Contains(out, "hi from alice") {
+		t.Errorf("expected alice's message to be hidden, got: %q", out)
+	}
+	if !strings.Contains(out, "hi from bob") {
+		t.Errorf("expected bob's message to still render, got: %q", out)
+	}
+}
+
+// TestRenderCircMessagesWithSelection_MutedSenderKeepsOffsetsAligned confirms
+// a muted sender's message contributes zero-height output but the
+// offsets/heights slices stay 1:1 with msgs, matching the invariant relied on
+// by selection/scrolling code.
+func TestRenderCircMessagesWithSelection_MutedSenderKeepsOffsetsAligned(t *testing.T) {
+	const width = 60
+	muted := circMsg("alice", "hi from alice")
+	muted.ID = "m1"
+	visible := circMsg("bob", "hi from bob")
+	visible.ID = "m2"
+	msgs := []model.Message{muted, visible}
+
+	content, offsets, heights := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "", "", nil, 0,
+		map[string]bool{"alice": true})
+
+	if len(offsets) != len(msgs) || len(heights) != len(msgs) {
+		t.Fatalf("offsets/heights not 1:1 with msgs: len(offsets)=%d len(heights)=%d want %d", len(offsets), len(heights), len(msgs))
+	}
+	if heights[0] != 0 {
+		t.Errorf("expected muted message's height to be 0, got %d", heights[0])
+	}
+	if strings.Contains(content, "hi from alice") {
+		t.Errorf("expected alice's message to be hidden, got: %q", content)
+	}
+	if !strings.Contains(content, "hi from bob") {
+		t.Errorf("expected bob's message to still render, got: %q", content)
 	}
 }


### PR DESCRIPTION
## Summary
Live-refresh cIRC mute state so `/mute`, `/unmute`, `/muted`, and `/unmuteall` take effect in the open room without a relogin.

## Changes
- `internal/model/types.go`: `Settings.MutedUsersByRoom map[string][]string` (roomID -> muted usernames)
- `internal/api/client.go`: decode `mutedUsersByRoom` from `GET /v1/settings`; deliberately excluded from `PATCH /v1/settings` (server-managed via slash commands)
- `internal/ui/app.go`: any cIRC slash-command reply now triggers a settings refetch (`loadSettingsCmd`) so mute state propagates via `SharedConfigMsg`
- `internal/ui/screens/chatrooms.go`: tracks `mutedUsersByRoom`; live re-renders the open room on settings refresh (re-scrolls to bottom while typing, keeps selection visible while browsing); muted senders excluded from selectable/flaggable/deletable messages
- `internal/ui/screens/render.go`: `renderCircMessages*` filter out muted (non-system) senders while preserving `msgOffsets`/`msgHeights` alignment with `m.messages`
- Docs: `docs/37-circ-mute.md` (new), `docs/00-api-backlog.md`, `docs/00-project-reference.md` updated

## Out of scope (by design)
- No dedicated keybinding — slash-command only, matching other cIRC commands
- No local config storage — server-synced via Settings, shared with the website
- C-Mail unaffected — `/mute` there 400s server-side, no client special-casing

## Testing
- `go build ./...` — pass
- `go test ./...` — pass (new: settings decode test, muted-sender render tests incl. offset/height alignment, live-refresh viewport tests)
- `go vet ./...` — pass, no warnings
- `staticcheck ./...` — pass, no warnings
