### PR TITLE
feat: allow esc to quit from the login screen

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -350,6 +350,7 @@ Email + password login form.
 
 - Two `textinput` fields (email, password)
 - Tab/Up/Down navigate between fields; Enter on the password field emits `SubmitLoginMsg` (picked up by App)
+- Esc quits the app (handled globally in `app.go`'s `handleKeys`, gated to `screenLogin`)
 - Supports email prefill from config
 - Shows loading spinner and error messages
 - Renders a retro ASCII banner

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -647,6 +647,10 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 		if a.active != screenLogin {
 			return a, tea.Quit, true
 		}
+	case "esc":
+		if a.active == screenLogin {
+			return a, tea.Quit, true
+		}
 	}
 	return a.layout.HandleNav(m, a)
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -219,6 +219,29 @@ func TestHandleKeys_Leader_G_LoginScreen_NoOp(t *testing.T) {
 	}
 }
 
+func TestHandleKeys_Esc_QuitsOnLoginScreen(t *testing.T) {
+	a := newTestApp() // active == screenLogin
+	_, cmd, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyEsc})
+	if !consumed {
+		t.Error("expected esc to be consumed on login screen")
+	}
+	if cmd == nil {
+		t.Error("expected esc to fire a quit command on login screen")
+	}
+}
+
+func TestHandleKeys_Esc_NotConsumed_OffLoginScreen(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenProfile
+	_, cmd, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyEsc})
+	if consumed {
+		t.Error("expected esc to NOT be consumed by the global quit handler off the login screen")
+	}
+	if cmd != nil {
+		t.Error("expected no quit command from esc off the login screen")
+	}
+}
+
 func TestHandleKeys_Leader_MappedChord_Navigates(t *testing.T) {
 	a := loggedInApp()
 	a.active = screenProfile


### PR DESCRIPTION
## Summary
Pressing Esc on the login screen now quits the app, matching the existing q/ctrl+q/ctrl+c quit shortcuts on every other screen.

## Change
- `internal/ui/app.go`: added an `esc` case in the global `handleKeys` switch, gated to `screenLogin`, returning `tea.Quit` — mirrors the existing quit-key case exactly.
- `internal/ui/app_test.go`: added tests confirming esc quits on the login screen and is a no-op (for the global quit handler) elsewhere.
- `docs/00-project-reference.md`: documented the new shortcut under the login screen section.

## Testing
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`

All clean.
