### PR TITLE
fix: resume style animation ticker after tab regains focus

### DIFF
--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -388,11 +388,17 @@ func (m ChatroomsModel) CancelSubscription() ChatroomsModel {
 }
 
 // SetFocused marks whether the Chatrooms tab is the one currently on screen.
-// Becoming focused clears unreadCount for the tab-bar badge.
+// Becoming focused clears unreadCount for the tab-bar badge. It also clears
+// styleAnimRunning: styleAnimTickMsg isn't in IsRoomStreamMsg, so a tick that
+// fires while this tab is backgrounded is dropped before updateInner ever
+// resets the flag, permanently blocking maybeStartStyleAnim from restarting
+// the ticker. Regaining focus is the point where any prior ticker is known
+// to be dead, so it's safe to clear the flag here.
 func (m ChatroomsModel) SetFocused(focused bool) ChatroomsModel {
 	m.focused = focused
 	if focused {
 		m.unreadCount = 0
+		m.styleAnimRunning = false
 	}
 	return m
 }

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -1206,6 +1206,29 @@ func TestUpdate_StyleAnimTick_AdvancesFrameAndRearms(t *testing.T) {
 	}
 }
 
+func TestSetFocused_ResumesStyleAnimAfterBackgroundedTickIsDropped(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m, _ = m.Update(roomReceivedMsg{msg: model.Message{ID: "m1", Body: "hi", Style: []string{"wave"}}})
+	if !m.styleAnimRunning {
+		t.Fatal("setup: expected styleAnimRunning = true")
+	}
+
+	// Simulate switching away: the in-flight styleAnimTickMsg is dropped by
+	// App's message routing (it's not an IsRoomStreamMsg), so updateInner
+	// never runs to clear styleAnimRunning. Switching back must still be
+	// able to restart the ticker.
+	m = m.SetFocused(false)
+	m = m.SetFocused(true)
+
+	m, cmd := m.maybeStartStyleAnim()
+	if !m.styleAnimRunning {
+		t.Error("expected styleAnimRunning = true after resuming")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil tea.Cmd restarting the ticker after refocusing")
+	}
+}
+
 // --- spoiler reveal (see updateBrowsingKey's "enter" case) ---
 
 func TestBrowsing_Enter_TogglesSpoilerReveal(t *testing.T) {

--- a/internal/ui/screens/cmail.go
+++ b/internal/ui/screens/cmail.go
@@ -636,11 +636,17 @@ func (m CMailModel) TotalUnread() int {
 // SetFocused marks whether the C-Mail tab is the one currently on screen.
 // Becoming focused clears the currently-open conversation's local unread
 // count (mirroring ChatroomsModel.SetFocused), so TotalUnread() doesn't keep
-// counting messages the user is now actively viewing.
+// counting messages the user is now actively viewing. It also clears
+// styleAnimRunning: styleAnimTickMsg isn't in IsDMStreamMsg, so a tick that
+// fires while this tab is backgrounded is dropped before updateInner ever
+// resets the flag, permanently blocking maybeStartStyleAnim from restarting
+// the ticker. Regaining focus is the point where any prior ticker is known
+// to be dead, so it's safe to clear the flag here.
 func (m CMailModel) SetFocused(focused bool) CMailModel {
 	m.focused = focused
 	if focused {
 		m = m.zeroActiveConvUnread()
+		m.styleAnimRunning = false
 	}
 	return m
 }

--- a/internal/ui/screens/cmail_test.go
+++ b/internal/ui/screens/cmail_test.go
@@ -537,3 +537,26 @@ func TestCMailUpdate_StyleAnimTick_AdvancesFrameAndRearms(t *testing.T) {
 		t.Error("expected a non-nil tea.Cmd to rearm the ticker")
 	}
 }
+
+func TestSetFocusedCMail_ResumesStyleAnimAfterBackgroundedTickIsDropped(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	m, _ = m.Update(dmReceivedMsg{msg: model.Message{ID: "m1", Body: "hi", Style: []string{"wave"}}})
+	if !m.styleAnimRunning {
+		t.Fatal("setup: expected styleAnimRunning = true")
+	}
+
+	// Simulate switching away: the in-flight styleAnimTickMsg is dropped by
+	// App's message routing (it's not an IsDMStreamMsg), so updateInner
+	// never runs to clear styleAnimRunning. Switching back must still be
+	// able to restart the ticker.
+	m = m.SetFocused(false)
+	m = m.SetFocused(true)
+
+	m, cmd := m.maybeStartStyleAnim()
+	if !m.styleAnimRunning {
+		t.Error("expected styleAnimRunning = true after resuming")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil tea.Cmd restarting the ticker after refocusing")
+	}
+}


### PR DESCRIPTION
## Summary
- Blink/wave/glitch text effects froze permanently after switching away from a Circ room or C-Mail conversation and back
- `styleAnimTickMsg` isn't routed to a backgrounded `ChatroomsModel`/`CMailModel` (it's not an `IsRoomStreamMsg`/`IsDMStreamMsg`), so a tick that fires while the tab is inactive is silently dropped, leaving `styleAnimRunning` stuck `true` and blocking `maybeStartStyleAnim` from ever restarting the ticker
- Clear `styleAnimRunning` in `SetFocused(true)`, the point where regaining focus guarantees any prior ticker is dead — the same keystroke that triggers the tab switch already flows through `delegateUpdate`, so the ticker restarts immediately with no extra plumbing

## Test plan
- [x] Added regression tests in `chatrooms_test.go` and `cmail_test.go` reproducing the exact drop-while-backgrounded scenario; verified they fail without the fix and pass with it
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)