### PR TITLE
fix: hide garbage rows for stale cIRC conversations

### DIFF
--- a/internal/ui/screens/cmail.go
+++ b/internal/ui/screens/cmail.go
@@ -1146,7 +1146,7 @@ func (m CMailModel) handleTypingInputChanged(newVal string) (CMailModel, tea.Cmd
 
 func (m CMailModel) otherParticipant(conv model.Conversation) string {
 	for _, u := range conv.Participants {
-		if u.Username != m.currentUser {
+		if u.Username != "" && u.Username != m.currentUser {
 			return u.Username
 		}
 	}
@@ -1191,7 +1191,7 @@ func (m CMailModel) renderConvCards() string {
 
 		// Right side: date  (N)
 		var rightParts []string
-		if !c.LastMessageAt.IsZero() {
+		if !c.LastMessageAt.IsZero() && c.LastMessageAt.Unix() != 0 {
 			rightParts = append(rightParts, theme.Subtle.Render(displayTime(c.LastMessageAt, m.location(), m.timeDisplayFormat, true)))
 		}
 		if c.UnreadCount > 0 {

--- a/internal/ui/screens/cmail_test.go
+++ b/internal/ui/screens/cmail_test.go
@@ -29,6 +29,37 @@ func TestCMailTotalUnread(t *testing.T) {
 	}
 }
 
+// TestOtherParticipant_EmptyUsernameFallsBackToUnknown guards against a stale
+// RTDB conversation entry with a blank otherUsername rendering as "@" instead
+// of the "unknown" fallback.
+func TestOtherParticipant_EmptyUsernameFallsBackToUnknown(t *testing.T) {
+	m := NewCMailModel("me", "", nil)
+	conv := model.Conversation{ID: "c1", Participants: []model.User{{Username: ""}}}
+
+	if got := m.otherParticipant(conv); got != "unknown" {
+		t.Fatalf("otherParticipant() with blank username = %q, want %q", got, "unknown")
+	}
+}
+
+// TestRenderConvCards_EpochZeroLastMessageAtHidesDate guards against a stale
+// conversation with a missing lastMessageAt (converted to epoch 1970-01-01,
+// not Go's zero time.Time) rendering a bogus "01-Jan-1970" date.
+func TestRenderConvCards_EpochZeroLastMessageAtHidesDate(t *testing.T) {
+	m := NewCMailModel("me", "", nil)
+	m.width = 80
+	m = m.SetConversations([]model.Conversation{
+		{ID: "c1", Participants: []model.User{{Username: ""}}, LastMessageAt: time.UnixMilli(0)},
+	})
+
+	out := m.renderConvCards()
+	if strings.Contains(out, "1970") {
+		t.Fatalf("renderConvCards() rendered epoch-0 date, want it hidden:\n%s", out)
+	}
+	if !strings.Contains(out, "@unknown") {
+		t.Fatalf("renderConvCards() = %q, want it to contain %q", out, "@unknown")
+	}
+}
+
 // TestCMailDetailView_HeaderHasDividerBeforeMessages guards against the
 // divider row (mirrors the same fix in chatrooms.go — the header shouldn't
 // float with no visual bottom edge, unlike the bordered input box below it)


### PR DESCRIPTION
## Problem

The cIRC conversation list showed garbage rows for stale/old conversations: username `@` (blank) and date `01-Jan-1970`.

The server's `/user_conversations/<uid>` RTDB feed (and REST `GET /v1/cmail`) can omit `otherUserId`/`otherUsername`/`lastMessageAt` for older conversations (see comment at `internal/api/client.go:526-529`). Two client-side gaps turned that into visible garbage:

- `otherParticipant` returned an empty `Username` instead of falling through to the `"unknown"` fallback, so the row rendered as `@` + `""` = `@`.
- `renderConvCards` only checked `LastMessageAt.IsZero()`, which does not catch `time.UnixMilli(0)` (epoch 1970-01-01) — the value produced when `lastMessageAt` is absent — so it rendered `01-Jan-1970` instead of hiding the date.

## Fix

- `internal/ui/screens/cmail.go`: `otherParticipant` now skips participants with a blank `Username`.
- `internal/ui/screens/cmail.go`: `renderConvCards` now also hides the date when `LastMessageAt` is epoch-0.

## Testing

- `go test ./...` — pass
- `go vet ./...` — clean
- `staticcheck ./...` — clean
- Added `TestOtherParticipant_EmptyUsernameFallsBackToUnknown` and `TestRenderConvCards_EpochZeroLastMessageAtHidesDate` covering both gaps.
