### PR TITLE
feat: add bland no-color theme

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -595,7 +595,7 @@ Time formatting helpers used by all screens.
 
 #### `theme.go`
 
-Color palettes and Lip Gloss style objects for three retro themes.
+Color palettes and Lip Gloss style objects for four retro themes.
 
 **Layout constants:**
 
@@ -616,7 +616,7 @@ Color palettes and Lip Gloss style objects for three retro themes.
 
 | Function | Purpose |
 |---|---|
-| `Set(name string)` | Applies a theme by name ("cyber", "c64", "vt320"); defaults to "cyber" |
+| `Set(name string)` | Applies a theme by name ("cyber", "c64", "vt320", "bland"); defaults to "cyber" |
 | `CurrentName() string` | Returns the active theme name |
 
 **Themes:**
@@ -626,6 +626,7 @@ Color palettes and Lip Gloss style objects for three retro themes.
 | **cyber** | Bright green-on-black (#00FF41) with cyan accents (#00FFFF) — default |
 | **c64** | Commodore 64 purple background with cyan and bright magenta |
 | **vt320** | VT320 terminal dim green with amber accents |
+| **bland** | No forced colors — renders in the terminal's own default palette; active/selected states use bold/underline and a thicker active-pane border instead of color |
 
 Because all colors are package variables, styles automatically inherit the new palette when `Set()` is called — no re-initialization needed.
 

--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -30,7 +30,7 @@ type Config struct {
 	Timezone string `json:"timezone,omitempty"`
 
 	// App settings — edit manually in ~/.cyber-tui.json.
-	// Theme selects the color palette: "cyber" (default), "c64", "vt320".
+	// Theme selects the color palette: "cyber" (default), "c64", "vt320", "bland".
 	Theme string `json:"theme,omitempty"`
 	// APIBaseURL overrides the default API endpoint (https://api.cyberspace.online).
 	APIBaseURL string `json:"apiBaseURL,omitempty"`

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -51,7 +51,7 @@ const (
 )
 
 // availableThemes is the ordered list of selectable themes shown in the picker.
-var availableThemes = []string{"cyber", "c64", "vt320"}
+var availableThemes = []string{"cyber", "c64", "vt320", "bland"}
 
 const (
 	logoOrig          = "ᑕ¥βєяรקค¢є"

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -123,7 +123,7 @@ var (
 )
 
 // Set applies the named theme by reassigning all color and style vars.
-// Valid names: "cyber" (default), "c64", "vt320".
+// Valid names: "cyber" (default), "c64", "vt320", "bland".
 // Unknown or empty names fall back to "cyber".
 func Set(name string) {
 	switch name {
@@ -133,6 +133,9 @@ func Set(name string) {
 	case "vt320":
 		currentName = "vt320"
 		setVT320()
+	case "bland":
+		currentName = "bland"
+		setBland()
 	default:
 		currentName = "cyber"
 		setCyber()
@@ -176,6 +179,28 @@ func setVT320() {
 	ColorMuted = lipgloss.Color("#6B4800")      // very dim amber (subtle text)
 	ColorWhite = lipgloss.Color("#FFECB3")      // cream
 	applyStyles()
+}
+
+// setBland applies no color at all: every style renders in the terminal's
+// own default foreground/background, so the theme always matches whatever
+// palette the user's terminal is configured with. Active/selected states
+// fall back to Bold/Underline and (for the active border) a heavier border
+// glyph, since no background or foreground color is forced.
+func setBland() {
+	ColorGreen = lipgloss.Color("")
+	ColorDimGreen = lipgloss.Color("")
+	ColorCyan = lipgloss.Color("")
+	ColorYellow = lipgloss.Color("")
+	ColorRed = lipgloss.Color("")
+	ColorBackground = lipgloss.Color("")
+	ColorMuted = lipgloss.Color("")
+	ColorWhite = lipgloss.Color("")
+	applyStyles()
+
+	ActiveBorder = ActiveBorder.BorderStyle(lipgloss.ThickBorder())
+	TabMnemonic = TabMnemonic.Underline(true)
+	ActiveTabMnemonic = ActiveTabMnemonic.Underline(true)
+	NavMnemonic = NavMnemonic.Underline(true)
 }
 
 // applyStyles rebuilds all style vars from the current color vars.


### PR DESCRIPTION
﻿## Summary
Adds a fourth theme, "bland", that applies no forced colors at all — every style renders in the terminal's own default foreground/background, so the theme matches whatever palette the user's terminal is configured with.

- All 8 `Color*` vars set to `lipgloss.Color("")` in a new `setBland()`.
- Active/selected states fall back to Bold/Underline; the active pane border switches to `ThickBorder()` and tab/nav mnemonics gain `Underline` to stay visible without color.
- Registered in the theme picker (`availableThemes` in app.go) — no other UI changes needed.
- Docs updated in `docs/00-project-reference.md`.

## Test plan
- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean
- `go test ./...` — all packages pass
- Manual: theme picker (`t`), select "bland", confirm live preview and persistence to `~/.cyber-tui.json`
