### PR TITLE
fix: sync cIRC known-command list with style and media commands

### DIFF
--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -302,6 +302,27 @@ var knownCircCommands = map[string]bool{
 	"/me": true, "/poke": true, "/hug": true, "/hi5": true, "/slap": true,
 	"/dice": true, "/8ball": true, "/fortune": true, "/help": true,
 	"/mute": true, "/unmute": true, "/muted": true, "/unmuteall": true,
+	"/gif": true, "/song": true, "/art": true,
+}
+
+// knownCircStyles are the text-style command names (see chatstyle.go) that
+// can appear alone or chained with "+" (e.g. "/comic+rainbow"), so they're
+// checked separately from the exact-match knownCircCommands lookup.
+var knownCircStyles = map[string]bool{
+	styleBlink: true, styleL33t: true, styleComic: true, styleCursive: true,
+	styleTimes: true, styleRainbow: true, styleFlip: true, styleQuiet: true,
+	styleSlow: true, styleGlitch: true, styleSpoiler: true, styleWave: true,
+}
+
+// isKnownCircStyleCombo reports whether cmd is a "/"-prefixed, "+"-joined
+// combination of known style names, e.g. "/comic+rainbow".
+func isKnownCircStyleCombo(cmd string) bool {
+	for p := range strings.SplitSeq(strings.TrimPrefix(cmd, "/"), "+") {
+		if !knownCircStyles[p] {
+			return false
+		}
+	}
+	return true
 }
 
 // RoomOpenedMsg is emitted when the user enters a chatroom. App uses it to call MarkRoomRead.
@@ -1281,7 +1302,7 @@ func (m ChatroomsModel) updateInner(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 						roomID := m.activeRoom.Slug
 						if strings.HasPrefix(val, "/") {
 							cmd := strings.ToLower(strings.Fields(val)[0])
-							if !knownCircCommands[cmd] {
+							if !knownCircCommands[cmd] && !isKnownCircStyleCombo(cmd) {
 								m.input.Reset()
 								return m.AppendSystemMessage(roomID, "*** unknown command: "+cmd), nil
 							}

--- a/internal/ui/screens/screens_test.go
+++ b/internal/ui/screens/screens_test.go
@@ -357,24 +357,36 @@ func TestChatrooms_Send_UnknownCommandIsRejected(t *testing.T) {
 }
 
 func TestChatrooms_Send_KnownCommandStillSends(t *testing.T) {
-	m := screens.NewChatroomsModel("neuromancer", nil)
-	m = m.SetRooms(sampleRooms())
-	m, _ = sendChatroomSpecialKey(m, tea.KeyEnter) // open room
+	cases := []string{
+		"/me waves",
+		"/blink hello",
+		"/comic+rainbow hi",
+		"/gif https://example.com/a.gif",
+		"/song https://youtu.be/x | artist | title",
+		"/art",
+	}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			m := screens.NewChatroomsModel("neuromancer", nil)
+			m = m.SetRooms(sampleRooms())
+			m, _ = sendChatroomSpecialKey(m, tea.KeyEnter) // open room
 
-	for _, r := range "/me waves" {
-		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
-	}
-	_, cmd := sendChatroomSpecialKey(m, tea.KeyEnter)
-	if cmd == nil {
-		t.Fatal("expected a command for a known slash command")
-	}
-	msg := cmd()
-	sendMsg, ok := msg.(screens.SendRoomMessageMsg)
-	if !ok {
-		t.Fatalf("expected SendRoomMessageMsg, got %T", msg)
-	}
-	if sendMsg.Body != "/me waves" {
-		t.Errorf("expected body='/me waves', got %q", sendMsg.Body)
+			for _, r := range body {
+				m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+			}
+			_, cmd := sendChatroomSpecialKey(m, tea.KeyEnter)
+			if cmd == nil {
+				t.Fatalf("expected a command for known slash command %q", body)
+			}
+			msg := cmd()
+			sendMsg, ok := msg.(screens.SendRoomMessageMsg)
+			if !ok {
+				t.Fatalf("expected SendRoomMessageMsg, got %T", msg)
+			}
+			if sendMsg.Body != body {
+				t.Errorf("expected body=%q, got %q", body, sendMsg.Body)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Valid cIRC slash commands (e.g. `/blink`) were rejected client-side with `*** unknown command: /blink` even though the server supports them.

## Root cause

`knownCircCommands` in `internal/ui/screens/chatrooms.go` is a client-side allow-list checked before a `/`-prefixed message is sent, to catch typos early. It was populated with the emote/utility/mute commands but never updated when the text-style commands (`/blink`, `/l33t`, `/comic`, `/cursive`, `/times`, `/rainbow`, `/flip`, `/quiet`, `/slow`, `/glitch`, `/spoiler`, `/wave`) and `/gif`, `/song`, `/art` were added server-side (see `docs/00-latest-api-reference.md`).

## Fix

- Added `/gif`, `/song`, `/art` to `knownCircCommands`.
- Added a `knownCircStyles` set built from the existing style constants in `chatstyle.go`.
- Added `isKnownCircStyleCombo` to validate `+`-chained style commands (e.g. `/comic+rainbow`), which a plain exact-match lookup can't handle.
- Updated the enter-key validation in the cIRC input handler to check both.

## Testing

- `go test ./...` — pass
- `go vet ./...` — clean
- `staticcheck ./internal/ui/screens/...` — clean
- Rewrote `TestChatrooms_Send_KnownCommandStillSends` as table-driven, covering `/me`, `/blink`, `/comic+rainbow`, `/gif`, `/song`, `/art`; existing bogus-command rejection test still passes.
