### PR TITLE
feat: add custom theme editor

### DIFF
--- a/cmd/cyber-tui/main.go
+++ b/cmd/cyber-tui/main.go
@@ -32,6 +32,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "config: %v\n", err)
 		os.Exit(1)
 	}
+	if cfg.CustomPalette != nil {
+		theme.SetCustomPalette(*cfg.CustomPalette)
+	}
 	theme.Set(cfg.Theme)
 	gfxProto := imgview.DetectProtocol()
 

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -597,7 +597,7 @@ Time formatting helpers used by all screens.
 
 #### `theme.go`
 
-Color palettes and Lip Gloss style objects for four retro themes.
+Color palettes and Lip Gloss style objects for four retro themes, plus a user-editable fifth "custom" theme.
 
 **Layout constants:**
 
@@ -609,7 +609,7 @@ Color palettes and Lip Gloss style objects for four retro themes.
 | `ChromeHeight` | 3 | Sum of the above; used by screens to compute usable height |
 
 **Color variables** (package-level; reassigned by `Set()`):  
-`ColorGreen`, `ColorDimGreen`, `ColorCyan`, `ColorYellow`, `ColorRed`, `ColorBackground`, `ColorMuted`, `ColorWhite`
+`ColorGreen`, `ColorDimGreen`, `ColorCyan`, `ColorYellow`, `ColorRed`, `ColorBackground`, `ColorMuted`, `ColorWhite`, `ColorMeta`
 
 **Style objects** (Lip Gloss; auto-update when `Set()` is called):  
 `Base`, `Title`, `Subtle`, `Highlight`, `MeHighlight`, `Error`, `Border`, `ActiveBorder`, `StatusBar`, `Tab`, `ActiveTab`
@@ -618,8 +618,14 @@ Color palettes and Lip Gloss style objects for four retro themes.
 
 | Function | Purpose |
 |---|---|
-| `Set(name string)` | Applies a theme by name ("cyber", "c64", "vt320", "bland"); defaults to "cyber" |
+| `Set(name string)` | Applies a theme by name ("cyber", "c64", "vt320", "bland", "custom"); defaults to "cyber" |
 | `CurrentName() string` | Returns the active theme name |
+| `ValidHex(s string) bool` | Reports whether `s` is a well-formed `#RRGGBB` hex color |
+| `(Palette) Valid() bool` | Reports whether the 9 rendered fields of a `Palette` are well-formed hex (`Background`/`CodeBackground` are optional) |
+| `SetCustomPalette(p Palette)` | Stores `p` as the "custom" theme's palette; re-applies immediately if "custom" is already active (live preview) |
+| `CurrentPalette() Palette` | Returns the colors currently active, as a `Palette` |
+
+**`Palette` type:** the data-driven counterpart to the literal `setCyber`/`setC64`/etc. themes, named by UI role rather than color so the theme editor and config file read as "what does this control": `Foreground`, `Dimmed`, `Border`, `Accent`, `Highlight`, `Error`, `BarText`, `Self`, `Meta` (all rendered; map internally to `ColorGreen`, `ColorMuted`, `ColorDimGreen`, `ColorCyan`, `ColorYellow`, `ColorRed`, `ColorBackground`, `ColorWhite`, `ColorMeta` respectively), plus `Background`/`CodeBackground` (reserved, unused by the renderer today, hidden from the editor). `Self` and `Meta` were one field until `ColorWhite` turned out to drive both the own-username highlight and unrelated status-bar text — split so each row controls exactly one thing. Used by the "custom" theme (edited in-TUI, see `docs/40-custom-themes.md`) and exposed for a future "detect theme in a post" feature to build/inspect palettes without touching `theme`'s internals — see that doc's post-field mapping table.
 
 **Themes:**
 
@@ -629,6 +635,7 @@ Color palettes and Lip Gloss style objects for four retro themes.
 | **c64** | Commodore 64 purple background with cyan and bright magenta |
 | **vt320** | VT320 terminal dim green with amber accents |
 | **bland** | No forced colors — renders in the terminal's own default palette; active/selected states use bold/underline and a thicker active-pane border instead of color |
+| **custom** | User-built palette, edited in-TUI via the theme picker (`t`, then `e` on the "custom" row) and persisted to `~/.cyber-tui.json`. See `docs/40-custom-themes.md`. |
 
 Because all colors are package variables, styles automatically inherit the new palette when `Set()` is called — no re-initialization needed.
 
@@ -647,7 +654,8 @@ Permissions: `0600` (owner read/write only)
 | `savedAt` | string | — | ISO timestamp of last login |
 | `density` | string | `""` | `""` = dense, `"relaxed"` = blank lines between items |
 | `timezone` | string | `"UTC"` | UTC offset label (e.g. "UTC+5:30") |
-| `theme` | string | `"cyber"` | `"cyber"`, `"c64"`, or `"vt320"` |
+| `theme` | string | `"cyber"` | `"cyber"`, `"c64"`, `"vt320"`, `"bland"`, or `"custom"` |
+| `customPalette` | object \| null | `null` | 8-hex-color palette for the "custom" theme, set via the in-TUI theme editor (`docs/40-custom-themes.md`) |
 | `apiBaseURL` | string | `"https://api.cyberspace.online"` | Override for development |
 | `allowInsecureApi` | bool | `false` | Permit a plain `http://` `apiBaseURL` to a non-loopback host |
 | `useMock` | bool | `false` | Use `MockClient` instead of real API |

--- a/docs/40-custom-themes.md
+++ b/docs/40-custom-themes.md
@@ -1,0 +1,145 @@
+# 40 — Custom Themes
+
+## Overview
+
+Alongside the 4 built-in themes (cyber, c64, vt320, bland), users can build and save their own "custom" theme from inside the TUI. The custom theme is an 8-color palette, edited via a modal opened from the existing theme picker (`t`), and persisted to `~/.cyber-tui.json`.
+
+This is out of scope but adjacent: users on cyberspace.online post custom themes as formatted text blocks (base theme + hex colors + some webui-only font/effect fields). A future feature will detect one of these blocks in a post (post detail screen) and apply it via a shortcut. `theme.SetCustomPalette`/`theme.CurrentPalette` are the intended entry point for that feature — see Design Notes below.
+
+---
+
+## Data Flow
+
+### Startup
+
+`cmd/cyber-tui/main.go` loads config, then:
+```go
+if cfg.CustomPalette != nil {
+    theme.SetCustomPalette(*cfg.CustomPalette)
+}
+theme.Set(cfg.Theme)
+```
+`SetCustomPalette` must be called first so `Set("custom")` has a palette to apply.
+
+### Theme Picker → Editor
+
+1. `t` opens the theme picker (`App.themePickerOpen`), listing `availableThemes = []string{"cyber", "c64", "vt320", "bland", "custom"}`.
+2. `↑`/`↓` previews each theme live. On the "custom" row, this only applies if a palette has already been saved (`App.customPalette != nil`) — otherwise the current theme stays put.
+3. `e` on the "custom" row opens the editor (`App.themeEditorOpen`), prefilled from the saved palette if one exists, otherwise from `theme.CurrentPalette()` (whatever theme is currently active).
+4. In the editor: `j`/`k` moves between the 8 color rows, `enter` focuses a row's 6-digit hex buffer. Each row shows a fixed, non-removable `#` followed by 6 editable slots. Typing an alphanumeric character overwrites the slot under the cursor (uppercased automatically) and advances to the next slot — except on the last slot, where the cursor stays put since there's nowhere further to go. `←`/`→` move the cursor within the 6 slots (clamped at both ends); `backspace` clears the current slot and steps back. `enter`/`esc` commits the field and returns to row navigation. Every edit emits `screens.PreviewPaletteMsg`, which `App.handleThemeEditor` applies via `theme.SetCustomPalette` + `refreshViewports()` for live preview.
+5. `ctrl+s` (when dirty and all 8 fields are valid `#RRGGBB`) emits `screens.SaveThemeMsg`. `App.handleThemeEditor` updates `App.customPalette` and persists via `saveConfig` (sets both `cfg.Theme = "custom"` and `cfg.CustomPalette`).
+6. `esc` (row-nav mode) emits `screens.CloseThemeEditorMsg`, which reverts to the theme that was active before the editor opened (`App.themeEditorOrig`) and closes without saving.
+
+### Ephemeral (SSH) Sessions
+
+`saveConfig` already no-ops when `App.ephemeral` is true — editing and live preview work normally in an SSH session, but nothing is written to the host operator's `~/.cyber-tui.json`.
+
+---
+
+## Model
+
+```go
+// internal/ui/theme
+type Palette struct {
+    Foreground string // primary body text, markdown emphasis
+    Dimmed     string // secondary/subtle text, strikethrough, separators
+    Border     string // inactive borders, tab bar, code gutters
+    Accent     string // titles, links, active border/tab
+    Highlight  string // @mentions and code text
+    Error      string // error messages/banner
+    BarText    string // text on colored bars: status bar, logo badge, notify banner
+    Self       string // your own username highlight (MeHighlight only)
+    Meta       string // status bar secondary info text & hint key-descriptions
+
+    // Reserved — not rendered by the TUI today, carried through for a future
+    // post-import feature. Not shown as editor rows.
+    Background     string
+    CodeBackground string
+}
+
+func ValidHex(s string) bool
+func (p Palette) Valid() bool     // the 9 rendered fields required; Background/CodeBackground optional
+func SetCustomPalette(p Palette)
+func CurrentPalette() Palette
+```
+
+`Self` and `Meta` were originally one field (`Self`, backed by `ColorWhite`) until it turned out to drive two unrelated things: own-username highlighting *and* the status bar's secondary text/hint descriptions. Split so each row controls exactly one thing — `ColorMeta` is a separate color var from `ColorWhite`, initialized to the same literal in every built-in theme (so no visual change there), letting only custom themes differentiate them.
+
+### Post-field mapping
+
+Fields are named to line up with the theme blocks users post on cyberspace.online (see Overview), so a future "detect theme in a post" feature can map them directly:
+
+| Post field | `Palette` field | Notes |
+|---|---|---|
+| `Foreground` | `Foreground` | |
+| `Background` | `Background` | Reserved — the TUI has no fillable full-screen background, so this has no visible effect yet |
+| `Dimmed` | `Dimmed` | |
+| `Border` | `Border` | |
+| `Code` | `Highlight` | The TUI already renders code block/span text in the same color as `@mention` highlights |
+| `Code BG` | `CodeBackground` | Reserved — no code-block background rendering exists yet |
+| *(no post field)* | `Accent`, `Error`, `BarText`, `Self`, `Meta` | TUI-only roles with no webui-post equivalent; a post-import would leave these at whatever the base theme already has |
+
+```go
+// internal/config
+type Config struct {
+    // ...
+    Theme         string          `json:"theme,omitempty"`         // now includes "custom"
+    CustomPalette *theme.Palette  `json:"customPalette,omitempty"` // nil until saved
+}
+```
+
+---
+
+## Key Bindings
+
+| Key | Context | Action |
+|-----|---------|--------|
+| `t` | global | Open theme picker |
+| `↑`/`↓` or `j`/`k` | picker | Move cursor, live-preview |
+| `e` | picker, "custom" row | Open theme editor |
+| `enter` | picker | Apply selected theme |
+| `esc` | picker | Cancel, revert |
+| `j`/`k` | editor (row nav) | Move between color fields |
+| `enter` | editor (row nav) | Focus the selected field's hex buffer |
+| `alnum key` | editor (editing) | Overwrite the slot under the cursor (uppercased), advance to the next slot (stays put on the last slot) |
+| `←`/`→` | editor (editing) | Move within the 6 hex-digit slots, clamped at both ends |
+| `backspace` | editor (editing) | Clear the current slot, step back |
+| `enter`/`esc` | editor (editing) | Commit the field, back to row nav |
+| `ctrl+s` | editor (row nav) | Save custom palette |
+| `esc` | editor (row nav) | Close without saving, revert theme |
+
+---
+
+## Save Strategy
+
+Same as the Settings screen: edits accumulate in memory (with live preview) until `ctrl+s`. No autosave, no partial writes — an invalid hex value blocks save and shows an inline error instead of persisting a broken palette.
+
+---
+
+## Design Notes
+
+- **Editor is a modal, not a tab.** It's a sub-action of the theme picker (already a modal with live-preview/overlay plumbing built), not an independent destination — adding a tab would mean a new `screen` const, mnemonic, and renumbering across two layouts for no benefit.
+- **Prefill from the active theme**, not blank fields — matches the picker's existing "start from what's on screen" model and means all 8 fields are valid immediately, so `ctrl+s` isn't blocked on first use.
+- **Future "detect theme in a post" feature**: call `theme.SetCustomPalette(p)` to preview a parsed palette and `theme.CurrentPalette()` to compare against what's currently active. No further hooks are needed in `theme` for that feature to build on.
+
+### Future: resolving unmapped fields when importing a post's theme
+
+A post always declares a `Base Theme:` name alongside its explicit colors (see Overview). The post's colors only ever cover `Foreground`, `Background`, `Dimmed`, `Border`, and `Code` (→ `Highlight`) — see the post-field mapping table above. That leaves `Accent`, `Error`, `Self`, `Meta`, and `CodeBackground` with nothing to import from the post itself. Resolution order for those, decided but not yet built:
+
+1. **If the post's `Base Theme` matches one of our own built-in themes** (`cyber`, `c64`, `vt320`, `bland`, case-insensitive) — prefill from *that* theme's full palette. We have the actual author-intended values for the unmapped fields sitting in `theme.go`; there's no reason to discard them for a guess.
+2. **If the name doesn't match a known built-in** (a webui-only theme, a typo, a future theme not yet ported to the TUI) — prefill from `theme.CurrentPalette()` (today's active theme) instead, since inventing values for an unrecognized theme would just be guessing. This mirrors the manual editor's own prefill behavior (`e` on the picker's "custom" row).
+3. Either way, overlay the post's explicit fields on top of whichever base was chosen in step 1 or 2.
+
+**Prerequisite refactor**: step 1 needs a way to read a built-in theme's palette *without* switching to it — `setCyber`/`setC64`/`setVT320`/`setBland` currently only mutate the live `ColorX` vars imperatively, with no way to hand back "what vt320's colors are" short of actually activating vt320 (an unwanted side effect mid-import). The fix is to pull each built-in's hex literals out into a named `Palette` value (e.g. `var vt320Palette = Palette{Foreground: "#FFB000", ...}`) and have `setVT320()` call `applyPalette(vt320Palette)` — a single source of truth instead of literals duplicated across `setX()` and a second lookup table, and it gives the post-import feature its lookup for free. `bland` fits trivially (its palette is all-empty strings); its extra Bold/Underline/border-weight tweaks stay separate imperative code, since those aren't part of `Palette`.
+
+---
+
+## Integration Checklist
+
+- [x] `theme.Palette` type + `SetCustomPalette`/`CurrentPalette`/`ValidHex`
+- [x] `Config.CustomPalette` field, round-tripped through `~/.cyber-tui.json`
+- [x] Theme editor screen (`internal/ui/screens/themeeditor.go`)
+- [x] Wired into theme picker (`e` to edit/create) in both layouts (tabs, miller)
+- [x] Live preview while editing
+- [x] Ephemeral (SSH) sessions: editing works, persistence no-ops
+- [ ] Detect a theme block in a post and apply it (future feature, out of scope here)

--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
 // Config holds all persistent state for the app: session tokens, user preferences,
@@ -30,8 +32,11 @@ type Config struct {
 	Timezone string `json:"timezone,omitempty"`
 
 	// App settings — edit manually in ~/.cyber-tui.json.
-	// Theme selects the color palette: "cyber" (default), "c64", "vt320", "bland".
+	// Theme selects the color palette: "cyber" (default), "c64", "vt320", "bland", "custom".
 	Theme string `json:"theme,omitempty"`
+	// CustomPalette holds the user-built palette for the "custom" theme,
+	// saved from the in-TUI theme editor. Nil until the user saves one.
+	CustomPalette *theme.Palette `json:"customPalette,omitempty"`
 	// APIBaseURL overrides the default API endpoint (https://api.cyberspace.online).
 	APIBaseURL string `json:"apiBaseURL,omitempty"`
 	// AllowInsecureAPI permits a plain http:// APIBaseURL to a non-loopback host.

--- a/internal/config/session_test.go
+++ b/internal/config/session_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ragnar/cyber-tui/internal/config"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
 // withTempHome redirects os.UserHomeDir to a temp directory for the duration
@@ -65,6 +66,50 @@ func TestSaveAndLoad(t *testing.T) {
 	}
 }
 
+
+func TestSaveAndLoad_CustomPalette(t *testing.T) {
+	withTempHome(t)
+
+	want := config.Config{
+		Theme: "custom",
+		CustomPalette: &theme.Palette{
+			Foreground: "#111111", Dimmed: "#222222", Border: "#333333", Accent: "#444444",
+			Highlight: "#555555", Error: "#666666", BarText: "#777777", Self: "#888888", Meta: "#999999",
+		},
+	}
+	if err := config.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Theme != "custom" {
+		t.Errorf("Theme = %q, want custom", got.Theme)
+	}
+	if got.CustomPalette == nil {
+		t.Fatal("CustomPalette = nil, want saved palette")
+	}
+	if *got.CustomPalette != *want.CustomPalette {
+		t.Errorf("CustomPalette = %+v, want %+v", *got.CustomPalette, *want.CustomPalette)
+	}
+}
+
+func TestLoad_CustomPaletteAbsentIsNil(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, ".cyber-tui.json")
+	if err := os.WriteFile(path, []byte(`{"theme":"cyber"}`), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.CustomPalette != nil {
+		t.Errorf("expected CustomPalette nil when absent from JSON, got %+v", cfg.CustomPalette)
+	}
+}
 
 // --- Wander mode ---
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -51,7 +51,7 @@ const (
 )
 
 // availableThemes is the ordered list of selectable themes shown in the picker.
-var availableThemes = []string{"cyber", "c64", "vt320", "bland"}
+var availableThemes = []string{"cyber", "c64", "vt320", "bland", "custom"}
 
 const (
 	logoOrig          = "ᑕ¥βєяรקค¢є"
@@ -109,6 +109,16 @@ type App struct {
 	themePickerOpen   bool
 	themePickerCursor int    // index into availableThemes
 	themePickerOrig   string // theme name when picker was opened (for Esc revert)
+
+	// themeEditor state — opened from the theme picker with 'e' on the
+	// "custom" row, closed by SaveThemeMsg/CloseThemeEditorMsg.
+	themeEditorOpen bool
+	themeEditor     screens.ThemeEditorModel
+	themeEditorOrig string // theme name before entering the editor, for close-without-save revert
+
+	// customPalette is the persisted custom theme, loaded from config. Nil
+	// means the user has never saved one yet.
+	customPalette *theme.Palette
 
 	// helpModal state — open with '?', close with any key.
 	helpModalOpen bool
@@ -300,6 +310,7 @@ func (a App) WithSavedSession(s config.Config) App {
 	a.imageViewer = s.ImageViewer
 	a.layoutName = s.Layout
 	a.layout = layoutFromName(s.Layout)
+	a.customPalette = s.CustomPalette
 	return a
 }
 
@@ -414,6 +425,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if a2, cmd, ok := a.handleSettings(msg); ok {
 		return a2, cmd
 	}
+	if a2, cmd, ok := a.handleThemeEditor(msg); ok {
+		return a2, cmd
+	}
 	if a2, cmd, ok := a.handleBookmarks(msg); ok {
 		return a2, cmd
 	}
@@ -523,6 +537,10 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 	// Modal overlays intercept all keys while open.
 	if a.themePickerOpen {
 		model, cmd := a.handleThemePickerKey(m)
+		return model.(App), cmd, true
+	}
+	if a.themeEditorOpen {
+		model, cmd := a.handleThemeEditorKey(m)
 		return model.(App), cmd, true
 	}
 	if a.helpModalOpen {
@@ -1109,6 +1127,38 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 				cfg.LastWandered = msg.at
 			})
 		}
+		return a, nil, true
+	}
+	return a, nil, false
+}
+
+// handleThemeEditor processes messages emitted by the theme editor modal:
+// live preview on every edit, persisting on save, and reverting on close.
+func (a App) handleThemeEditor(msg tea.Msg) (App, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case screens.PreviewPaletteMsg:
+		theme.SetCustomPalette(msg.Palette)
+		a.refreshViewports()
+		return a, nil, true
+
+	case screens.SaveThemeMsg:
+		p := msg.Palette
+		a.themeEditor = a.themeEditor.SetSaved(p)
+		a.customPalette = &p
+		a.themeEditorOpen = false
+		return a, func() tea.Msg {
+			a.saveConfig(func(cfg *config.Config) {
+				cfg.Theme = "custom"
+				pp := p
+				cfg.CustomPalette = &pp
+			})
+			return nil
+		}, true
+
+	case screens.CloseThemeEditorMsg:
+		a.themeEditorOpen = false
+		theme.Set(a.themeEditorOrig)
+		a.refreshViewports()
 		return a, nil, true
 	}
 	return a, nil, false
@@ -1867,17 +1917,48 @@ func (a App) activeScreenHasFocusedInput() bool { return a.layout.HasFocusedInpu
 // handleThemePickerKey processes keyboard input while the theme picker is open.
 func (a App) handleThemePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	refreshCmd := func() tea.Msg { return tea.WindowSizeMsg{Width: a.width, Height: a.height} }
+	// preview applies the theme at the cursor for a live preview. "custom"
+	// only previews if a palette has already been saved — otherwise there's
+	// nothing to show yet, so the current theme stays put until 'e' builds one.
+	preview := func() {
+		name := availableThemes[a.themePickerCursor]
+		if name == "custom" {
+			if a.customPalette == nil {
+				return
+			}
+			theme.SetCustomPalette(*a.customPalette)
+		}
+		theme.Set(name)
+		a.refreshViewports()
+	}
 	switch msg.String() {
 	case "up", "k":
 		a.themePickerCursor = (a.themePickerCursor - 1 + len(availableThemes)) % len(availableThemes)
-		theme.Set(availableThemes[a.themePickerCursor])
-		a.refreshViewports()
+		preview()
 	case "down", "j":
 		a.themePickerCursor = (a.themePickerCursor + 1) % len(availableThemes)
-		theme.Set(availableThemes[a.themePickerCursor])
+		preview()
+	case "e":
+		if availableThemes[a.themePickerCursor] != "custom" {
+			return a, nil
+		}
+		prefill := theme.CurrentPalette()
+		if a.customPalette != nil {
+			prefill = *a.customPalette
+		}
+		theme.SetCustomPalette(prefill)
+		theme.Set("custom")
 		a.refreshViewports()
+		a.themeEditorOrig = a.themePickerOrig
+		a.themePickerOpen = false
+		a.themeEditorOpen = true
+		a.themeEditor = screens.NewThemeEditorModel(prefill)
+		return a, nil
 	case "enter":
 		selected := availableThemes[a.themePickerCursor]
+		if selected == "custom" && a.customPalette == nil {
+			return a, nil // nothing saved yet — press 'e' to build one
+		}
 		a.themePickerOpen = false
 		return a, tea.Batch(
 			refreshCmd,
@@ -1894,6 +1975,14 @@ func (a App) handleThemePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, refreshCmd
 	}
 	return a, nil
+}
+
+// handleThemeEditorKey forwards keyboard input to the theme editor model
+// while it's open.
+func (a App) handleThemeEditorKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	a.themeEditor, cmd = a.themeEditor.Update(msg)
+	return a, cmd
 }
 
 // refreshViewports forces all screen viewports to re-render with the current

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -148,7 +148,7 @@ func sbStyle() lipgloss.Style {
 // renderHints formats a []hint slice as a compact styled string.
 func renderHints(hints []hint) string {
 	key := sbStyle().Foreground(theme.ColorCyan).Bold(true)
-	desc := sbStyle().Foreground(theme.ColorWhite)
+	desc := sbStyle().Foreground(theme.ColorMeta)
 	sep := sbStyle().Foreground(theme.ColorMuted).Render(" · ")
 	parts := make([]string, 0, len(hints)*3)
 	for i, h := range hints {

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -124,6 +124,9 @@ func (l MillerLayout) View(a App) string {
 	if a.themePickerOpen {
 		return overlayCenter(base, l.renderThemePicker(a), a.width, a.height)
 	}
+	if a.themeEditorOpen {
+		return overlayCenter(base, l.renderThemeEditor(a), a.width, a.height)
+	}
 	if a.helpModalOpen {
 		return overlayCenter(base, l.renderHelpModal(a), a.width, a.height)
 	}
@@ -444,7 +447,7 @@ func (l MillerLayout) screenHints(a App) []hint {
 
 func (l MillerLayout) renderStatusBar(a App) string {
 	user := sbStyle().Foreground(theme.ColorCyan).Bold(true)
-	meta := sbStyle().Foreground(theme.ColorWhite)
+	meta := sbStyle().Foreground(theme.ColorMeta)
 	sep := sbStyle().Foreground(theme.ColorMuted).Render(" · ")
 
 	densityLabel := "dense"
@@ -514,9 +517,14 @@ func (l MillerLayout) renderThemePicker(a App) string {
 		"",
 		strings.Join(rows, "\n"),
 		"",
-		theme.Subtle.Render("↑↓ select   enter apply   esc cancel"),
+		theme.Subtle.Render("↑↓ select   enter apply   e edit custom   esc cancel"),
 	)
 	return theme.ActiveBorder.Render(body)
+}
+
+// renderThemeEditor renders the "custom" theme color editor modal.
+func (l MillerLayout) renderThemeEditor(a App) string {
+	return a.themeEditor.View()
 }
 
 func (l MillerLayout) renderHelpModal(a App) string {
@@ -537,6 +545,7 @@ func (l MillerLayout) renderHelpModal(a App) string {
 	globalRows = append(globalRows,
 		row("/", "search"),
 		row("t", "theme"),
+		row("e", "edit custom theme (in theme picker)"),
 		row("v", "density"),
 		row("o", "open url"),
 		row("q", "quit"),

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -49,6 +49,9 @@ func (l TabsLayout) View(a App) string {
 	if a.themePickerOpen {
 		return overlayCenter(base, l.renderThemePicker(a), a.width, a.height)
 	}
+	if a.themeEditorOpen {
+		return overlayCenter(base, l.renderThemeEditor(a), a.width, a.height)
+	}
 	if a.helpModalOpen {
 		return overlayCenter(base, l.renderHelpModal(a), a.width, a.height)
 	}
@@ -302,7 +305,7 @@ func (l TabsLayout) renderNotification(a App) string {
 
 func (l TabsLayout) renderStatusBar(a App) string {
 	user := sbStyle().Foreground(theme.ColorCyan).Bold(true)
-	meta := sbStyle().Foreground(theme.ColorWhite)
+	meta := sbStyle().Foreground(theme.ColorMeta)
 	sep := sbStyle().Foreground(theme.ColorMuted).Render(" · ")
 
 	densityLabel := "dense"
@@ -461,7 +464,7 @@ func (l TabsLayout) renderThemePicker(a App) string {
 			items = append(items, theme.Subtle.Render("  "+name))
 		}
 	}
-	hint := theme.Subtle.Render("↑↓ preview   enter save   esc cancel")
+	hint := theme.Subtle.Render("↑↓ preview   enter save   e edit custom   esc cancel")
 	body := lipgloss.JoinVertical(lipgloss.Left,
 		title,
 		"",
@@ -470,6 +473,11 @@ func (l TabsLayout) renderThemePicker(a App) string {
 		hint,
 	)
 	return theme.ActiveBorder.Render(body)
+}
+
+// renderThemeEditor renders the "custom" theme color editor modal.
+func (l TabsLayout) renderThemeEditor(a App) string {
+	return a.themeEditor.View()
 }
 
 func (l TabsLayout) renderHelpModal(a App) string {
@@ -488,6 +496,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		row("← →", "cycle tabs"),
 		row("/", "search"),
 		row("t", "theme"),
+		row("e", "edit custom theme (in theme picker)"),
 		row("v", "density"),
 		row("o", "open url"),
 		row("q", "quit"),

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/ragnar/cyber-tui/internal/model"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
 // BookmarkedIDsMsg is broadcast by App whenever the set of bookmarked post/reply
@@ -222,3 +223,16 @@ type LoadNoteRevisionMsg struct {
 	NoteID         string
 	RevisionNumber int
 }
+
+// PreviewPaletteMsg is emitted by ThemeEditorModel on every edit so App can
+// live-preview via theme.SetCustomPalette + refreshViewports, mirroring the
+// theme picker's up/down preview.
+type PreviewPaletteMsg struct{ Palette theme.Palette }
+
+// SaveThemeMsg is emitted by ThemeEditorModel on ctrl+s with a valid, dirty
+// palette. App persists it (unless ephemeral) and applies it as "custom".
+type SaveThemeMsg struct{ Palette theme.Palette }
+
+// CloseThemeEditorMsg is emitted by ThemeEditorModel on esc (row-nav mode,
+// not mid-field-edit) to close without saving.
+type CloseThemeEditorMsg struct{}

--- a/internal/ui/screens/themeeditor.go
+++ b/internal/ui/screens/themeeditor.go
@@ -1,0 +1,311 @@
+package screens
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
+)
+
+// isAlnum/upperRune are deliberately ASCII-only (not unicode.IsLetter) — hex
+// digits are always ASCII, and keeping the buffer single-byte-per-rune keeps
+// renderBuffer's cursor-position math trivial.
+func isAlnum(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+func upperRune(r rune) rune {
+	if r >= 'a' && r <= 'z' {
+		return r - 'a' + 'A'
+	}
+	return r
+}
+
+// themeEditorField binds one row of the editor to a Palette field via typed
+// accessors, so field order in themeEditorFields has no impact on correctness.
+type themeEditorField struct {
+	label string
+	get   func(p theme.Palette) string
+	set   func(p *theme.Palette, v string)
+}
+
+// themeEditorFields lists only the palette roles the TUI actually renders.
+// Palette.Background/CodeBackground are reserved for a future post-import
+// feature and have no visible effect here, so they're deliberately excluded
+// from the editor — showing an editable field that does nothing would be the
+// exact confusion this labeling is meant to fix.
+var themeEditorFields = []themeEditorField{
+	{"foreground", func(p theme.Palette) string { return p.Foreground }, func(p *theme.Palette, v string) { p.Foreground = v }},
+	{"border", func(p theme.Palette) string { return p.Border }, func(p *theme.Palette, v string) { p.Border = v }},
+	{"accent", func(p theme.Palette) string { return p.Accent }, func(p *theme.Palette, v string) { p.Accent = v }},
+	{"highlight", func(p theme.Palette) string { return p.Highlight }, func(p *theme.Palette, v string) { p.Highlight = v }},
+	{"error", func(p theme.Palette) string { return p.Error }, func(p *theme.Palette, v string) { p.Error = v }},
+	{"bar text", func(p theme.Palette) string { return p.BarText }, func(p *theme.Palette, v string) { p.BarText = v }},
+	{"dimmed", func(p theme.Palette) string { return p.Dimmed }, func(p *theme.Palette, v string) { p.Dimmed = v }},
+	{"self", func(p theme.Palette) string { return p.Self }, func(p *theme.Palette, v string) { p.Self = v }},
+	{"meta", func(p theme.Palette) string { return p.Meta }, func(p *theme.Palette, v string) { p.Meta = v }},
+}
+
+// hexDigits is the fixed width of each row's editable buffer — 6 hex digits,
+// the "#" itself is a fixed prompt and never part of the buffer.
+const hexDigits = 6
+
+// ThemeEditorModel is the "custom" theme color editor, opened as a modal
+// overlay from the theme picker. Each row is a fixed 6-character hex buffer
+// edited in overwrite mode (like a masked input): typing a character
+// replaces whatever is under the cursor and advances to the next slot, and
+// the cursor can't move past either end of the buffer.
+type ThemeEditorModel struct {
+	values        [9]string // each exactly hexDigits runes; ' ' marks an unset slot
+	cursor        int       // row cursor, 0..len(themeEditorFields)-1
+	editing       bool      // true while values[cursor] is being edited
+	charCursor    int       // position within values[cursor], 0..hexDigits-1
+	original      theme.Palette
+	width, height int
+	saved         bool
+	err           string
+}
+
+// padHex uppercases s and pads/truncates it to exactly hexDigits runes,
+// using ' ' for any missing trailing digits.
+func padHex(s string) string {
+	r := []rune(strings.ToUpper(s))
+	if len(r) > hexDigits {
+		r = r[:hexDigits]
+	}
+	for len(r) < hexDigits {
+		r = append(r, ' ')
+	}
+	return string(r)
+}
+
+// NewThemeEditorModel creates an editor prefilled with p (either the saved
+// custom palette, or the currently active theme's colors if none is saved yet).
+func NewThemeEditorModel(p theme.Palette) ThemeEditorModel {
+	// Normalize the 8 editable fields to uppercase up front, so the initial
+	// values (uppercased) match m.original exactly and IsDirty doesn't fire
+	// on a palette that was saved in lowercase.
+	for _, f := range themeEditorFields {
+		f.set(&p, strings.ToUpper(f.get(p)))
+	}
+	m := ThemeEditorModel{original: p}
+	for i, f := range themeEditorFields {
+		m.values[i] = padHex(strings.TrimPrefix(f.get(p), "#"))
+	}
+	return m
+}
+
+// hexValue returns row i's value as a full "#RRGGBB" string. Unset slots
+// (' ') make this fail ValidHex, exactly like a partially-typed field should.
+func (m ThemeEditorModel) hexValue(i int) string { return "#" + m.values[i] }
+
+// setChar overwrites the rune at pos in row's buffer.
+func (m *ThemeEditorModel) setChar(row, pos int, ch rune) {
+	r := []rune(m.values[row])
+	r[pos] = ch
+	m.values[row] = string(r)
+}
+
+// currentPalette builds a Palette from the raw (possibly invalid, mid-edit)
+// buffer values, starting from m.original so the reserved Background/
+// CodeBackground fields (not shown as editor rows) pass through unchanged.
+func (m ThemeEditorModel) currentPalette() theme.Palette {
+	p := m.original
+	for i, f := range themeEditorFields {
+		f.set(&p, m.hexValue(i))
+	}
+	return p
+}
+
+// livePreviewPalette is like currentPalette but substitutes any field that
+// isn't currently well-formed hex (e.g. mid-edit, unset slots) with its
+// last-known-good value, so partial input never reaches lipgloss as a
+// malformed color.
+func (m ThemeEditorModel) livePreviewPalette() theme.Palette {
+	p := m.currentPalette()
+	for i, f := range themeEditorFields {
+		if !theme.ValidHex(m.hexValue(i)) {
+			f.set(&p, f.get(m.original))
+		}
+	}
+	return p
+}
+
+// IsDirty reports whether any field differs from the last saved baseline.
+func (m ThemeEditorModel) IsDirty() bool { return m.currentPalette() != m.original }
+
+// IsValid reports whether every field is currently well-formed hex.
+func (m ThemeEditorModel) IsValid() bool { return m.currentPalette().Valid() }
+
+// SetSaved advances the baseline after a successful save.
+func (m ThemeEditorModel) SetSaved(p theme.Palette) ThemeEditorModel {
+	m.original = p
+	m.saved = true
+	m.err = ""
+	return m
+}
+
+func (m ThemeEditorModel) Init() tea.Cmd { return nil }
+
+func (m ThemeEditorModel) Update(msg tea.Msg) (ThemeEditorModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.editing {
+			return m.updateEditingKey(msg)
+		}
+
+		switch msg.String() {
+		case "up", "k":
+			m.cursor = (m.cursor - 1 + len(themeEditorFields)) % len(themeEditorFields)
+		case "down", "j":
+			m.cursor = (m.cursor + 1) % len(themeEditorFields)
+		case "enter":
+			m.editing = true
+			m.charCursor = 0
+			return m, nil
+		case "ctrl+s":
+			if m.IsDirty() {
+				if !m.IsValid() {
+					m.err = "all colors must be #RRGGBB"
+					return m, nil
+				}
+				p := m.currentPalette()
+				return m, func() tea.Msg { return SaveThemeMsg{Palette: p} }
+			}
+		case "esc":
+			return m, func() tea.Msg { return CloseThemeEditorMsg{} }
+		}
+	}
+	return m, nil
+}
+
+// updateEditingKey handles keystrokes while a row's hex buffer is focused:
+// left/right move the cursor within the 6 slots, backspace clears and steps
+// back, a typed alphanumeric rune overwrites the current slot (uppercased)
+// and advances — except on the last slot, which stays put since there's
+// nowhere further to advance to. enter/esc commit the field and return to
+// row navigation.
+func (m ThemeEditorModel) updateEditingKey(msg tea.KeyMsg) (ThemeEditorModel, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEnter, tea.KeyEsc:
+		m.editing = false
+		return m, nil
+	case tea.KeyLeft:
+		if m.charCursor > 0 {
+			m.charCursor--
+		}
+		return m, nil
+	case tea.KeyRight:
+		if m.charCursor < hexDigits-1 {
+			m.charCursor++
+		}
+		return m, nil
+	case tea.KeyBackspace:
+		if m.charCursor > 0 {
+			m.charCursor--
+		}
+		m.setChar(m.cursor, m.charCursor, ' ')
+		return m.previewCmd()
+	case tea.KeyRunes:
+		if len(msg.Runes) != 1 || !isAlnum(msg.Runes[0]) {
+			return m, nil
+		}
+		m.setChar(m.cursor, m.charCursor, upperRune(msg.Runes[0]))
+		if m.charCursor < hexDigits-1 {
+			m.charCursor++
+		}
+		return m.previewCmd()
+	}
+	return m, nil
+}
+
+// previewCmd clears transient save state and emits a PreviewPaletteMsg for
+// the buffer's current (possibly still mid-edit) contents.
+func (m ThemeEditorModel) previewCmd() (ThemeEditorModel, tea.Cmd) {
+	m.saved = false
+	m.err = ""
+	p := m.livePreviewPalette()
+	return m, func() tea.Msg { return PreviewPaletteMsg{Palette: p} }
+}
+
+func (m ThemeEditorModel) View() string {
+	var rows []string
+	rows = append(rows, theme.Title.Render("custom theme"))
+
+	for i, f := range themeEditorFields {
+		selected := m.cursor == i
+		var cursor string
+		if selected {
+			cursor = theme.Highlight.Render("▸ ")
+		} else {
+			cursor = "  "
+		}
+
+		labelStyle := theme.Base
+		if selected {
+			labelStyle = theme.Highlight
+		}
+		label := labelStyle.Render(f.label)
+
+		val := m.hexValue(i)
+		var swatch string
+		if theme.ValidHex(val) {
+			swatch = lipgloss.NewStyle().Background(lipgloss.Color(val)).Render("  ")
+		} else {
+			swatch = "  "
+		}
+
+		var value string
+		if selected && m.editing {
+			value = "#" + m.renderBuffer(i)
+		} else {
+			value = theme.Subtle.Render(val)
+		}
+
+		innerW := max(24, m.width-2)
+		content := swatch + " " + value
+		gap := max(1, innerW-lipgloss.Width(label)-lipgloss.Width(content))
+		rows = append(rows, cursor+label+strings.Repeat(" ", gap)+content)
+	}
+
+	var footer string
+	switch {
+	case m.err != "":
+		footer = theme.Error.Render("error: " + m.err)
+	case m.saved:
+		footer = theme.Highlight.Render("saved!")
+	case m.editing:
+		footer = theme.Subtle.Render("type · overwrite & advance   ←→ · move   enter/esc · commit")
+	case m.IsDirty():
+		footer = theme.Subtle.Render("ctrl+s · save   esc · close")
+	default:
+		footer = theme.Subtle.Render("enter · edit field   j/k · move   esc · close")
+	}
+	rows = append(rows, "", footer)
+
+	return theme.ActiveBorder.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}
+
+// renderBuffer renders row i's 6-slot hex buffer with the overwrite cursor
+// highlighted at m.charCursor. Unset slots (' ') show as "_" so the empty
+// positions are visible instead of collapsing to blank space.
+func (m ThemeEditorModel) renderBuffer(i int) string {
+	var sb strings.Builder
+	for pos, ch := range []rune(m.values[i]) {
+		display := string(ch)
+		if ch == ' ' {
+			display = "_"
+		}
+		style := theme.Base
+		if pos == m.charCursor {
+			style = theme.SelectedRow
+		}
+		sb.WriteString(style.Render(display))
+	}
+	return sb.String()
+}

--- a/internal/ui/screens/themeeditor_test.go
+++ b/internal/ui/screens/themeeditor_test.go
@@ -1,0 +1,171 @@
+package screens
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
+)
+
+func testPalette() theme.Palette {
+	return theme.Palette{
+		Foreground: "#111111", Border: "#222222", Accent: "#333333", Highlight: "#444444",
+		Error: "#555555", BarText: "#666666", Dimmed: "#777777", Self: "#888888", Meta: "#999999",
+	}
+}
+
+func runeMsg(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func TestThemeEditorModel_DirtyTracking(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	if m.IsDirty() {
+		t.Error("expected fresh editor to not be dirty")
+	}
+
+	m, _ = m.Update(keyMsg("enter")) // focus row 0
+	m, _ = m.Update(runeMsg("9"))
+	if !m.IsDirty() {
+		t.Error("expected editor to be dirty after editing a field")
+	}
+
+	m = m.SetSaved(m.currentPalette())
+	if m.IsDirty() {
+		t.Error("expected editor to not be dirty after SetSaved")
+	}
+}
+
+func TestThemeEditorModel_TypingOverwritesAndAdvances(t *testing.T) {
+	m := NewThemeEditorModel(testPalette()) // row 0 buffer starts "111111"
+	m, _ = m.Update(keyMsg("enter"))
+	if m.charCursor != 0 {
+		t.Fatalf("charCursor = %d, want 0 on entering edit mode", m.charCursor)
+	}
+
+	m, _ = m.Update(runeMsg("a"))
+	if m.values[0] != "A11111" {
+		t.Errorf("values[0] = %q, want %q", m.values[0], "A11111")
+	}
+	if m.charCursor != 1 {
+		t.Errorf("charCursor = %d, want 1 after typing", m.charCursor)
+	}
+
+	m, _ = m.Update(runeMsg("b"))
+	if m.values[0] != "AB1111" {
+		t.Errorf("values[0] = %q, want %q", m.values[0], "AB1111")
+	}
+	if m.charCursor != 2 {
+		t.Errorf("charCursor = %d, want 2 after typing", m.charCursor)
+	}
+}
+
+func TestThemeEditorModel_UppercasesLetters(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter"))
+	m, _ = m.Update(runeMsg("f"))
+	if got := m.values[0][:1]; got != "F" {
+		t.Errorf("typed 'f' stored as %q, want uppercase %q", got, "F")
+	}
+}
+
+func TestThemeEditorModel_LastSlotDoesNotAdvancePastEnd(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter"))
+	for range hexDigits - 1 {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	}
+	if m.charCursor != hexDigits-1 {
+		t.Fatalf("charCursor = %d, want %d (last slot)", m.charCursor, hexDigits-1)
+	}
+
+	m, _ = m.Update(runeMsg("9"))
+	if m.charCursor != hexDigits-1 {
+		t.Errorf("charCursor = %d after typing on last slot, want it to stay at %d", m.charCursor, hexDigits-1)
+	}
+	if m.values[0][hexDigits-1] != '9' {
+		t.Errorf("last slot = %q, want overwritten with '9'", m.values[0][hexDigits-1:])
+	}
+
+	// One more right press beyond the last slot must not move the cursor further.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if m.charCursor != hexDigits-1 {
+		t.Errorf("charCursor = %d after right at last slot, want clamped at %d", m.charCursor, hexDigits-1)
+	}
+}
+
+func TestThemeEditorModel_CursorClampedAtStart(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter"))
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if m.charCursor != 0 {
+		t.Errorf("charCursor = %d after left at start, want clamped at 0", m.charCursor)
+	}
+}
+
+func TestThemeEditorModel_Backspace_ClearsAndStepsBack(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter"))
+	m, _ = m.Update(runeMsg("a")) // charCursor now 1, slot 0 = 'A'
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if m.charCursor != 0 {
+		t.Errorf("charCursor = %d after backspace, want 0", m.charCursor)
+	}
+	if m.values[0][0] != ' ' {
+		t.Errorf("values[0][0] = %q, want cleared to space", string(m.values[0][0]))
+	}
+}
+
+func TestThemeEditorModel_CtrlS_EmitsSaveThemeMsg_WhenValidAndDirty(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter"))
+	m, _ = m.Update(runeMsg("9"))
+	m, _ = m.Update(keyMsg("enter")) // commit field, back to nav mode
+
+	_, cmd := m.Update(keyMsg("ctrl+s"))
+	if cmd == nil {
+		t.Fatal("expected a cmd from ctrl+s")
+	}
+	msg := cmd()
+	if _, ok := msg.(SaveThemeMsg); !ok {
+		t.Errorf("expected SaveThemeMsg, got %T", msg)
+	}
+}
+
+func TestThemeEditorModel_CtrlS_NoOp_WhenInvalid(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter"))
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace}) // clears slot 0, leaving a blank — malformed hex
+	m, _ = m.Update(keyMsg("enter"))                    // commit field, back to nav mode
+
+	m, cmd := m.Update(keyMsg("ctrl+s"))
+	if cmd != nil {
+		t.Error("expected no cmd from ctrl+s with invalid input")
+	}
+	if m.err == "" {
+		t.Error("expected err to be set")
+	}
+}
+
+func TestThemeEditorModel_Esc_EmitsCloseThemeEditorMsg(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	_, cmd := m.Update(keyMsg("esc"))
+	if cmd == nil {
+		t.Fatal("expected a cmd from esc")
+	}
+	if _, ok := cmd().(CloseThemeEditorMsg); !ok {
+		t.Errorf("expected CloseThemeEditorMsg, got %T", cmd())
+	}
+}
+
+func TestThemeEditorModel_Editing_IgnoresNonAlnumRunes(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter"))
+	m, _ = m.Update(runeMsg("!"))
+	if m.values[0] != "111111" {
+		t.Errorf("values[0] = %q, want unchanged %q after non-alnum keypress", m.values[0], "111111")
+	}
+	if m.charCursor != 0 {
+		t.Errorf("charCursor = %d, want 0 (non-alnum keypress should not advance)", m.charCursor)
+	}
+}

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -1,6 +1,10 @@
 package theme
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"regexp"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // Layout constants — shared across app and screens so viewport heights
 // are calculated from a single source of truth rather than magic numbers.
@@ -20,6 +24,10 @@ func CurrentName() string {
 }
 
 // Color vars — reassigned by Set(). Named after the default Cyber palette.
+// ColorWhite drives only MeHighlight (own-username highlighting); ColorMeta
+// drives the status bar's secondary info text and hint key-descriptions —
+// a distinct role that happens to share the same hex value in every
+// built-in theme today, but can diverge in a custom theme.
 var (
 	ColorGreen      = lipgloss.Color("#00FF41")
 	ColorDimGreen   = lipgloss.Color("#007A1F")
@@ -29,6 +37,7 @@ var (
 	ColorBackground = lipgloss.Color("#0D0D0D")
 	ColorMuted      = lipgloss.Color("#888888")
 	ColorWhite      = lipgloss.Color("#E0E0E0")
+	ColorMeta       = lipgloss.Color("#E0E0E0")
 )
 
 var (
@@ -123,7 +132,7 @@ var (
 )
 
 // Set applies the named theme by reassigning all color and style vars.
-// Valid names: "cyber" (default), "c64", "vt320", "bland".
+// Valid names: "cyber" (default), "c64", "vt320", "bland", "custom".
 // Unknown or empty names fall back to "cyber".
 func Set(name string) {
 	switch name {
@@ -136,10 +145,110 @@ func Set(name string) {
 	case "bland":
 		currentName = "bland"
 		setBland()
+	case "custom":
+		currentName = "custom"
+		applyPalette(customPalette)
 	default:
 		currentName = "cyber"
 		setCyber()
 	}
+}
+
+// Palette is the set of colors a theme is built from, named after the UI
+// role each one drives rather than the color itself — so the theme editor
+// and ~/.cyber-tui.json read as "what does this control" instead of raw
+// color names. It's the data-driven counterpart to the literal
+// setCyber/setC64/etc. themes, used for the user-editable "custom" theme and
+// exposed so other packages (the theme editor screen, and a future "detect
+// theme in a post" feature) can build and inspect palettes without reaching
+// into theme's internals.
+//
+// Background and CodeBackground are not rendered anywhere in the TUI today —
+// there is no fillable full-screen background or code-block background —
+// but are kept so a future post-import can carry those two post fields
+// through without losing them. They're excluded from the theme editor's
+// rows and from Valid()'s required fields.
+type Palette struct {
+	Foreground string // primary body text, markdown emphasis — matches a post's "Foreground"
+	Dimmed     string // secondary/subtle text, strikethrough, separators — matches "Dimmed"
+	Border     string // inactive borders, tab bar, code gutters — matches "Border"
+	Accent     string // titles, links, active border/tab — no post equivalent
+	Highlight  string // @mentions and code text — matches a post's "Code"
+	Error      string // error messages/banner — no post equivalent
+	BarText    string // text on colored bars: status bar, logo badge, notify banner — no post equivalent
+	Self       string // your own username highlight — no post equivalent
+	Meta       string // status bar secondary info text & hint key-descriptions — no post equivalent
+
+	// Reserved, unused by the TUI's renderer today; see doc comment above.
+	Background     string // matches a post's "Background"
+	CodeBackground string // matches a post's "Code BG"
+}
+
+var hexColorRe = regexp.MustCompile(`^#[0-9A-Fa-f]{6}$`)
+
+// ValidHex reports whether s is a well-formed "#RRGGBB" hex color.
+func ValidHex(s string) bool { return hexColorRe.MatchString(s) }
+
+// validHexOrEmpty reports whether s is either empty or a well-formed hex
+// color — used for the reserved fields, which are optional.
+func validHexOrEmpty(s string) bool { return s == "" || ValidHex(s) }
+
+// Valid reports whether every rendered field of p is a well-formed hex
+// color. The reserved Background/CodeBackground fields are optional.
+func (p Palette) Valid() bool {
+	return ValidHex(p.Foreground) && ValidHex(p.Dimmed) && ValidHex(p.Border) &&
+		ValidHex(p.Accent) && ValidHex(p.Highlight) && ValidHex(p.Error) &&
+		ValidHex(p.BarText) && ValidHex(p.Self) && ValidHex(p.Meta) &&
+		validHexOrEmpty(p.Background) && validHexOrEmpty(p.CodeBackground)
+}
+
+// customPalette is the last palette set via SetCustomPalette, applied when
+// Set("custom") is called.
+var customPalette Palette
+
+// SetCustomPalette stores p as the "custom" theme's palette. If "custom" is
+// the currently active theme, it re-applies immediately for live preview.
+func SetCustomPalette(p Palette) {
+	customPalette = p
+	if currentName == "custom" {
+		applyPalette(p)
+	}
+}
+
+// CurrentPalette returns the colors currently active as a Palette — used to
+// prefill the theme editor, and by a future post-theme-detection feature to
+// inspect what's on screen right now. The reserved Background/CodeBackground
+// fields have no driving Color var, so they're carried over from the stored
+// custom palette (empty if none has ever set them).
+func CurrentPalette() Palette {
+	return Palette{
+		Foreground:     string(ColorGreen),
+		Dimmed:         string(ColorMuted),
+		Border:         string(ColorDimGreen),
+		Accent:         string(ColorCyan),
+		Highlight:      string(ColorYellow),
+		Error:          string(ColorRed),
+		BarText:        string(ColorBackground),
+		Self:           string(ColorWhite),
+		Meta:           string(ColorMeta),
+		Background:     customPalette.Background,
+		CodeBackground: customPalette.CodeBackground,
+	}
+}
+
+// applyPalette sets the rendered color vars from p's driven fields and
+// rebuilds all styles. Background/CodeBackground have no Color var to drive.
+func applyPalette(p Palette) {
+	ColorGreen = lipgloss.Color(p.Foreground)
+	ColorDimGreen = lipgloss.Color(p.Border)
+	ColorCyan = lipgloss.Color(p.Accent)
+	ColorYellow = lipgloss.Color(p.Highlight)
+	ColorRed = lipgloss.Color(p.Error)
+	ColorBackground = lipgloss.Color(p.BarText)
+	ColorMuted = lipgloss.Color(p.Dimmed)
+	ColorWhite = lipgloss.Color(p.Self)
+	ColorMeta = lipgloss.Color(p.Meta)
+	applyStyles()
 }
 
 func setCyber() {
@@ -151,6 +260,7 @@ func setCyber() {
 	ColorBackground = lipgloss.Color("#0D0D0D")
 	ColorMuted = lipgloss.Color("#888888")
 	ColorWhite = lipgloss.Color("#E0E0E0")
+	ColorMeta = lipgloss.Color("#E0E0E0")
 	applyStyles()
 }
 
@@ -165,6 +275,7 @@ func setC64() {
 	ColorBackground = lipgloss.Color("#3535CE") // C64 cobalt blue (background)
 	ColorMuted = lipgloss.Color("#6B69C4")      // dimmed blue-purple (subtle text)
 	ColorWhite = lipgloss.Color("#FFFFFF")
+	ColorMeta = lipgloss.Color("#FFFFFF")
 	applyStyles()
 }
 
@@ -178,6 +289,7 @@ func setVT320() {
 	ColorBackground = lipgloss.Color("#1A1200") // near-black amber background
 	ColorMuted = lipgloss.Color("#6B4800")      // very dim amber (subtle text)
 	ColorWhite = lipgloss.Color("#FFECB3")      // cream
+	ColorMeta = lipgloss.Color("#FFECB3")       // cream
 	applyStyles()
 }
 
@@ -195,6 +307,7 @@ func setBland() {
 	ColorBackground = lipgloss.Color("")
 	ColorMuted = lipgloss.Color("")
 	ColorWhite = lipgloss.Color("")
+	ColorMeta = lipgloss.Color("")
 	applyStyles()
 
 	ActiveBorder = ActiveBorder.BorderStyle(lipgloss.ThickBorder())

--- a/internal/ui/theme/theme_test.go
+++ b/internal/ui/theme/theme_test.go
@@ -78,3 +78,91 @@ func TestSet_StylesRebuildOnThemeChange(t *testing.T) {
 		t.Error("Base foreground should differ between cyber and c64 themes")
 	}
 }
+
+func TestValidHex(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"#00FF41", true},
+		{"#abcdef", true},
+		{"00FF41", false},
+		{"#0G0000", false},
+		{"#FFF", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := ValidHex(c.in); got != c.want {
+			t.Errorf("ValidHex(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func testPalette9() Palette {
+	return Palette{
+		Foreground: "#111111", Dimmed: "#222222", Border: "#333333", Accent: "#444444",
+		Highlight: "#555555", Error: "#666666", BarText: "#777777", Self: "#888888", Meta: "#999999",
+	}
+}
+
+func TestPalette_Valid(t *testing.T) {
+	valid := testPalette9()
+	if !valid.Valid() {
+		t.Error("expected fully hex palette to be valid")
+	}
+	invalid := valid
+	invalid.Accent = "not-a-color"
+	if invalid.Valid() {
+		t.Error("expected palette with malformed field to be invalid")
+	}
+}
+
+func TestPalette_Valid_ReservedFieldsOptional(t *testing.T) {
+	p := testPalette9() // Background/CodeBackground left empty
+	if !p.Valid() {
+		t.Error("expected palette with empty reserved fields to be valid")
+	}
+	p.Background = "not-a-color"
+	if p.Valid() {
+		t.Error("expected palette with malformed reserved field to be invalid")
+	}
+}
+
+func TestSet_Custom_AppliesStoredPalette(t *testing.T) {
+	p := testPalette9()
+	SetCustomPalette(p)
+	Set("custom")
+	if ColorGreen != lipgloss.Color(p.Foreground) {
+		t.Errorf("ColorGreen = %q, want %q", ColorGreen, p.Foreground)
+	}
+	if ColorBackground != lipgloss.Color(p.BarText) {
+		t.Errorf("ColorBackground = %q, want %q", ColorBackground, p.BarText)
+	}
+	if CurrentName() != "custom" {
+		t.Errorf("CurrentName() = %q, want custom", CurrentName())
+	}
+}
+
+func TestSetCustomPalette_LivePreviewWhenActive(t *testing.T) {
+	p1 := testPalette9()
+	Set("cyber")
+	SetCustomPalette(p1)
+	Set("custom")
+
+	p2 := Palette{
+		Foreground: "#aaaaaa", Dimmed: "#bbbbbb", Border: "#cccccc", Accent: "#dddddd",
+		Highlight: "#eeeeee", Error: "#111111", BarText: "#222222", Self: "#333333", Meta: "#444444",
+	}
+	SetCustomPalette(p2)
+	if ColorGreen != lipgloss.Color(p2.Foreground) {
+		t.Errorf("ColorGreen = %q, want live-updated %q", ColorGreen, p2.Foreground)
+	}
+}
+
+func TestCurrentPalette_RoundTrips(t *testing.T) {
+	Set("cyber")
+	p := CurrentPalette()
+	if p.Foreground != "#00FF41" || p.BarText != "#0D0D0D" {
+		t.Errorf("CurrentPalette() = %+v, want cyber's literal hex values", p)
+	}
+}


### PR DESCRIPTION
﻿## Summary
Adds a 5th, user-editable "custom" theme alongside cyber/c64/vt320/bland, built and saved entirely from the TUI.

- **Theme engine** (`internal/ui/theme/theme.go`): `Palette` type with role-named fields (`Foreground`, `Dimmed`, `Border`, `Accent`, `Highlight`, `Error`, `BarText`, `Self`, `Meta`) rather than raw color names, plus `SetCustomPalette`/`CurrentPalette`/`ValidHex`. Two reserved fields (`Background`, `CodeBackground`) are carried through for a future "detect a theme from a post" feature but not rendered or editable yet.
- **Theme editor** (`internal/ui/screens/themeeditor.go`): modal opened with `e` on the theme picker's "custom" row. Each color is a fixed 6-digit hex buffer edited in overwrite mode — typing overwrites the slot under the cursor, uppercases automatically, and advances (except on the last slot). Live preview, `ctrl+s` to save, `esc` to revert.
- **Persistence**: `Config.CustomPalette` round-trips through `~/.cyber-tui.json`; no-ops for ephemeral SSH sessions like every other config write.
- **Docs**: new `docs/40-custom-themes.md`, updated `docs/00-project-reference.md`.

## Design notes
- `Self` and `Meta` were originally one field (backed by `ColorWhite`) until it turned out to drive both the own-username highlight and unrelated status bar text — split so each editor row controls exactly one thing. All 4 built-in themes initialize both to the same hex, so no visual change there.
- Post-theme-detection (parsing a cyberspace.online post's theme block and applying it) is intentionally out of scope here; the design notes in `docs/40-custom-themes.md` capture the resolution plan for when that's built.

## Testing
- `go build ./...`, `go test ./...`, `go vet ./...`, `staticcheck ./...` all clean.
- Not yet click-tested end-to-end in a live terminal session — unit-level behavior only.

## Definition of Done checklist
- [x] Unit tests pass
- [x] No linter warnings (`go vet`, `staticcheck`)
- [x] Documented (`docs/40-custom-themes.md`, `docs/00-project-reference.md` updated)
- [x] Manual smoke test in a live terminal
