### PR TITLE
feat: background feed polling with pending-new indicator in chrome

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -362,7 +362,8 @@ Key types: `LoginModel`, `SubmitLoginMsg` (email + password), `LoginErrMsg` (err
 Home feed of posts from followed users.
 
 - Cursor-based pagination: emits `LoadMoreFeedMsg` when viewport reaches the bottom; App appends new posts
-- Emits `RefreshFeedMsg` when pressing Up at the top
+- Emits `RefreshFeedMsg` when pressing Up at the top (no entries pending) — see `docs/13-feed-refresh.md`
+- Background poll every 15s stages newly-seen posts (`pendingNew`) without touching the viewport; shows a "load N new entries" banner and a Feed-tab badge. Pressing Up at the top with entries pending merges them locally instead of emitting `RefreshFeedMsg` — see `docs/39-feed-background-poll.md`
 - Emits `ShowPostMsg` on Enter → App navigates to PostDetail
 - Emits `SubmitNewPostMsg` on compose submit (content + topics)
 - `n` opens compose for a new post (with topics input); `r` opens compose for a reply

--- a/docs/13-feed-refresh.md
+++ b/docs/13-feed-refresh.md
@@ -28,3 +28,6 @@ App.Update
 | `internal/ui/screens/feed.go` | `buildContent()` | Prepends the fetching line and shifts post offsets by 1 when `refreshing` |
 | `internal/ui/screens/feed.go` | `SetPosts()` | Clears `refreshing` on completion |
 | `internal/ui/app.go` | `case screens.RefreshFeedMsg` | Calls `loadFeedCmd()` |
+
+## See also
+[`docs/39-feed-background-poll.md`](./39-feed-background-poll.md) — a passive 15s background poll that detects new posts and stages them (tab badge + banner) without disturbing the viewport. Pressing `Up`/`k` at the top merges staged posts locally when any are pending, instead of the network round-trip described above.

--- a/docs/39-feed-background-poll.md
+++ b/docs/39-feed-background-poll.md
@@ -1,0 +1,70 @@
+# 39 — Feed background poll ("load new entries")
+
+## Purpose
+Passively detect new posts on the server without disturbing the user's scroll
+position. New posts are never spliced into the viewport automatically — a
+banner and a tab badge tell the user entries are waiting, and the existing
+pull-to-top gesture (`docs/13-feed-refresh.md`) brings them into view.
+
+## Behaviour
+- Every 15s (after login, running globally regardless of the active tab —
+  same shape as the notifications unread-count poll), the app fetches the
+  newest page of the feed and diffs it against the currently loaded posts.
+- New (not-yet-seen) post IDs are staged on `FeedModel` as `pendingNew` —
+  not merged into `posts`, so the viewport and scroll position are
+  untouched.
+- While entries are pending, a banner line (`"  ↑ load N new entries ↑"`)
+  is prepended above the first post, and the Feed tab shows a `(N)` badge
+  (`layout_tabs.go`) / `●N` badge (`layout_miller.go`), mirroring the
+  notifications badge.
+- Pressing `Up`/`k` at the top of the feed while entries are pending plays
+  the same brief `"  fetching new posts..."` transition as a manual refresh
+  (~200ms, via `tea.Tick` — no network round-trip, the posts are already
+  fetched) before merging them in locally (prepend + clear pending + scroll
+  to top).
+- The poll is skipped while a manual refresh is in flight (`refreshing`) or
+  before the feed has loaded once, and reschedules itself either way.
+
+## Known limitation
+The poll reuses the same `GetFeed("")` endpoint as the initial load, which
+returns only the newest 20 posts per request. Walking multiple
+cursor-paginated pages per poll to get an exact count was considered and
+rejected — it would multiply the request count on every 15s tick (not just
+the rare case) and add latency on slow connections for a number in a
+banner. Instead: if the single fetched page comes back entirely new posts
+(the previously-known top post wasn't found within it), the real count
+could be higher than what one page can show, so the count is displayed as
+a floor — `"20+"` — rather than asserting a specific, likely-wrong number.
+The count self-corrects on the next 15s tick as more of the backlog surfaces.
+
+## Message flow
+```
+App (after login)
+  → schedules feedPollTickMsg every 15s (scheduleFeedPollCmd)
+App.Update (feedPollTickMsg)
+  → skips if feed not loaded yet or a manual refresh is in flight
+  → else: fetchFeedPeekCmd() (GetFeed("")) + reschedules itself
+  → result arrives as feedPeekMsg{posts}
+  → calls feed.SetPendingNew(posts) — dedupes against feed.posts, stages the rest
+
+FeedModel (up at index 0, pendingNew non-empty)
+  → sets refreshing (banner reuses the manual-refresh "fetching new posts..." line)
+  → returns tea.Tick(feedMergeAnimDelay) → mergePendingTickMsg
+  → MergePendingNew(): prepends staged posts, clears pendingNew, scrolls to top
+```
+
+## Key files
+| File | Symbol | Role |
+|---|---|---|
+| `internal/ui/screens/feed.go` | `FeedModel.pendingNew []model.Post` | Staged new posts, not yet in the viewport |
+| `internal/ui/screens/feed.go` | `FeedModel.pendingCapped bool` | True when the peek page was entirely new posts — count shown as "N+" |
+| `internal/ui/screens/feed.go` | `SetPendingNew()` | Dedupes incoming posts against `posts`, stages the rest, sets `pendingCapped` |
+| `internal/ui/screens/feed.go` | `PendingNewCount()` | Getter used by both tab-bar layouts for the badge |
+| `internal/ui/screens/feed.go` | `MergePendingNew()` | Prepends staged posts into `posts`, clears pending, scrolls to top |
+| `internal/ui/screens/feed.go` | `mergePendingTickMsg`, `feedMergeAnimDelay` | ~200ms delay so the local merge shows the same transition as a real refresh |
+| `internal/ui/screens/feed.go` | `buildContent()` | Renders the "load N (or N+) new entries" banner when `pendingNew` is non-empty |
+| `internal/ui/app.go` | `feedPollTickMsg`, `feedPeekMsg` | Poll tick and peek-result messages |
+| `internal/ui/app.go` | `scheduleFeedPollCmd()`, `fetchFeedPeekCmd()` | 15s self-rescheduling ticker (mirrors `schedulePollCmd`/`pollUnreadTickMsg`) |
+| `internal/ui/app.go` | `afterLoginCmd()` | Starts the ticker once, alongside the notifications poll |
+| `internal/ui/layout_tabs.go` | `renderTabBar()` | `(N)` badge for `screenFeed` |
+| `internal/ui/layout_miller.go` | `renderNav()` | `●N` badge for `screenFeed` |

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2301,6 +2301,7 @@ func (a *App) afterLoginCmd() tea.Cmd {
 		cmailCmd,
 		a.fetchUnreadCountCmd(),
 		a.schedulePollCmd(),
+		a.scheduleFeedPollCmd(),
 		a.loadSettingsCmd(),
 		a.scheduleWanderCmd(),
 		a.checkAndWanderCmd(),
@@ -2609,6 +2610,8 @@ type notifPostLoadedMsg struct{ post model.Post }
 type profilePostLoadedMsg struct{ post model.Post }
 type pollUnreadTickMsg struct{}
 type unreadCountMsg struct{ count int }
+type feedPollTickMsg struct{}
+type feedPeekMsg struct{ posts []model.Post }
 type logoAnimTickMsg struct{}  // 30s idle trigger — begins the scramble animation
 type logoFrameTickMsg struct{} // 60ms per-frame tick during scramble/hold/unscramble
 
@@ -2620,6 +2623,23 @@ func (a *App) loadFeedCmd() tea.Cmd {
 		}
 		return feedLoadedMsg{posts: posts, cursor: cursor}
 	}
+}
+
+// fetchFeedPeekCmd fetches the newest page of the feed for the background
+// poll to diff against the currently loaded posts. Errors are swallowed
+// (nil msg) — a missed poll just tries again on the next tick.
+func (a *App) fetchFeedPeekCmd() tea.Cmd {
+	return func() tea.Msg {
+		posts, _, err := a.client.GetFeed("")
+		if err != nil {
+			return nil
+		}
+		return feedPeekMsg{posts: posts}
+	}
+}
+
+func (a *App) scheduleFeedPollCmd() tea.Cmd {
+	return tea.Tick(15*time.Second, func(time.Time) tea.Msg { return feedPollTickMsg{} })
 }
 
 func (a *App) loadFeedPageCmd(cursor string) tea.Cmd {
@@ -2986,6 +3006,14 @@ func (a App) handleNotifications(msg tea.Msg) (App, tea.Cmd, bool) {
 		if msg.count > prev && !a.notifications.HasPaginated() {
 			return a, a.loadNotifsCmd(), true
 		}
+		return a, nil, true
+	case feedPollTickMsg:
+		if !a.feed.IsLoaded() || a.feed.IsRefreshing() {
+			return a, a.scheduleFeedPollCmd(), true
+		}
+		return a, tea.Batch(a.fetchFeedPeekCmd(), a.scheduleFeedPollCmd()), true
+	case feedPeekMsg:
+		a.feed = a.feed.SetPendingNew(msg.posts)
 		return a, nil, true
 	}
 	return a, nil, false

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -288,6 +288,11 @@ func (l MillerLayout) renderNav(a App) string {
 		if t.s == screenNotifications && a.polledUnreadCount > 0 {
 			badge = fmt.Sprintf(" ●%d", a.polledUnreadCount)
 		}
+		if t.s == screenFeed {
+			if n := a.feed.PendingNewCount(); n > 0 {
+				badge = fmt.Sprintf(" ●%d", n)
+			}
+		}
 		if t.s == screenCMail {
 			if n := a.cmail.TotalUnread(); n > 0 {
 				badge = fmt.Sprintf(" ●%d", n)

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -42,7 +42,7 @@ func (l TabsLayout) View(a App) string {
 	content := lipgloss.NewStyle().Height(contentHeight).MaxHeight(contentHeight).Render(l.renderActiveScreen(a))
 	base := lipgloss.JoinVertical(lipgloss.Left,
 		l.renderTabBar(a),
-		"",
+		l.renderFeedPendingBar(a),
 		content,
 		l.renderBottomBar(a),
 	)
@@ -224,6 +224,20 @@ func (l TabsLayout) renderTabBar(a App) string {
 		Render(a.logoText)
 	spacer := strings.Repeat(" ", max(0, a.width-lipgloss.Width(tabs)-lipgloss.Width(logo)))
 	return tabs + spacer + logo
+}
+
+// renderFeedPendingBar fills the blank separator row below the tab bar with
+// the "N new entries" message while posts are staged from the background
+// feed poll. Hidden during an active refresh so it doesn't sit alongside the
+// viewport's own "fetching new posts..." message for that instant.
+func (l TabsLayout) renderFeedPendingBar(a App) string {
+	if a.active != screenFeed || a.feed.IsRefreshing() {
+		return ""
+	}
+	if label := a.feed.PendingNewLabel(); label != "" {
+		return theme.Subtle.Render(label)
+	}
+	return ""
 }
 
 func (l TabsLayout) renderActiveScreen(a App) string {

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -178,6 +178,11 @@ func (l TabsLayout) renderTabBar(a App) string {
 		if t.s == screenNotifications && a.polledUnreadCount > 0 {
 			badge = fmt.Sprintf(" (%d)", a.polledUnreadCount)
 		}
+		if t.s == screenFeed {
+			if n := a.feed.PendingNewCount(); n > 0 {
+				badge = fmt.Sprintf(" (%d)", n)
+			}
+		}
 		if t.s == screenCMail {
 			if n := a.cmail.TotalUnread(); n > 0 {
 				badge = fmt.Sprintf(" (%d)", n)

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -33,6 +33,34 @@ func TestRenderTabBar_DoesNotShowSearch(t *testing.T) {
 	}
 }
 
+// --- renderFeedPendingBar: background-poll indicator lives in the separator
+// row, not pushed into the feed viewport (see FeedModel.buildContent) ---
+
+func TestRenderFeedPendingBar_ShowsLabelWhenPending(t *testing.T) {
+	a := loggedInApp()
+	a.feed = a.feed.SetPosts(nil, "")
+	a.feed = a.feed.SetPendingNew([]model.Post{{ID: "p1"}, {ID: "p2"}})
+
+	out := ansi.Strip(TabsLayout{}.renderFeedPendingBar(a))
+	if !strings.Contains(out, "load 2 new entries") {
+		t.Errorf("renderFeedPendingBar() = %q, want it to contain \"load 2 new entries\"", out)
+	}
+}
+
+func TestRenderFeedPendingBar_BlankWhenNoneOrNotOnFeed(t *testing.T) {
+	a := loggedInApp()
+	a.feed = a.feed.SetPosts(nil, "")
+	if out := (TabsLayout{}).renderFeedPendingBar(a); out != "" {
+		t.Errorf("renderFeedPendingBar() = %q, want blank with nothing pending", out)
+	}
+
+	a.feed = a.feed.SetPendingNew([]model.Post{{ID: "p1"}})
+	a.active = screenNotifications
+	if out := (TabsLayout{}).renderFeedPendingBar(a); out != "" {
+		t.Errorf("renderFeedPendingBar() = %q, want blank on a non-feed tab", out)
+	}
+}
+
 func TestRenderNav_DoesNotShowSearch(t *testing.T) {
 	a := loggedInApp()
 	out := ansi.Strip(MillerLayout{}.renderNav(a))

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -1,6 +1,8 @@
 package screens
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -53,6 +55,13 @@ type FeedDetailDebounceMsg struct{ PostID string }
 
 const feedDetailDebounceDelay = time.Second
 
+// mergePendingTickMsg fires after feedMergeAnimDelay to complete a pending-new
+// merge, giving the local merge (no network round-trip) the same brief
+// "fetching new posts..." transition as a real refresh.
+type mergePendingTickMsg struct{}
+
+const feedMergeAnimDelay = 200 * time.Millisecond
+
 // SubmitNewPostMsg is emitted when the user submits a new post from the Feed.
 type SubmitNewPostMsg struct {
 	Content  string
@@ -78,6 +87,8 @@ type FeedModel struct {
 	loading           bool
 	fetching          bool           // true while the initial (or tab-switch) load is in flight
 	refreshing        bool           // true while re-fetching newest posts (up at top)
+	pendingNew        []model.Post   // new posts detected by the background poll, staged but not yet merged into posts
+	pendingCapped     bool           // true when pendingNew hit the single-page poll limit — count is a floor, not exact
 	loaded            bool           // true once the first page has successfully loaded
 	exhausted         bool           // true once API returned an empty cursor
 	relaxed           bool           // true = blank line between posts (relaxed density)
@@ -128,7 +139,8 @@ func ParseTopics(s string) []string {
 	return out
 }
 
-func (m FeedModel) IsLoaded() bool { return m.loaded }
+func (m FeedModel) IsLoaded() bool     { return m.loaded }
+func (m FeedModel) IsRefreshing() bool { return m.refreshing }
 
 func (m FeedModel) SetFetching() FeedModel {
 	m.fetching = true
@@ -152,6 +164,8 @@ func (m FeedModel) SetPosts(posts []model.Post, cursor string) FeedModel {
 	m.loading = false
 	m.fetching = false
 	m.refreshing = false
+	m.pendingNew = nil
+	m.pendingCapped = false
 	m.loaded = true
 	m.selectedIndex = 0
 	if prevID != "" {
@@ -181,6 +195,61 @@ func (m FeedModel) AppendPosts(posts []model.Post, cursor string) FeedModel {
 	m.fetching = false
 	if m.ready {
 		m = m.refreshContent() // selectedIndex preserved; scroll position preserved
+	}
+	return m
+}
+
+// feedPeekPageSize is the page size the background poll fetches (GetFeed("")
+// always requests limit=20). Used to detect when a peek page is entirely new
+// posts — meaning the real count may exceed what this one page can show.
+const feedPeekPageSize = 20
+
+// SetPendingNew stages newly-detected posts (from the background feed poll)
+// without inserting them into the viewport. Posts already present in m.posts
+// are filtered out. Call MergePendingNew to bring them into view.
+//
+// If every post in the fetched page turns out to be new, the previously-known
+// top post wasn't found within one page — the real count could be higher than
+// what this single-request poll can see, so pendingCapped is set and the
+// count is displayed as a floor ("20+") rather than an exact (and likely
+// wrong) number.
+func (m FeedModel) SetPendingNew(posts []model.Post) FeedModel {
+	existing := make(map[string]struct{}, len(m.posts))
+	for _, p := range m.posts {
+		existing[p.ID] = struct{}{}
+	}
+	var fresh []model.Post
+	for _, p := range posts {
+		if _, ok := existing[p.ID]; !ok {
+			fresh = append(fresh, p)
+		}
+	}
+	m.pendingNew = fresh
+	m.pendingCapped = len(posts) == feedPeekPageSize && len(fresh) == len(posts)
+	if m.ready {
+		m = m.refreshContent()
+	}
+	return m
+}
+
+// PendingNewCount reports how many staged-but-unmerged posts are pending,
+// for the tab-bar badge.
+func (m FeedModel) PendingNewCount() int { return len(m.pendingNew) }
+
+// MergePendingNew prepends the staged posts onto the visible list and clears
+// the pending count. Called when the user presses up at the top of the feed
+// while entries are pending.
+func (m FeedModel) MergePendingNew() FeedModel {
+	if len(m.pendingNew) == 0 {
+		return m
+	}
+	m.posts = append(append([]model.Post{}, m.pendingNew...), m.posts...)
+	m.pendingNew = nil
+	m.pendingCapped = false
+	m.selectedIndex = 0
+	if m.ready {
+		m = m.refreshContent()
+		m.viewport.GotoTop()
 	}
 	return m
 }
@@ -373,6 +442,11 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case mergePendingTickMsg:
+		m.refreshing = false
+		m = m.MergePendingNew()
+		return m, nil
+
 	case FeedDetailNavMsg:
 		if msg.PaneHeight > 0 && msg.PaneWidth > 0 {
 			m = m.pageDetailNav(msg.Delta, msg.PaneHeight, msg.PaneWidth)
@@ -465,6 +539,10 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 				var detailCmd tea.Cmd
 				m, detailCmd = m.currentDetailCmd()
 				return m, detailCmd
+			} else if len(m.pendingNew) > 0 && !m.refreshing {
+				m.refreshing = true
+				m = m.refreshContent()
+				return m, tea.Tick(feedMergeAnimDelay, func(time.Time) tea.Msg { return mergePendingTickMsg{} })
 			} else if !m.loading && !m.refreshing {
 				m.refreshing = true
 				m = m.refreshContent()
@@ -606,6 +684,13 @@ func (m FeedModel) buildContent() (string, []int) {
 	startLine := 0
 	if m.refreshing {
 		prefix = theme.Subtle.Render("  fetching new posts...") + "\n"
+		startLine = 1
+	} else if n := len(m.pendingNew); n > 0 {
+		label := strconv.Itoa(n)
+		if m.pendingCapped {
+			label = strconv.Itoa(n) + "+"
+		}
+		prefix = theme.Subtle.Render(fmt.Sprintf("  ↑ load %s new entries ↑", label)) + "\n"
 		startLine = 1
 	}
 	if len(m.posts) == 0 {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -236,6 +236,21 @@ func (m FeedModel) SetPendingNew(posts []model.Post) FeedModel {
 // for the tab-bar badge.
 func (m FeedModel) PendingNewCount() int { return len(m.pendingNew) }
 
+// PendingNewLabel returns the "↑ load N new entries ↑" chrome message for
+// the separator bar, or "" if nothing is pending. N is a floor ("N+") when
+// pendingCapped is set — see SetPendingNew.
+func (m FeedModel) PendingNewLabel() string {
+	n := len(m.pendingNew)
+	if n == 0 {
+		return ""
+	}
+	label := strconv.Itoa(n)
+	if m.pendingCapped {
+		label += "+"
+	}
+	return fmt.Sprintf("  ↑ load %s new entries ↑", label)
+}
+
 // MergePendingNew prepends the staged posts onto the visible list and clears
 // the pending count. Called when the user presses up at the top of the feed
 // while entries are pending.
@@ -684,13 +699,6 @@ func (m FeedModel) buildContent() (string, []int) {
 	startLine := 0
 	if m.refreshing {
 		prefix = theme.Subtle.Render("  fetching new posts...") + "\n"
-		startLine = 1
-	} else if n := len(m.pendingNew); n > 0 {
-		label := strconv.Itoa(n)
-		if m.pendingCapped {
-			label = strconv.Itoa(n) + "+"
-		}
-		prefix = theme.Subtle.Render(fmt.Sprintf("  ↑ load %s new entries ↑", label)) + "\n"
 		startLine = 1
 	}
 	if len(m.posts) == 0 {

--- a/internal/ui/screens/feed_test.go
+++ b/internal/ui/screens/feed_test.go
@@ -1,6 +1,8 @@
 package screens_test
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -197,5 +199,155 @@ func TestFeed_ComposeActive_TrueWhileConfirmingDelete(t *testing.T) {
 	m, _ = m.Update(keyRune("d"))
 	if !m.ComposeActive() {
 		t.Error("expected ComposeActive to report true while the delete-confirm overlay is open")
+	}
+}
+
+// --- Background poll: pending new entries ---
+
+func TestFeed_SetPendingNew_FiltersAlreadyPresentPosts(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "existing"},
+	}, "")
+
+	m = m.SetPendingNew([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "existing"}, // already present, filtered
+		{ID: "p2", AuthorUsername: "bob", Content: "new"},
+		{ID: "p3", AuthorUsername: "carol", Content: "also new"},
+	})
+
+	if got := m.PendingNewCount(); got != 2 {
+		t.Fatalf("PendingNewCount() = %d, want 2", got)
+	}
+}
+
+func TestFeed_MergePendingNew_PrependsAndClears(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "existing"},
+	}, "")
+	m = m.SetPendingNew([]model.Post{
+		{ID: "p2", AuthorUsername: "bob", Content: "new"},
+	})
+
+	m = m.MergePendingNew()
+
+	if got := m.PendingNewCount(); got != 0 {
+		t.Fatalf("PendingNewCount() after merge = %d, want 0", got)
+	}
+
+	// Enter on the (now first, selected) post should be the merged post.
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected a cmd on enter")
+	}
+	sp, ok := cmd().(screens.ShowPostMsg)
+	if !ok {
+		t.Fatalf("expected ShowPostMsg, got %T", cmd())
+	}
+	if sp.Post.ID != "p2" {
+		t.Errorf("expected merged post p2 to be selected, got %s", sp.Post.ID)
+	}
+}
+
+func TestFeed_MergePendingNew_NoOpWhenNothingPending(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "existing"},
+	}, "")
+
+	m2 := m.MergePendingNew()
+	if m2.PendingNewCount() != 0 {
+		t.Fatalf("PendingNewCount() = %d, want 0", m2.PendingNewCount())
+	}
+}
+
+// If a peek page comes back entirely new (no overlap with known posts), the
+// real new-post count could exceed what one 20-post page can show — the
+// banner should read "20+" rather than assert a specific, likely-wrong number.
+func TestFeed_SetPendingNew_FullPageAllNew_ShowsCappedLabel(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24}) // mark ready so View() renders content
+	m = m.SetPosts([]model.Post{
+		{ID: "known", AuthorUsername: "alice", Content: "existing"},
+	}, "")
+
+	full := make([]model.Post, 20)
+	for i := range full {
+		full[i] = model.Post{ID: "new" + strconv.Itoa(i), AuthorUsername: "bob", Content: "new"}
+	}
+	m = m.SetPendingNew(full)
+
+	if got := m.PendingNewCount(); got != 20 {
+		t.Fatalf("PendingNewCount() = %d, want 20", got)
+	}
+	if !strings.Contains(m.View(), "20+") {
+		t.Errorf("View() = %q, want it to contain \"20+\"", m.View())
+	}
+}
+
+// A partial-overlap peek page (some posts already known) is not capped — the
+// count is exact and the banner should show the plain number, not "N+".
+func TestFeed_SetPendingNew_PartialOverlap_ShowsExactLabel(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetPosts([]model.Post{
+		{ID: "known", AuthorUsername: "alice", Content: "existing"},
+	}, "")
+
+	m = m.SetPendingNew([]model.Post{
+		{ID: "n1", AuthorUsername: "bob", Content: "new"},
+		{ID: "n2", AuthorUsername: "carol", Content: "new"},
+		{ID: "known", AuthorUsername: "alice", Content: "existing"}, // overlap found within the page
+	})
+
+	if got := m.PendingNewCount(); got != 2 {
+		t.Fatalf("PendingNewCount() = %d, want 2", got)
+	}
+	view := m.View()
+	if !strings.Contains(view, "load 2 new entries") {
+		t.Errorf("View() = %q, want it to contain \"load 2 new entries\"", view)
+	}
+	if strings.Contains(view, "2+") {
+		t.Errorf("View() = %q, should not show a capped label when count is exact", view)
+	}
+}
+
+// Pressing up at the top of the feed with entries pending should play the
+// same brief "fetching new posts..." transition as a real refresh (via a
+// short tea.Tick) before merging locally, rather than firing a
+// RefreshFeedMsg network round-trip or merging instantly with no feedback.
+func TestFeed_UpAtTop_WithPendingNew_AnimatesThenMergesLocally(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "existing"},
+	}, "")
+	m = m.SetPendingNew([]model.Post{
+		{ID: "p2", AuthorUsername: "bob", Content: "new"},
+	})
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+
+	// Not merged yet — the tick hasn't fired.
+	if m.PendingNewCount() != 1 {
+		t.Fatalf("PendingNewCount() = %d, want 1 (not yet merged)", m.PendingNewCount())
+	}
+	if !strings.Contains(m.View(), "fetching new posts...") {
+		t.Errorf("View() = %q, want the transitional banner while the merge tick is pending", m.View())
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd (the merge-delay tea.Tick)")
+	}
+	tickMsg := cmd() // tea.Tick's cmd reads its timer channel once — call it exactly once
+	if _, ok := tickMsg.(screens.RefreshFeedMsg); ok {
+		t.Fatal("expected the local merge path, not a RefreshFeedMsg network round-trip")
+	}
+
+	// Feed the tick's message back through Update to complete the merge.
+	m, _ = m.Update(tickMsg)
+
+	if m.PendingNewCount() != 0 {
+		t.Errorf("PendingNewCount() = %d, want 0 after the merge tick fires", m.PendingNewCount())
 	}
 }

--- a/internal/ui/screens/feed_test.go
+++ b/internal/ui/screens/feed_test.go
@@ -281,8 +281,8 @@ func TestFeed_SetPendingNew_FullPageAllNew_ShowsCappedLabel(t *testing.T) {
 	if got := m.PendingNewCount(); got != 20 {
 		t.Fatalf("PendingNewCount() = %d, want 20", got)
 	}
-	if !strings.Contains(m.View(), "20+") {
-		t.Errorf("View() = %q, want it to contain \"20+\"", m.View())
+	if !strings.Contains(m.PendingNewLabel(), "20+") {
+		t.Errorf("PendingNewLabel() = %q, want it to contain \"20+\"", m.PendingNewLabel())
 	}
 }
 
@@ -304,12 +304,12 @@ func TestFeed_SetPendingNew_PartialOverlap_ShowsExactLabel(t *testing.T) {
 	if got := m.PendingNewCount(); got != 2 {
 		t.Fatalf("PendingNewCount() = %d, want 2", got)
 	}
-	view := m.View()
-	if !strings.Contains(view, "load 2 new entries") {
-		t.Errorf("View() = %q, want it to contain \"load 2 new entries\"", view)
+	label := m.PendingNewLabel()
+	if !strings.Contains(label, "load 2 new entries") {
+		t.Errorf("PendingNewLabel() = %q, want it to contain \"load 2 new entries\"", label)
 	}
-	if strings.Contains(view, "2+") {
-		t.Errorf("View() = %q, should not show a capped label when count is exact", view)
+	if strings.Contains(label, "2+") {
+		t.Errorf("PendingNewLabel() = %q, should not show a capped label when count is exact", label)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Background poll fetches the feed's latest page every 15s and stages any newly-discovered posts (`FeedModel.SetPendingNew`) without disrupting the currently viewed list
- Pressing up at the top of the feed merges staged posts in, reusing the existing manual-refresh push-down + "fetching new posts..." animation
- The idle "N new entries" indicator lives in the separator row between the tab bar and content (TabsLayout only) instead of being pushed into the scrollable post list, so the list never shifts except during an actual fetch

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] Manual check against mock data: separator row stays blank when idle, shows the pending-count message only on the Feed tab, other tabs unaffected, up-press still triggers the fetch animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)