### PR TITLE
feat: select and scroll to newly posted reply in post detail

### DIFF
--- a/docs/10-replies.md
+++ b/docs/10-replies.md
@@ -51,7 +51,7 @@ All multi-line text entry uses the shared `ComposeModel` (`internal/ui/screens/c
 
 Response: `{ "data": { "replyId": "..." } }` (201).
 
-After a successful reply, the reply list for the current post is automatically reloaded.
+After a successful reply, the reply list for the current post is automatically reloaded, and the newly created reply is selected and scrolled fully into view — the same `App.pendingReplyID` → `repliesLoadedMsg` → `PostDetailModel.ScrollToReply` pipeline used to deep-link into a specific reply from a notification or search result (see Implementation Notes). If the new reply isn't in the loaded tree (e.g. thread nesting deeper than `effectiveMaxDepth`), `ScrollToReply` no-ops and selection falls back to whatever `SetReplies` defaults to.
 
 ---
 
@@ -60,6 +60,7 @@ After a successful reply, the reply list for the current post is automatically r
 - `CreateReply` is defined in `api.Client` interface and implemented in `HTTPClient` and `MockClient`.
 - `PostDetailModel` embeds `ComposeModel`. When compose is active, the viewport height shrinks by `compose.BoxHeight()` (= `contentLines + 3`) and navigation keys (`↑↓/jk`) are blocked.
 - `ShowPostForReplyMsg` (from feed) and `SubmitReplyMsg` (from post detail) are the inter-screen message types handled by `App.Update` in `internal/ui/app.go`.
+- `createReplyCmd` returns the new reply's ID (`CreateReply`'s response) on `replyCreatedMsg`; `handlePostDetail` sets `App.pendingReplyID` to it before reloading, reusing the same field/pipeline the notification and search deep-link paths (`ShowSearchReplyMsg`, etc.) already use to select and scroll to a specific reply.
 
 ---
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -788,6 +788,7 @@ func (a App) handlePostDetail(msg tea.Msg) (App, tea.Cmd, bool) {
 				a.broadcastWatchedIDs()
 			}
 		}
+		a.pendingReplyID = msg.replyID
 		return a, a.loadRepliesCmd(msg.postID), true
 	case screens.BackToFeedMsg:
 		a.active = a.postDetailReturn
@@ -2338,7 +2339,7 @@ type userProfileLoadedMsg struct {
 type followResultMsg struct{ followID string }
 type unfollowResultMsg struct{}
 type repliesLoadedMsg struct{ replies []model.Reply }
-type replyCreatedMsg struct{ postID string }
+type replyCreatedMsg struct{ postID, replyID string }
 type replyDeletedMsg struct{ replyID string }
 type postCreatedMsg struct{}
 type postDeletedMsg struct {
@@ -2852,11 +2853,11 @@ func (a *App) loadTopicThreadCmd(postID string) tea.Cmd {
 
 func (a *App) createReplyCmd(postID, content, parentReplyID string) tea.Cmd {
 	return func() tea.Msg {
-		_, err := a.client.CreateReply(postID, content, parentReplyID)
+		reply, err := a.client.CreateReply(postID, content, parentReplyID)
 		if err != nil {
 			return actionErrMsg{err}
 		}
-		return replyCreatedMsg{postID: postID}
+		return replyCreatedMsg{postID: postID, replyID: reply.ID}
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -828,6 +828,65 @@ func TestShowSearchReplyMsg_NavigatesToPostDetailAndScrollsToReply(t *testing.T)
 	}
 }
 
+// --- Newly posted reply is selected and scrolled into view ---
+
+// TestCreateReplyCmd_ReturnsReplyID guards against the reply ID being
+// silently discarded — without it, nothing downstream can select or scroll
+// to the reply that was just posted.
+func TestCreateReplyCmd_ReturnsReplyID(t *testing.T) {
+	a := loggedInApp()
+
+	cmd := a.createReplyCmd("p1", "nice post", "")
+	msg := cmd()
+
+	created, ok := msg.(replyCreatedMsg)
+	if !ok {
+		t.Fatalf("expected replyCreatedMsg, got %T", msg)
+	}
+	if created.postID != "p1" {
+		t.Errorf("postID = %q, want %q", created.postID, "p1")
+	}
+	if created.replyID == "" {
+		t.Error("expected a non-empty replyID from CreateReply's response")
+	}
+}
+
+// TestReplyCreatedMsg_SetsPendingReplyID verifies that handling
+// replyCreatedMsg sets pendingReplyID to the new reply's ID before
+// reloading — the same field the notification/search deep-link path uses
+// (TestShowSearchReplyMsg_NavigatesToPostDetailAndScrollsToReply) to make
+// repliesLoadedMsg call ScrollToReply. Posting a reply must feed that same
+// pipeline instead of leaving the new reply unselected after reload.
+func TestReplyCreatedMsg_SetsPendingReplyID(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenPostDetail
+
+	m, cmd := a.Update(replyCreatedMsg{postID: "p1", replyID: "reply-new-1"})
+	a2 := m.(App)
+
+	if a2.pendingReplyID != "reply-new-1" {
+		t.Fatalf("expected pendingReplyID = reply-new-1, got %q", a2.pendingReplyID)
+	}
+
+	// The reload-then-scroll half of the pipeline (repliesLoadedMsg calling
+	// ScrollToReply and clearing pendingReplyID) is already covered by
+	// TestShowSearchReplyMsg_NavigatesToPostDetailAndScrollsToReply and
+	// PostDetailModel's own TestPostDetail_ScrollToReply_AfterTree — this
+	// just confirms the reply-create path feeds pendingReplyID the same way.
+	msgs := resolveMsgs(cmd)
+	if len(msgs) == 0 {
+		t.Fatal("expected a resolved message from the replies reload")
+	}
+	for _, msg := range msgs {
+		var model tea.Model
+		model, _ = a2.Update(msg)
+		a2 = model.(App)
+	}
+	if a2.pendingReplyID != "" {
+		t.Errorf("expected pendingReplyID cleared after replies loaded, got %q", a2.pendingReplyID)
+	}
+}
+
 // --- PostDetail persists across tab switches ---
 //
 // Mirrors Circ's background-room persistence (PR #58): a post left open


### PR DESCRIPTION
## Summary

When posting a reply to a post (or a reply-to-a-reply) in Post Detail, the reply list reloaded from the server but nothing selected the new reply or scrolled it into view — the viewport fell back to whatever `SetReplies` defaults to (post selected). Now the newly created reply is selected and fully scrolled into view after posting.

## Changes

- `internal/ui/app.go`: reuses the existing `pendingReplyID` → `repliesLoadedMsg` → `PostDetailModel.ScrollToReply` → `ensureSelectedVisible` pipeline already used for notification/search deep-links — no new selection or scrolling logic needed.
  - `replyCreatedMsg` gained a `replyID` field.
  - `createReplyCmd` now captures and returns the created reply's server-assigned ID instead of discarding it.
  - `handlePostDetail`'s `replyCreatedMsg` case sets `App.pendingReplyID` to the new reply's ID before triggering the reload.
- `internal/ui/app_test.go`: new tests `TestCreateReplyCmd_ReturnsReplyID` and `TestReplyCreatedMsg_SetsPendingReplyID` covering the new wiring. The actual select/scroll mechanics (`ScrollToReply`, `ensureSelectedVisible`) were already covered by existing `postdetail_test.go` tests.
- `docs/10-replies.md`: documents the new behavior and the reused pipeline.

If the new reply isn't in the loaded tree (e.g. thread nesting deeper than `effectiveMaxDepth`), `ScrollToReply` no-ops as it already did for the deep-link case — no crash, just no selection change.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean
- `go test ./...` — all packages pass
- Manually verified: posting a top-level reply and a nested reply both select and fully scroll the new reply into view.
