### PR TITLE
feat: handle 403 EMAIL_NOT_VERIFIED with a resend-verification flow

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -176,7 +176,7 @@ cIRC/C-Mail messages can now carry `imageUrl`, `gifUrl` (`/gif <url>`), `audioAt
 
 | Error | Description | Priority |
 |---|---|---|
-| `403 EMAIL_NOT_VERIFIED` | New error code — account access now gated on email verification instead of supporter/API-access-grant. Client should surface a clear message pointing at `/v1/auth/resend-verification` (web-only flow) rather than a generic auth failure. | Not implemented |
+| `403 EMAIL_NOT_VERIFIED` | New error code — account access now gated on email verification instead of supporter/API-access-grant. Surfaces from the profile fetch immediately after a successful login (login itself doesn't gate on this); the login screen shows a distinct message with an `r` keybinding to call `POST /v1/auth/resend-verification`, and `friendlyErr` softens the same code for any mid-session authenticated call. See `docs/38-email-verification.md`. | **Done** — 2026-08-03 |
 
 ### Thread Watching (new in v0.5.1)
 

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -157,7 +157,7 @@ Defines the `Client` interface — the only type the UI layer imports from this 
 
 | Group | Methods |
 |---|---|
-| Auth | `Login(email, password)`, `LoginWithRefreshToken(token)`, `Logout()` |
+| Auth | `Login(email, password)`, `LoginWithRefreshToken(token)`, `Logout()`, `ResendVerification(idToken)` |
 | Feed | `GetFeed(cursor)`, `CreatePost(content, title, slug, topics, isPublic, isNSFW)`, `GetPost(postID)`, `DeletePost(postID)` |
 | Thread watching | `GetWatches(cursor)`, `WatchPost(postID)`, `UnwatchPost(postID)` |
 | Replies | `GetPostReplies(postID)`, `GetReply(replyID)`, `CreateReply(postID, content, parentReplyID)`, `DeleteReply(replyID)` |
@@ -198,7 +198,7 @@ Production REST HTTP client. Exported type: `HTTPClient`.
 - `refresh()` — token refresh path; does not recurse
 - `wirePostToModel()`, `wireReplyToModel()`, `wireUserToModel()`, `wireSettingsToModel()`, `wireNotificationToModel()`, `wireNoteToModel()` — convert API JSON wire types to `model.*` types
 
-**Wire types (unexported):** `loginRequest`, `loginResponseData`, `wirePost`, `wireUser`, `wireReply`, `wireNotification`, `wireSettings`, `wireNote`, `wireBookmark`, `wireTopic`, `wireFollow`, `wireRoom`, `wireCircMessage`, `wireRoomUser`, `wirePresenceResponse`, `wireRTDBPresenceEntry`, `wireCMailConversation`, `wireCMailMessage`, `wireRTDBMessage`, `wireRTDBSSEData`, `wireSearchPreview` — match the JSON envelope shapes returned by the API.
+**Wire types (unexported):** `loginRequest`, `loginResponseData`, `resendVerificationRequest`, `wirePost`, `wireUser`, `wireReply`, `wireNotification`, `wireSettings`, `wireNote`, `wireBookmark`, `wireTopic`, `wireFollow`, `wireRoom`, `wireCircMessage`, `wireRoomUser`, `wirePresenceResponse`, `wireRTDBPresenceEntry`, `wireCMailConversation`, `wireCMailMessage`, `wireRTDBMessage`, `wireRTDBSSEData`, `wireSearchPreview` — match the JSON envelope shapes returned by the API.
 
 **Note:** `HTTPClient.tokens` is guarded by a `sync.Mutex`. Bubble Tea runs commands in concurrent goroutines, so reads in `doRequest` and writes in `Login`/`refresh` go through the token accessor methods (`idToken`, `setTokens`, `snapshotTokens`, `applyRefresh`). See `docs/30-security-hardening.md`.
 

--- a/docs/38-email-verification.md
+++ b/docs/38-email-verification.md
@@ -1,0 +1,41 @@
+# 38 — Email Verification (403 EMAIL_NOT_VERIFIED)
+
+Since API v0.8, account access is gated on a verified email address. An unverified account's authenticated requests are rejected with `403 EMAIL_NOT_VERIFIED`. Verification itself is a web-only click-through link flow — there's no code-entry endpoint — but the client can trigger a fresh verification email via `POST /v1/auth/resend-verification`.
+
+## Where the error actually surfaces
+
+`POST /v1/auth/login` itself succeeds regardless of verification status — an `idToken` is required to call `resend-verification`, which only makes sense if login didn't already block on this. The `403` shows up on the very next authenticated call, `GET /v1/users/me`, which both `loginCmd` and `tokenLoginCmd` (`internal/ui/app.go`) make immediately after a successful login to fetch the profile.
+
+`loginErrMsgFor(err, idToken)` (`app.go`) is the shared helper both call sites route their `GetOwnProfile` failure through: it detects `Code == "EMAIL_NOT_VERIFIED"` via `errors.As` against `*api.APIError` and, if so, returns `screens.LoginErrMsg{EmailNotVerified: true, IDToken: idToken}` instead of a generic error — carrying the already-issued `idToken` forward, since that's what `resend-verification` needs and there's no other route to get one for an unverified account (a plain login doesn't return one on its own — you need the successful `Login()` call that just happened).
+
+## Login screen UX
+
+`LoginModel` (`internal/ui/screens/login.go`) tracks `emailNotVerified`, `idToken`, `resending`, and `resendResult`. When `EmailNotVerified` is set:
+
+- The status line switches from the generic `error: ...` text to `your email isn't verified yet — check your inbox for the verification link`, plus a resend hint/status line beneath it.
+- Pressing **`r`** (only live in this state — otherwise it's just a character typed into whichever input is focused) emits `ResendVerificationMsg{IDToken}` up to the app, which calls `client.ResendVerification(idToken)` (`resendVerificationCmd`, `app.go`) and returns `ResendVerificationResultMsg{Err}`.
+- While in flight, the status line shows `sending verification email...`; on completion it shows either `sent — check your inbox` or `error: <message>` (e.g. a `RATE_LIMITED` hit — the endpoint is capped at 1/min, 5/hour server-side).
+- Starting a fresh login attempt (`submitCmd`) clears `emailNotVerified`/`resendResult`, so a stale resend hint doesn't linger across a retry with different credentials.
+
+## Mid-session defense-in-depth
+
+Verification status can't normally change *after* a session starts (you can't get past the profile fetch above unless already verified), but as a cheap safety net, `friendlyErr` (`app.go`) — the same chokepoint that softens a `404` into "Not found — it may have been deleted." for the global error banner — also softens `EMAIL_NOT_VERIFIED` into "Please verify your email — check your inbox for the verification link." for any authenticated call made during normal use, rather than showing the raw `API error EMAIL_NOT_VERIFIED (403): ...` string.
+
+## API surface
+
+| Endpoint | Method | Client method | Notes |
+|---|---|---|---|
+| `/v1/auth/resend-verification` | POST | `Client.ResendVerification(idToken string) error` | Body `{"idToken": "..."}`. Rate limit 1/min, 5/hour — a `RATE_LIMITED` `*APIError` is returned as-is for the caller to display. |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `internal/api/client.go` | `ResendVerification`, `resendVerificationRequest` wire type |
+| `internal/api/interface.go` / `mock.go` | `Client` interface + mock stub |
+| `internal/ui/screens/login.go` | `LoginErrMsg` (`EmailNotVerified`/`IDToken`), `ResendVerificationMsg`/`ResendVerificationResultMsg`, resend UI + `r` keybinding |
+| `internal/ui/app.go` | `loginErrMsgFor`, `resendVerificationCmd`, `friendlyErr`'s `EMAIL_NOT_VERIFIED` branch |
+
+## Known limitations
+
+- No client-side cooldown/disabling of the `r` key between attempts — a user mashing `r` faster than 1/min will just see the server's `RATE_LIMITED` error surface via `resendResult` rather than being pre-emptively blocked. Low-stakes: the worst case is a slightly less friendly error message, not a broken flow.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -69,6 +69,10 @@ type refreshResponseData struct {
 	RTDBUrl   string `json:"rtdbUrl"`
 }
 
+type resendVerificationRequest struct {
+	IDToken string `json:"idToken"`
+}
+
 type wireAttachment struct {
 	Type   string `json:"type"`
 	Src    string `json:"src"`
@@ -1164,6 +1168,16 @@ func (c *HTTPClient) Login(email, password string) (model.Tokens, error) {
 	}
 	c.setTokens(t)
 	return t, nil
+}
+
+// ResendVerification requests a fresh verification email via
+// POST /v1/auth/resend-verification, for an account whose email isn't
+// verified yet (surfaced as a 403 EMAIL_NOT_VERIFIED on any authenticated
+// request). Rate limited server-side to 1/min, 5/hour — a RATE_LIMITED
+// APIError is returned as-is for the caller to display.
+func (c *HTTPClient) ResendVerification(idToken string) error {
+	_, err := c.doJSON("POST", "/v1/auth/resend-verification", resendVerificationRequest{IDToken: idToken})
+	return err
 }
 
 // LoginWithRefreshToken exchanges a saved refresh token for a fresh IDToken and

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -454,6 +455,39 @@ func TestHTTPTokenRefresh_Failure(t *testing.T) {
 	}
 	if apiErr.Code != "UNAUTHORIZED" {
 		t.Errorf("Code = %q, want UNAUTHORIZED", apiErr.Code)
+	}
+}
+
+func TestHTTPResendVerification_SendsIDTokenBody(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/auth/resend-verification" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			IDToken string `json:"idToken"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.IDToken != "id-abc" {
+			t.Errorf("idToken = %q, want id-abc", body.IDToken)
+		}
+		writeOK(t, w, map[string]any{"sent": true})
+	}))
+
+	if err := c.ResendVerification("id-abc"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHTTPResendVerification_RateLimited(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+
+	err := c.ResendVerification("id-abc")
+	if !errors.Is(err, api.ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited, got %v", err)
 	}
 }
 

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -15,6 +15,9 @@ type Client interface {
 	// LoginWithRefreshToken exchanges a saved refresh token for a fresh set of
 	// tokens (IDToken + RTDBToken) without requiring the user's password.
 	LoginWithRefreshToken(refreshToken string) (model.Tokens, error)
+	// ResendVerification requests a fresh verification email for an account
+	// whose email isn't verified yet (see EMAIL_NOT_VERIFIED).
+	ResendVerification(idToken string) error
 	Logout() error
 	// RefreshSession proactively refreshes the ID token (and RTDB token) using
 	// the stored refresh token, without waiting for a failed request to trigger

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -110,6 +110,10 @@ func (m *MockClient) Logout() error {
 	return nil
 }
 
+func (m *MockClient) ResendVerification(idToken string) error {
+	return nil
+}
+
 func (m *MockClient) RefreshSession() error {
 	return nil
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -672,6 +672,12 @@ func (a App) handleAuth(msg tea.Msg) (App, tea.Cmd, bool) {
 		var cmd tea.Cmd
 		a.login, cmd = a.login.Update(msg)
 		return a, cmd, true
+	case screens.ResendVerificationMsg:
+		return a, a.resendVerificationCmd(msg.IDToken), true
+	case screens.ResendVerificationResultMsg:
+		var cmd tea.Cmd
+		a.login, cmd = a.login.Update(msg)
+		return a, cmd, true
 	}
 	return a, nil, false
 }
@@ -1825,8 +1831,13 @@ func (a App) handleErr(msg tea.Msg) (App, tea.Cmd, bool) {
 // raw "API error NOT_FOUND (404): …" wording for the common deleted-resource case.
 func friendlyErr(err error) string {
 	var apiErr *api.APIError
-	if errors.As(err, &apiErr) && apiErr.Status == 404 {
-		return "Not found — it may have been deleted."
+	if errors.As(err, &apiErr) {
+		switch {
+		case apiErr.Status == 404:
+			return "Not found — it may have been deleted."
+		case apiErr.Code == "EMAIL_NOT_VERIFIED":
+			return "Please verify your email — check your inbox for the verification link."
+		}
 	}
 	return err.Error()
 }
@@ -2165,6 +2176,31 @@ type loginSuccessMsg struct {
 	user   model.User
 }
 
+// loginErrMsgFor builds a LoginErrMsg from a login/profile-fetch failure,
+// detecting EMAIL_NOT_VERIFIED so the login screen can offer a resend action
+// using the already-issued idToken instead of showing a generic error. Login
+// itself succeeds regardless of verification status (per the API docs, an
+// idToken is required to call resend-verification, which only makes sense
+// if login itself didn't already block on this) — the 403 shows up on the
+// profile fetch that follows.
+func loginErrMsgFor(err error, idToken string) screens.LoginErrMsg {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) && apiErr.Code == "EMAIL_NOT_VERIFIED" {
+		return screens.LoginErrMsg{Err: err, EmailNotVerified: true, IDToken: idToken}
+	}
+	return screens.LoginErrMsg{Err: err}
+}
+
+// resendVerificationCmd calls POST /v1/auth/resend-verification for idToken,
+// obtained from a login that succeeded but hit EMAIL_NOT_VERIFIED on the
+// follow-up profile fetch.
+func (a *App) resendVerificationCmd(idToken string) tea.Cmd {
+	client := a.client
+	return func() tea.Msg {
+		return screens.ResendVerificationResultMsg{Err: client.ResendVerification(idToken)}
+	}
+}
+
 func (a *App) loginCmd(email, password string) tea.Cmd {
 	return func() tea.Msg {
 		tokens, err := a.client.Login(email, password)
@@ -2177,7 +2213,7 @@ func (a *App) loginCmd(email, password string) tea.Cmd {
 		}
 		user, err := a.client.GetOwnProfile()
 		if err != nil {
-			return screens.LoginErrMsg{Err: err}
+			return loginErrMsgFor(err, tokens.IDToken)
 		}
 		// Wire the user ID into the HTTP client for RTDB path construction.
 		if hc, ok := a.client.(*api.HTTPClient); ok {
@@ -2214,7 +2250,7 @@ func (a *App) tokenLoginCmd(refreshToken string) tea.Cmd {
 		}
 		user, err := a.client.GetOwnProfile()
 		if err != nil {
-			return screens.LoginErrMsg{Err: err}
+			return loginErrMsgFor(err, tokens.IDToken)
 		}
 		if hc, ok := a.client.(*api.HTTPClient); ok {
 			hc.SetCurrentUID(user.ID)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1406,6 +1406,121 @@ func TestFriendlyErr_404IsSoftened(t *testing.T) {
 	}
 }
 
+// friendlyErr also softens EMAIL_NOT_VERIFIED — the one other error code the
+// app branches on by Code rather than Status, since it can surface from any
+// authenticated call, not just login.
+func TestFriendlyErr_EmailNotVerifiedIsSoftened(t *testing.T) {
+	got := friendlyErr(&api.APIError{Code: "EMAIL_NOT_VERIFIED", Status: 403, Message: "email not verified"})
+	if got != "Please verify your email — check your inbox for the verification link." {
+		t.Errorf("friendlyErr(EMAIL_NOT_VERIFIED) = %q, want softened message", got)
+	}
+}
+
+// loginErrMsgFor is what routes an EMAIL_NOT_VERIFIED profile-fetch failure
+// (login itself succeeded — an idToken is required to call
+// resend-verification) into a distinguishable LoginErrMsg the login screen
+// can offer a resend action from, instead of a generic error.
+func TestLoginErrMsgFor_EmailNotVerifiedCarriesIDToken(t *testing.T) {
+	err := &api.APIError{Code: "EMAIL_NOT_VERIFIED", Status: 403, Message: "email not verified"}
+	got := loginErrMsgFor(err, "id-abc")
+	if !got.EmailNotVerified {
+		t.Error("expected EmailNotVerified = true")
+	}
+	if got.IDToken != "id-abc" {
+		t.Errorf("IDToken = %q, want id-abc", got.IDToken)
+	}
+	if got.Err != err {
+		t.Errorf("Err = %v, want the original error", got.Err)
+	}
+}
+
+func TestLoginErrMsgFor_OtherErrorsDoNotSetEmailNotVerified(t *testing.T) {
+	got := loginErrMsgFor(&api.APIError{Code: "UNAUTHORIZED", Status: 401, Message: "bad credentials"}, "id-abc")
+	if got.EmailNotVerified {
+		t.Error("expected EmailNotVerified = false for an unrelated error")
+	}
+	if got.IDToken != "" {
+		t.Errorf("IDToken = %q, want empty for an unrelated error", got.IDToken)
+	}
+}
+
+// emailNotVerifiedClient simulates a login that succeeds but whose follow-up
+// profile fetch is rejected because the account's email isn't verified —
+// the actual failure point per the API docs (Login itself doesn't gate on
+// verification; an idToken is needed to call resend-verification).
+type emailNotVerifiedClient struct {
+	*api.MockClient
+}
+
+func (c *emailNotVerifiedClient) GetOwnProfile() (model.User, error) {
+	return model.User{}, &api.APIError{Code: "EMAIL_NOT_VERIFIED", Status: 403, Message: "email not verified"}
+}
+
+// TestLoginCmd_EmailNotVerified_ReturnsDistinguishableLoginErrMsg confirms
+// the end-to-end wiring: a real Login() success followed by an
+// EMAIL_NOT_VERIFIED profile-fetch failure produces a LoginErrMsg carrying
+// the idToken the login screen needs to offer a resend action, not a
+// generic error.
+func TestLoginCmd_EmailNotVerified_ReturnsDistinguishableLoginErrMsg(t *testing.T) {
+	a := NewApp(&emailNotVerifiedClient{MockClient: api.NewMockClient()})
+	msg := a.loginCmd("user@example.com", "secret")()
+	lem, ok := msg.(screens.LoginErrMsg)
+	if !ok {
+		t.Fatalf("expected LoginErrMsg, got %T", msg)
+	}
+	if !lem.EmailNotVerified {
+		t.Error("expected EmailNotVerified = true")
+	}
+	if lem.IDToken == "" {
+		t.Error("expected a non-empty IDToken carried over from the successful Login() call")
+	}
+}
+
+// resendVerificationSpyClient records the idToken ResendVerification was
+// called with, and returns a canned error.
+type resendVerificationSpyClient struct {
+	*api.MockClient
+	gotIDToken string
+	err        error
+}
+
+func (c *resendVerificationSpyClient) ResendVerification(idToken string) error {
+	c.gotIDToken = idToken
+	return c.err
+}
+
+func TestResendVerificationCmd_CallsClientAndWrapsResult(t *testing.T) {
+	spy := &resendVerificationSpyClient{MockClient: api.NewMockClient()}
+	a := NewApp(spy)
+
+	msg := a.resendVerificationCmd("id-abc")()
+	rvr, ok := msg.(screens.ResendVerificationResultMsg)
+	if !ok {
+		t.Fatalf("expected ResendVerificationResultMsg, got %T", msg)
+	}
+	if rvr.Err != nil {
+		t.Errorf("Err = %v, want nil", rvr.Err)
+	}
+	if spy.gotIDToken != "id-abc" {
+		t.Errorf("ResendVerification called with %q, want id-abc", spy.gotIDToken)
+	}
+}
+
+func TestResendVerificationCmd_PropagatesError(t *testing.T) {
+	wantErr := errors.New("rate limited")
+	spy := &resendVerificationSpyClient{MockClient: api.NewMockClient(), err: wantErr}
+	a := NewApp(spy)
+
+	msg := a.resendVerificationCmd("id-abc")()
+	rvr, ok := msg.(screens.ResendVerificationResultMsg)
+	if !ok {
+		t.Fatalf("expected ResendVerificationResultMsg, got %T", msg)
+	}
+	if rvr.Err != wantErr {
+		t.Errorf("Err = %v, want %v", rvr.Err, wantErr)
+	}
+}
+
 // flagErrorMsg softens the documented self-report 403 into a friendly banner;
 // anything else falls through to the normal actionErrMsg handling.
 func TestFlagErrorMsg_403IsSoftened(t *testing.T) {

--- a/internal/ui/screens/login.go
+++ b/internal/ui/screens/login.go
@@ -9,13 +9,36 @@ import (
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
-type LoginErrMsg struct{ Err error }
+// LoginErrMsg reports a failed login attempt. EmailNotVerified/IDToken are
+// set when the failure was specifically a 403 EMAIL_NOT_VERIFIED — Login
+// itself succeeded (so IDToken is valid), but the follow-up profile fetch
+// was rejected because the account's email isn't verified yet. IDToken is
+// what ResendVerificationMsg needs to request a fresh verification email.
+type LoginErrMsg struct {
+	Err              error
+	EmailNotVerified bool
+	IDToken          string
+}
+
+// ResendVerificationMsg asks the app to call POST /v1/auth/resend-verification
+// for the given (already-issued) idToken.
+type ResendVerificationMsg struct{ IDToken string }
+
+// ResendVerificationResultMsg reports the outcome of a resend request.
+type ResendVerificationResultMsg struct{ Err error }
 
 type LoginModel struct {
 	inputs  [2]textinput.Model
 	focused int
 	err     error
 	loading bool
+
+	// Set once a login attempt fails with EMAIL_NOT_VERIFIED, so the view can
+	// show a distinct message + resend hint instead of the generic error.
+	emailNotVerified bool
+	idToken          string
+	resending        bool
+	resendResult     string // "" (not attempted), "sent", or an error string
 }
 
 func NewLoginModel(email string) LoginModel {
@@ -48,6 +71,11 @@ func (m LoginModel) Init() tea.Cmd { return textinput.Blink }
 func (m LoginModel) Update(msg tea.Msg) (LoginModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if m.emailNotVerified && !m.resending && msg.String() == "r" {
+			m.resending = true
+			m.resendResult = ""
+			return m, m.resendCmd()
+		}
 		switch msg.String() {
 		case "tab", "down":
 			m.focused = (m.focused + 1) % 2
@@ -70,6 +98,16 @@ func (m LoginModel) Update(msg tea.Msg) (LoginModel, tea.Cmd) {
 	case LoginErrMsg:
 		m.err = msg.Err
 		m.loading = false
+		m.emailNotVerified = msg.EmailNotVerified
+		m.idToken = msg.IDToken
+		m.resendResult = ""
+	case ResendVerificationResultMsg:
+		m.resending = false
+		if msg.Err != nil {
+			m.resendResult = "error: " + msg.Err.Error()
+		} else {
+			m.resendResult = "sent — check your inbox"
+		}
 	}
 
 	var cmds [2]tea.Cmd
@@ -79,9 +117,21 @@ func (m LoginModel) Update(msg tea.Msg) (LoginModel, tea.Cmd) {
 	return m, tea.Batch(cmds[0], cmds[1])
 }
 
+// resendCmd asks the root app to call ResendVerification for the idToken
+// obtained from the just-completed (but unverified) login. Like submitCmd,
+// LoginModel has no direct API access — the actual call happens in app.go.
+func (m *LoginModel) resendCmd() tea.Cmd {
+	idToken := m.idToken
+	return func() tea.Msg {
+		return ResendVerificationMsg{IDToken: idToken}
+	}
+}
+
 func (m *LoginModel) submitCmd() tea.Cmd {
 	m.loading = true
 	m.err = nil
+	m.emailNotVerified = false
+	m.resendResult = ""
 	// Login is handled by the root app which has the API client.
 	// We send credentials up via a message.
 	return func() tea.Msg {
@@ -122,9 +172,21 @@ func (m LoginModel) View() string {
 	hint := theme.Subtle.Render("tab · navigate   enter · confirm")
 
 	var status string
-	if m.loading {
+	switch {
+	case m.loading:
 		status = theme.Highlight.Render("connecting...")
-	} else if m.err != nil {
+	case m.emailNotVerified:
+		msg := "your email isn't verified yet — check your inbox for the verification link"
+		switch {
+		case m.resending:
+			msg += "\n" + "sending verification email..."
+		case m.resendResult != "":
+			msg += "\n" + m.resendResult
+		default:
+			msg += "\n" + "press r to resend it"
+		}
+		status = theme.Error.Render(msg)
+	case m.err != nil:
 		status = theme.Error.Render(fmt.Sprintf("error: %s", m.err))
 	}
 

--- a/internal/ui/screens/login_test.go
+++ b/internal/ui/screens/login_test.go
@@ -1,0 +1,108 @@
+package screens
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestLoginModel_EmailNotVerified_ShowsResendHint confirms an
+// EMAIL_NOT_VERIFIED LoginErrMsg switches the status line to the
+// verification message with a resend hint, instead of the generic error.
+func TestLoginModel_EmailNotVerified_ShowsResendHint(t *testing.T) {
+	m := NewLoginModel("")
+	m, _ = m.Update(LoginErrMsg{Err: errors.New("boom"), EmailNotVerified: true, IDToken: "id-abc"})
+
+	if !m.emailNotVerified {
+		t.Fatal("expected emailNotVerified = true")
+	}
+	if m.idToken != "id-abc" {
+		t.Errorf("idToken = %q, want id-abc", m.idToken)
+	}
+	view := m.View()
+	if !strings.Contains(view, "isn't verified yet") {
+		t.Errorf("expected the verification message in the view, got: %q", view)
+	}
+	if !strings.Contains(view, "press r to resend") {
+		t.Errorf("expected the resend hint in the view, got: %q", view)
+	}
+}
+
+// TestLoginModel_ROnlyTriggersResendWhenEmailNotVerified confirms the 'r'
+// keybinding is scoped to the EMAIL_NOT_VERIFIED state — normally it's just
+// a character typed into the focused input.
+func TestLoginModel_ROnlyTriggersResendWhenEmailNotVerified(t *testing.T) {
+	m := NewLoginModel("")
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(ResendVerificationMsg); ok {
+			t.Fatal("expected 'r' to type into the input, not trigger resend, when not in the EMAIL_NOT_VERIFIED state")
+		}
+	}
+	if m.inputs[0].Value() != "r" {
+		t.Errorf("expected 'r' typed into the focused (email) input, got %q", m.inputs[0].Value())
+	}
+}
+
+// TestLoginModel_RTriggersResendWhenEmailNotVerified confirms 'r' fires
+// ResendVerificationMsg with the stored idToken once EMAIL_NOT_VERIFIED is
+// set, and enters the "resending" state.
+func TestLoginModel_RTriggersResendWhenEmailNotVerified(t *testing.T) {
+	m := NewLoginModel("")
+	m, _ = m.Update(LoginErrMsg{Err: errors.New("boom"), EmailNotVerified: true, IDToken: "id-abc"})
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if !m.resending {
+		t.Error("expected resending = true")
+	}
+	if cmd == nil {
+		t.Fatal("expected a command emitting ResendVerificationMsg")
+	}
+	msg, ok := cmd().(ResendVerificationMsg)
+	if !ok {
+		t.Fatalf("expected ResendVerificationMsg, got %T", msg)
+	}
+	if msg.IDToken != "id-abc" {
+		t.Errorf("IDToken = %q, want id-abc", msg.IDToken)
+	}
+}
+
+// TestLoginModel_ResendResult_UpdatesStatus confirms the result of a resend
+// attempt (success or error) clears the "resending" flag and updates the
+// status text shown to the user.
+func TestLoginModel_ResendResult_UpdatesStatus(t *testing.T) {
+	m := NewLoginModel("")
+	m, _ = m.Update(LoginErrMsg{Err: errors.New("boom"), EmailNotVerified: true, IDToken: "id-abc"})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+
+	m, _ = m.Update(ResendVerificationResultMsg{Err: nil})
+	if m.resending {
+		t.Error("expected resending = false after a result arrives")
+	}
+	if !strings.Contains(m.View(), "sent") {
+		t.Errorf("expected a sent confirmation in the view, got: %q", m.View())
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	m, _ = m.Update(ResendVerificationResultMsg{Err: errors.New("rate limited")})
+	if !strings.Contains(m.View(), "error: rate limited") {
+		t.Errorf("expected the resend error in the view, got: %q", m.View())
+	}
+}
+
+// TestLoginModel_Resubmit_ClearsEmailNotVerified confirms starting a fresh
+// login attempt (e.g. after fixing credentials) resets the verification
+// state rather than leaving a stale resend hint showing.
+func TestLoginModel_Resubmit_ClearsEmailNotVerified(t *testing.T) {
+	m := NewLoginModel("")
+	m, _ = m.Update(LoginErrMsg{Err: errors.New("boom"), EmailNotVerified: true, IDToken: "id-abc"})
+	m.focused = 1 // password field, so "enter" submits rather than advancing focus
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.emailNotVerified {
+		t.Error("expected emailNotVerified to clear on a fresh submit")
+	}
+}


### PR DESCRIPTION
## 403 EMAIL_NOT_VERIFIED handling

Closes the last remaining "Not implemented" item in `docs/00-api-backlog.md`.

Since API v0.8, account access is gated on a verified email; unverified accounts get `403 EMAIL_NOT_VERIFIED` on authenticated requests. Verification itself is a web-only click-through link, but the client can request a fresh verification email via `POST /v1/auth/resend-verification`.

- `Client.ResendVerification(idToken) error` — new client method.
- `Login()` itself succeeds regardless of verification status; the `403` actually surfaces from the profile fetch (`GET /v1/users/me`) that immediately follows a successful login. `loginErrMsgFor` detects this and routes it into a distinguishable `LoginErrMsg` carrying the already-issued `idToken`.
- The login screen shows a clear "your email isn't verified yet" message with an `r` keybinding to trigger resend, with sending/sent/error feedback.
- `friendlyErr` also softens the same code for any authenticated call made mid-session, as defense in depth (shouldn't normally be reachable post-login, but cheap to cover).

Docs: new `docs/38-email-verification.md`, `00-api-backlog.md` row flipped to Done, `00-project-reference.md` Client interface list updated.

## Testing

- `go build ./...` — clean
- `go test ./...` — all pass (12 new tests: API method success/rate-limit, `loginErrMsgFor`/`friendlyErr` branching, app-level `loginCmd`/`resendVerificationCmd` wiring via spy clients, full `LoginModel` UI state machine)
- `go vet ./...` — clean
- `staticcheck ./...` — clean
