### PR TITLE
feat: apply a theme detected in a post

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -624,6 +624,7 @@ Color palettes and Lip Gloss style objects for four retro themes, plus a user-ed
 | `(Palette) Valid() bool` | Reports whether the 9 rendered fields of a `Palette` are well-formed hex (`Background`/`CodeBackground` are optional) |
 | `SetCustomPalette(p Palette)` | Stores `p` as the "custom" theme's palette; re-applies immediately if "custom" is already active (live preview) |
 | `CurrentPalette() Palette` | Returns the colors currently active, as a `Palette` |
+| `ParsePost(content string) (Palette, bool)` | Detects and parses a cyberspace.online custom-theme post block; `ok=false` only when no block is found. See `docs/40-custom-themes.md`. |
 
 **`Palette` type:** the data-driven counterpart to the literal `setCyber`/`setC64`/etc. themes, named by UI role rather than color so the theme editor and config file read as "what does this control": `Foreground`, `Dimmed`, `Border`, `Accent`, `Highlight`, `Error`, `BarText`, `Self`, `Meta` (all rendered; map internally to `ColorGreen`, `ColorMuted`, `ColorDimGreen`, `ColorCyan`, `ColorYellow`, `ColorRed`, `ColorBackground`, `ColorWhite`, `ColorMeta` respectively), plus `Background`/`CodeBackground` (reserved, unused by the renderer today, hidden from the editor). `Self` and `Meta` were one field until `ColorWhite` turned out to drive both the own-username highlight and unrelated status-bar text — split so each row controls exactly one thing. Used by the "custom" theme (edited in-TUI, see `docs/40-custom-themes.md`) and exposed for a future "detect theme in a post" feature to build/inspect palettes without touching `theme`'s internals — see that doc's post-field mapping table.
 
@@ -829,6 +830,7 @@ cycle), not a global shortcut.
 | `p` | View author's profile |
 | `c` | Start C-Mail conversation with focused author |
 | `w` | Watch / unwatch the thread (root post focused only; no-op on replies) |
+| `T` | Preview a theme detected in the post's body (root post focused only) — opens the theme editor prefilled from it; hint only shown when one is detected. See `docs/40-custom-themes.md`. |
 | `esc` | Back to feed |
 
 ### Compose

--- a/docs/40-custom-themes.md
+++ b/docs/40-custom-themes.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-Alongside the 4 built-in themes (cyber, c64, vt320, bland), users can build and save their own "custom" theme from inside the TUI. The custom theme is an 8-color palette, edited via a modal opened from the existing theme picker (`t`), and persisted to `~/.cyber-tui.json`.
+Alongside the 4 built-in themes (cyber, c64, vt320, bland), users can build and save their own "custom" theme from inside the TUI. The custom theme is a palette edited via a modal opened from the existing theme picker (`t`), and persisted to `~/.cyber-tui.json`.
 
-This is out of scope but adjacent: users on cyberspace.online post custom themes as formatted text blocks (base theme + hex colors + some webui-only font/effect fields). A future feature will detect one of these blocks in a post (post detail screen) and apply it via a shortcut. `theme.SetCustomPalette`/`theme.CurrentPalette` are the intended entry point for that feature — see Design Notes below.
+Users on cyberspace.online also post custom themes as formatted text blocks (base theme + hex colors + some webui-only font/effect fields). Post Detail's `T` key detects one of these blocks and opens the same theme editor prefilled from it, so trying it out and saving/canceling both reuse the manual editor's existing preview/save/revert contract — see Post Theme Import below.
 
 ---
 
@@ -26,9 +26,18 @@ theme.Set(cfg.Theme)
 1. `t` opens the theme picker (`App.themePickerOpen`), listing `availableThemes = []string{"cyber", "c64", "vt320", "bland", "custom"}`.
 2. `↑`/`↓` previews each theme live. On the "custom" row, this only applies if a palette has already been saved (`App.customPalette != nil`) — otherwise the current theme stays put.
 3. `e` on the "custom" row opens the editor (`App.themeEditorOpen`), prefilled from the saved palette if one exists, otherwise from `theme.CurrentPalette()` (whatever theme is currently active).
-4. In the editor: `j`/`k` moves between the 8 color rows, `enter` focuses a row's 6-digit hex buffer. Each row shows a fixed, non-removable `#` followed by 6 editable slots. Typing an alphanumeric character overwrites the slot under the cursor (uppercased automatically) and advances to the next slot — except on the last slot, where the cursor stays put since there's nowhere further to go. `←`/`→` move the cursor within the 6 slots (clamped at both ends); `backspace` clears the current slot and steps back. `enter`/`esc` commits the field and returns to row navigation. Every edit emits `screens.PreviewPaletteMsg`, which `App.handleThemeEditor` applies via `theme.SetCustomPalette` + `refreshViewports()` for live preview.
-5. `ctrl+s` (when dirty and all 8 fields are valid `#RRGGBB`) emits `screens.SaveThemeMsg`. `App.handleThemeEditor` updates `App.customPalette` and persists via `saveConfig` (sets both `cfg.Theme = "custom"` and `cfg.CustomPalette`).
-6. `esc` (row-nav mode) emits `screens.CloseThemeEditorMsg`, which reverts to the theme that was active before the editor opened (`App.themeEditorOrig`) and closes without saving.
+4. In the editor: `j`/`k` moves between the 9 color rows, `enter` focuses a row's 6-digit hex buffer. Each row shows a fixed, non-removable `#` followed by 6 editable slots. Typing an alphanumeric character overwrites the slot under the cursor (uppercased automatically) and advances to the next slot — except on the last slot, where the cursor stays put since there's nowhere further to go. `←`/`→` move the cursor within the 6 slots (clamped at both ends); `backspace` clears the current slot and steps back. `enter`/`esc` commits the field and returns to row navigation. Every edit emits `screens.PreviewPaletteMsg`, which `App.handleThemeEditor` applies via `theme.SetCustomPalette` + `refreshViewports()` for live preview.
+5. `ctrl+s` (when dirty and all 9 fields are valid `#RRGGBB`) emits `screens.SaveThemeMsg`. `App.handleThemeEditor` updates `App.customPalette` and persists via `saveConfig` (sets both `cfg.Theme = "custom"` and `cfg.CustomPalette`).
+6. `esc` (row-nav mode) emits `screens.CloseThemeEditorMsg`, which reverts to the theme that was active before the editor opened (`App.themeEditorOrig`) and closes without saving. If that theme was `"custom"`, the revert also restores `App.themeEditorOrigPalette` — a snapshot of `theme.CurrentPalette()` taken *before* the preview started — into `theme.customPalette` first; without this, `theme.Set("custom")` alone would just re-apply whatever the abandoned edit left in that shared package-level variable instead of the actual prior saved colors. (This was a real bug in the first version of this feature, fixed alongside Post Theme Import below since that entry path needs the same correct revert.)
+
+### Post Theme Import
+
+1. `PostDetailModel.SetPost` calls `theme.ParsePost(post.Content)` once per post load (not per keystroke) and stores the result in `postTheme *theme.Palette` (nil if no theme block was detected). `HasThemeInPost()` exposes this for the `T` hint (shown in the footer and help modal only when a block was found) and both layouts' `screenHints`.
+2. `T`, pressed with the post itself focused (not a reply) and a block detected, emits `screens.PreviewPostThemeMsg{Palette}`.
+3. `App`'s handler snapshots `themeEditorOrig`/`themeEditorOrigPalette` (as above), then previews and opens the theme editor exactly like the picker's `e` key — but prefilled from the parsed post palette instead of the current theme. From here it's the same editor: review the swatches, tweak anything, `ctrl+s` to keep it (persists as the new custom theme and activates it) or `esc` to cancel (reverts fully to whatever was active before).
+4. Detection is post-body only, not replies — matches how these blocks are actually shared (their own top-level post) and keeps parsing a one-time cost per post load.
+
+See `theme.ParsePost`'s doc comment and the post-field mapping table below for how the block's fields resolve.
 
 ### Ephemeral (SSH) Sessions
 
@@ -61,13 +70,16 @@ func ValidHex(s string) bool
 func (p Palette) Valid() bool     // the 9 rendered fields required; Background/CodeBackground optional
 func SetCustomPalette(p Palette)
 func CurrentPalette() Palette
+func ParsePost(content string) (Palette, bool)
 ```
 
 `Self` and `Meta` were originally one field (`Self`, backed by `ColorWhite`) until it turned out to drive two unrelated things: own-username highlighting *and* the status bar's secondary text/hint descriptions. Split so each row controls exactly one thing — `ColorMeta` is a separate color var from `ColorWhite`, initialized to the same literal in every built-in theme (so no visual change there), letting only custom themes differentiate them.
 
-### Post-field mapping
+`builtinPalettes map[string]Palette` (unexported) holds each of the 4 built-ins' full color set as data — the single source of truth `setCyber`/`setC64`/`setVT320`/`setBland` apply from (`applyPalette(builtinPalettes["cyber"])`, etc.), and what lets `ParsePost` read a named built-in's colors without switching the live theme.
 
-Fields are named to line up with the theme blocks users post on cyberspace.online (see Overview), so a future "detect theme in a post" feature can map them directly:
+### `ParsePost` — detecting a theme block in a post
+
+Fields are named to line up with the theme blocks users post on cyberspace.online (see Overview), so parsing maps them directly:
 
 | Post field | `Palette` field | Notes |
 |---|---|---|
@@ -77,7 +89,13 @@ Fields are named to line up with the theme blocks users post on cyberspace.onlin
 | `Border` | `Border` | |
 | `Code` | `Highlight` | The TUI already renders code block/span text in the same color as `@mention` highlights |
 | `Code BG` | `CodeBackground` | Reserved — no code-block background rendering exists yet |
-| *(no post field)* | `Accent`, `Error`, `BarText`, `Self`, `Meta` | TUI-only roles with no webui-post equivalent; a post-import would leave these at whatever the base theme already has |
+| *(no post field)* | `Accent`, `Error`, `BarText`, `Self`, `Meta` | TUI-only roles with no webui-post equivalent; resolved from the base theme (see below) |
+
+`ParsePost(content string) (Palette, bool)`:
+1. Looks for the marker line (`/* Cyberspace Custom Theme */`, case-insensitive substring match). Absent → `ok=false`; nothing else matters.
+2. Scans up to 30 lines after the marker for `Key: value` lines (case-insensitive key match); everything not in the table above (`Main Font`, `Disable Text Glow`, etc. — webui-only, no `Palette` field) is simply never matched, no special-casing needed to ignore it.
+3. Resolves the base palette: if `Base Theme` names one of our own built-ins (`cyber`/`c64`/`vt320`/`bland`, case-insensitive) → `builtinPalettes[name]`, the actual author-intended values for the unmapped fields; otherwise → `CurrentPalette()` (today's active theme), since inventing values for an unrecognized name would just be guessing.
+4. Overlays each recognized color field onto the base **only if `ValidHex` passes** — a malformed or missing individual field silently falls back to the base's value rather than invalidating the whole block (a typo in one line shouldn't discard an otherwise-good theme). `ok=true` as long as the marker was found, even in this degenerate case.
 
 ```go
 // internal/config
@@ -107,6 +125,7 @@ type Config struct {
 | `enter`/`esc` | editor (editing) | Commit the field, back to row nav |
 | `ctrl+s` | editor (row nav) | Save custom palette |
 | `esc` | editor (row nav) | Close without saving, revert theme |
+| `T` | Post Detail, post focused (not a reply) | Preview a detected post theme — opens the editor prefilled from it, when `HasThemeInPost()` |
 
 ---
 
@@ -118,19 +137,10 @@ Same as the Settings screen: edits accumulate in memory (with live preview) unti
 
 ## Design Notes
 
-- **Editor is a modal, not a tab.** It's a sub-action of the theme picker (already a modal with live-preview/overlay plumbing built), not an independent destination — adding a tab would mean a new `screen` const, mnemonic, and renumbering across two layouts for no benefit.
-- **Prefill from the active theme**, not blank fields — matches the picker's existing "start from what's on screen" model and means all 8 fields are valid immediately, so `ctrl+s` isn't blocked on first use.
-- **Future "detect theme in a post" feature**: call `theme.SetCustomPalette(p)` to preview a parsed palette and `theme.CurrentPalette()` to compare against what's currently active. No further hooks are needed in `theme` for that feature to build on.
-
-### Future: resolving unmapped fields when importing a post's theme
-
-A post always declares a `Base Theme:` name alongside its explicit colors (see Overview). The post's colors only ever cover `Foreground`, `Background`, `Dimmed`, `Border`, and `Code` (→ `Highlight`) — see the post-field mapping table above. That leaves `Accent`, `Error`, `Self`, `Meta`, and `CodeBackground` with nothing to import from the post itself. Resolution order for those, decided but not yet built:
-
-1. **If the post's `Base Theme` matches one of our own built-in themes** (`cyber`, `c64`, `vt320`, `bland`, case-insensitive) — prefill from *that* theme's full palette. We have the actual author-intended values for the unmapped fields sitting in `theme.go`; there's no reason to discard them for a guess.
-2. **If the name doesn't match a known built-in** (a webui-only theme, a typo, a future theme not yet ported to the TUI) — prefill from `theme.CurrentPalette()` (today's active theme) instead, since inventing values for an unrecognized theme would just be guessing. This mirrors the manual editor's own prefill behavior (`e` on the picker's "custom" row).
-3. Either way, overlay the post's explicit fields on top of whichever base was chosen in step 1 or 2.
-
-**Prerequisite refactor**: step 1 needs a way to read a built-in theme's palette *without* switching to it — `setCyber`/`setC64`/`setVT320`/`setBland` currently only mutate the live `ColorX` vars imperatively, with no way to hand back "what vt320's colors are" short of actually activating vt320 (an unwanted side effect mid-import). The fix is to pull each built-in's hex literals out into a named `Palette` value (e.g. `var vt320Palette = Palette{Foreground: "#FFB000", ...}`) and have `setVT320()` call `applyPalette(vt320Palette)` — a single source of truth instead of literals duplicated across `setX()` and a second lookup table, and it gives the post-import feature its lookup for free. `bland` fits trivially (its palette is all-empty strings); its extra Bold/Underline/border-weight tweaks stay separate imperative code, since those aren't part of `Palette`.
+- **Editor is a modal, not a tab.** It's a sub-action of the theme picker (already a modal with live-preview/overlay plumbing built), not an independent destination — adding a tab would mean a new `screen` const, mnemonic, and renumbering across two layouts for no benefit. Post Theme Import reuses the same modal rather than building a second one.
+- **Prefill from the active theme**, not blank fields — matches the picker's existing "start from what's on screen" model and means all 9 fields are valid immediately, so `ctrl+s` isn't blocked on first use. Post Theme Import follows the same principle, just prefilling from the parsed post palette instead.
+- **Post Theme Import reuses the theme editor wholesale** rather than a bespoke confirm/cancel dialog: `T` just opens `ThemeEditorModel` prefilled differently. This gives the user the ability to tweak a color they don't like before committing, for free, and means there's exactly one preview/save/revert implementation to maintain instead of two.
+- **The revert-on-cancel bug**: the first version of the theme editor only stored `themeEditorOrig` (a theme *name*) for reverting on `esc`. When that name was `"custom"`, reverting just called `theme.Set("custom")`, which re-applies whatever `theme.customPalette` currently holds — but live-preview edits (from either the manual editor or a post-theme preview) mutate that same package-level variable, so an abandoned edit was left applied instead of the actual prior saved colors. Fixed by also snapshotting `themeEditorOrigPalette := theme.CurrentPalette()` at the moment preview starts, and restoring it via `theme.SetCustomPalette(...)` before `theme.Set("custom")` on cancel.
 
 ---
 
@@ -142,4 +152,6 @@ A post always declares a `Base Theme:` name alongside its explicit colors (see O
 - [x] Wired into theme picker (`e` to edit/create) in both layouts (tabs, miller)
 - [x] Live preview while editing
 - [x] Ephemeral (SSH) sessions: editing works, persistence no-ops
-- [ ] Detect a theme block in a post and apply it (future feature, out of scope here)
+- [x] `builtinPalettes` data table + `theme.ParsePost` (detects and resolves a post's theme block)
+- [x] Post Detail's `T` key + `HasThemeInPost()` hint, wired into both layouts
+- [x] Revert-on-cancel bug fixed (`themeEditorOrigPalette` snapshot), covered by a regression test

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -111,10 +111,18 @@ type App struct {
 	themePickerOrig   string // theme name when picker was opened (for Esc revert)
 
 	// themeEditor state — opened from the theme picker with 'e' on the
-	// "custom" row, closed by SaveThemeMsg/CloseThemeEditorMsg.
+	// "custom" row (or from Post Detail's try-theme key), closed by
+	// SaveThemeMsg/CloseThemeEditorMsg.
 	themeEditorOpen bool
 	themeEditor     screens.ThemeEditorModel
 	themeEditorOrig string // theme name before entering the editor, for close-without-save revert
+	// themeEditorOrigPalette is a CurrentPalette() snapshot taken at the same
+	// moment as themeEditorOrig, before the editor's preview starts mutating
+	// theme's package-level customPalette. Needed to correctly revert when
+	// themeEditorOrig == "custom": theme.Set("custom") alone would just
+	// re-apply whatever the abandoned edit left in that shared variable
+	// instead of the palette that was actually active before previewing.
+	themeEditorOrigPalette theme.Palette
 
 	// customPalette is the persisted custom theme, loaded from config. Nil
 	// means the user has never saved one yet.
@@ -1141,6 +1149,20 @@ func (a App) handleThemeEditor(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.refreshViewports()
 		return a, nil, true
 
+	case screens.PreviewPostThemeMsg:
+		// Same contract as the picker's 'e' key, but prefilled from a
+		// detected post theme instead of the current theme/saved custom
+		// palette: snapshot for correct revert, preview live, hand off to
+		// the theme editor so the user can review/tweak before ctrl+s.
+		a.themeEditorOrig = theme.CurrentName()
+		a.themeEditorOrigPalette = theme.CurrentPalette()
+		theme.SetCustomPalette(msg.Palette)
+		theme.Set("custom")
+		a.refreshViewports()
+		a.themeEditorOpen = true
+		a.themeEditor = screens.NewThemeEditorModel(msg.Palette)
+		return a, nil, true
+
 	case screens.SaveThemeMsg:
 		p := msg.Palette
 		a.themeEditor = a.themeEditor.SetSaved(p)
@@ -1157,6 +1179,13 @@ func (a App) handleThemeEditor(msg tea.Msg) (App, tea.Cmd, bool) {
 
 	case screens.CloseThemeEditorMsg:
 		a.themeEditorOpen = false
+		if a.themeEditorOrig == "custom" {
+			// Restore the snapshot taken before preview started — the
+			// abandoned edit has left theme's package-level customPalette
+			// dirty, so Set("custom") alone would reapply that instead of
+			// what was actually active before the editor opened.
+			theme.SetCustomPalette(a.themeEditorOrigPalette)
+		}
 		theme.Set(a.themeEditorOrig)
 		a.refreshViewports()
 		return a, nil, true
@@ -1946,10 +1975,11 @@ func (a App) handleThemePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if a.customPalette != nil {
 			prefill = *a.customPalette
 		}
+		a.themeEditorOrig = a.themePickerOrig
+		a.themeEditorOrigPalette = theme.CurrentPalette() // snapshot before preview, for correct revert
 		theme.SetCustomPalette(prefill)
 		theme.Set("custom")
 		a.refreshViewports()
-		a.themeEditorOrig = a.themePickerOrig
 		a.themePickerOpen = false
 		a.themeEditorOpen = true
 		a.themeEditor = screens.NewThemeEditorModel(prefill)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ragnar/cyber-tui/internal/model"
 	"github.com/ragnar/cyber-tui/internal/ui/imgview"
 	"github.com/ragnar/cyber-tui/internal/ui/screens"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
 func keyMsg(key string) tea.KeyMsg {
@@ -2500,5 +2501,47 @@ func TestHandleImageViewer_SingleImageSuccess_NoClearScreen(t *testing.T) {
 	}
 	if cmd != nil {
 		t.Error("expected no ClearScreen outside a carousel")
+	}
+}
+
+// --- Theme editor revert: cancel while "custom" was already active must
+// restore the saved custom palette, not whatever the abandoned edit left in
+// theme's shared package-level customPalette. ---
+
+func TestHandleThemeEditor_Close_RestoresSavedCustomPalette_NotAbandonedEdit(t *testing.T) {
+	saved := theme.Palette{
+		Foreground: "#111111", Dimmed: "#222222", Border: "#333333", Accent: "#444444",
+		Highlight: "#555555", Error: "#666666", BarText: "#777777", Self: "#888888", Meta: "#999999",
+	}
+	theme.SetCustomPalette(saved)
+	theme.Set("custom")
+
+	a := loggedInApp()
+	a.customPalette = &saved
+	a.themeEditorOpen = true
+	a.themeEditorOrig = "custom"
+	a.themeEditorOrigPalette = theme.CurrentPalette() // snapshot, as the 'e' handler now does
+
+	// Simulate an abandoned mid-edit: a keystroke's PreviewPaletteMsg
+	// diverges the live custom palette from the saved one.
+	dirty := saved
+	dirty.Foreground = "#ABCDEF"
+	a2, _, ok := a.handleThemeEditor(screens.PreviewPaletteMsg{Palette: dirty})
+	if !ok {
+		t.Fatal("expected PreviewPaletteMsg to be handled")
+	}
+	if theme.CurrentPalette().Foreground != "#ABCDEF" {
+		t.Fatal("expected the live preview to apply the dirty edit")
+	}
+
+	a3, _, ok := a2.handleThemeEditor(screens.CloseThemeEditorMsg{})
+	if !ok {
+		t.Fatal("expected CloseThemeEditorMsg to be handled")
+	}
+	if a3.themeEditorOpen {
+		t.Error("expected the editor to close")
+	}
+	if got := theme.CurrentPalette(); got != saved {
+		t.Errorf("CurrentPalette() after cancel = %+v, want the saved palette %+v", got, saved)
 	}
 }

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -439,7 +439,11 @@ func (l MillerLayout) screenHints(a App) []hint {
 	case focusMenu:
 		return []hint{{"j/k", "nav"}, {"l/↵", "enter"}, {"1-9 / g+", "jump"}, {"?", "more"}}
 	case focusDetail:
-		return []hint{{"h/←", "list"}, {"j/k", "replies"}, {"↵", "thread"}, {"r", "reply"}}
+		hints := []hint{{"h/←", "list"}, {"j/k", "replies"}, {"↵", "thread"}, {"r", "reply"}}
+		if a.active == screenPostDetail && a.postDetail.HasThemeInPost() {
+			hints = append(hints, hint{"T", "try theme"})
+		}
+		return hints
 	default: // focusList
 		return append([]hint{{"h/←", "menu"}, {"→/↵", "preview"}}, TabsLayout{}.screenHints(a)...)
 	}

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -378,7 +378,11 @@ func (l TabsLayout) screenHints(a App) []hint {
 		if a.postDetail.ComposeActive() {
 			return []hint{{"Ctrl+s", "send"}, {"Esc", "cancel"}}
 		}
-		return []hint{{"↑↓", "navigate"}, {"r", "reply"}, {"b", "bookmark"}, {"w", "watch"}, {"c", "message"}, {"esc", "back"}, more}
+		hints := []hint{{"↑↓", "navigate"}, {"r", "reply"}, {"b", "bookmark"}, {"w", "watch"}, {"c", "message"}}
+		if a.postDetail.HasThemeInPost() {
+			hints = append(hints, hint{"T", "try theme"})
+		}
+		return append(hints, hint{"esc", "back"}, more)
 	case screenProfile:
 		if a.profile.ComposeActive() {
 			return []hint{{"Ctrl+s", "save"}, {"Esc", "cancel"}, {"tab", "cycle"}}

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -236,3 +236,10 @@ type SaveThemeMsg struct{ Palette theme.Palette }
 // CloseThemeEditorMsg is emitted by ThemeEditorModel on esc (row-nav mode,
 // not mid-field-edit) to close without saving.
 type CloseThemeEditorMsg struct{}
+
+// PreviewPostThemeMsg is emitted by PostDetailModel when the user presses
+// the try-theme key on a post with a detected theme block. App opens the
+// theme editor prefilled with Palette, exactly as if the user had pressed
+// 'e' on the picker's "custom" row but starting from the post's colors
+// instead of the current theme's.
+type PreviewPostThemeMsg struct{ Palette theme.Palette }

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -134,6 +134,11 @@ type PostDetailModel struct {
 	bookmarkedPostIDs  map[string]struct{}
 	bookmarkedReplyIDs map[string]struct{}
 	watchedPostIDs     map[string]struct{}
+
+	// postTheme is the parsed theme block from the post's body, if any —
+	// computed once in SetPost rather than on every keystroke/render. Nil
+	// means no theme block was detected.
+	postTheme *theme.Palette
 }
 
 func NewPostDetailModel() PostDetailModel {
@@ -152,12 +157,21 @@ func (m PostDetailModel) SetPost(post model.Post) PostDetailModel {
 	m.selectedReply = -1 // post itself is selected by default
 	m.loading = true
 	m.err = nil
+	if p, ok := theme.ParsePost(post.Content); ok {
+		m.postTheme = &p
+	} else {
+		m.postTheme = nil
+	}
 	if m.ready {
 		m = m.refreshContent()
 		m.viewport.GotoTop()
 	}
 	return m
 }
+
+// HasThemeInPost reports whether the currently open post's body contains a
+// detected custom-theme block (see docs/40-custom-themes.md).
+func (m PostDetailModel) HasThemeInPost() bool { return m.postTheme != nil }
 
 // HasPost reports whether a post is currently open or persisted in the
 // background — used by activateScreen to decide whether returning to the
@@ -578,6 +592,14 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 			var cmd tea.Cmd
 			m, cmd = m.OpenCompose()
 			return m, cmd
+		case "T":
+			// Post-only (not replies) — matches how these theme blocks are
+			// actually shared, and keeps detection a one-time SetPost cost.
+			if m.selectedReply < 0 && m.postTheme != nil {
+				p := *m.postTheme
+				return m, func() tea.Msg { return PreviewPostThemeMsg{Palette: p} }
+			}
+			return m, nil
 		case "p":
 			if m.post.ID == "" {
 				return m, nil

--- a/internal/ui/screens/postdetail_test.go
+++ b/internal/ui/screens/postdetail_test.go
@@ -374,3 +374,80 @@ func TestPostDetail_ComposeActive_TrueWhileConfirmingDelete(t *testing.T) {
 		t.Error("expected ComposeActive to report true while the delete-confirm overlay is open")
 	}
 }
+
+// --- Post theme detection / try-theme key ---
+
+const postWithThemeBlock = `Check out my theme!
+
+/* Cyberspace Custom Theme */
+Base Theme: vt320
+/* Colors */
+Foreground: #d000ff
+Background: #000000
+Dimmed: #270082
+Border: #270082
+Code: #7A5DFF
+Code BG: #5100ff
+`
+
+func TestPostDetail_ThemeBlockDetected_SetsHasThemeInPost(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetPost(model.Post{ID: "p1", AuthorUsername: "op", Content: postWithThemeBlock})
+
+	if !m.HasThemeInPost() {
+		t.Error("expected HasThemeInPost() == true for a post with a theme block")
+	}
+}
+
+func TestPostDetail_NoThemeBlock_HasThemeInPostFalse(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetPost(pdPost("p1")) // plain "original post" content, no theme block
+
+	if m.HasThemeInPost() {
+		t.Error("expected HasThemeInPost() == false for a post without a theme block")
+	}
+}
+
+func TestPostDetail_T_EmitsPreviewPostThemeMsg_WhenDetected(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetPost(model.Post{ID: "p1", AuthorUsername: "op", Content: postWithThemeBlock})
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("T")})
+	if cmd == nil {
+		t.Fatal("expected a cmd from T when a theme block is detected")
+	}
+	msg, ok := cmd().(screens.PreviewPostThemeMsg)
+	if !ok {
+		t.Fatalf("expected PreviewPostThemeMsg, got %T", cmd())
+	}
+	if msg.Palette.Foreground != "#d000ff" {
+		t.Errorf("Palette.Foreground = %q, want #d000ff", msg.Palette.Foreground)
+	}
+}
+
+func TestPostDetail_T_NoOp_WhenNoThemeBlock(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetPost(pdPost("p1"))
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("T")})
+	if cmd != nil {
+		t.Error("expected no cmd from T when no theme block is detected")
+	}
+}
+
+func TestPostDetail_T_NoOp_WhenReplySelected(t *testing.T) {
+	m := initPostDetail()
+	now := time.Now()
+	m = m.SetPost(model.Post{ID: "p1", AuthorUsername: "op", Content: postWithThemeBlock})
+	m = m.SetReplies([]model.Reply{pdReply("r1", "", "alice", now)})
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}) // select the reply
+	if m.SelectedReplyID() != "r1" {
+		t.Fatal("expected the reply to be selected")
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("T")})
+	if cmd != nil {
+		t.Error("expected T to no-op when a reply (not the post) is selected, even with a theme block present")
+	}
+}

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -2,6 +2,7 @@ package theme
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -236,6 +237,78 @@ func CurrentPalette() Palette {
 	}
 }
 
+// postThemeMarker is the fixed marker line cyberspace.online's web UI emits
+// at the top of a posted custom-theme block. Its presence (case-insensitive
+// substring match) is what triggers detection; everything else is lenient.
+const postThemeMarker = "cyberspace custom theme"
+
+// postParseWindow bounds how many lines after the marker ParsePost scans for
+// "Key: value" fields — generous for the known fixed format (under 20 lines)
+// without letting a false-positive scan run into unrelated later content in
+// a long post.
+const postParseWindow = 30
+
+// postFieldLineRe matches one "Key: value" line, e.g. "Foreground: #d000ff"
+// or "Base Theme: vt320". Lines that don't match this shape (comments like
+// "/* Colors */", blank lines) are silently skipped.
+var postFieldLineRe = regexp.MustCompile(`^([A-Za-z][A-Za-z ]*?):\s*(.+)$`)
+
+// ParsePost scans content for a posted custom-theme block (see
+// docs/40-custom-themes.md) and returns the resulting Palette. Fields the
+// block doesn't cover (Accent, Error, BarText, Self, Meta, and any
+// missing/malformed color field) are resolved from a base palette: if
+// "Base Theme" names one of our own built-ins (case-insensitive), that
+// theme's full palette is used; otherwise CurrentPalette() (today's active
+// theme). The block's explicit, validly-hex fields are then overlaid on
+// top. Returns ok=false only when the marker itself isn't present — an
+// otherwise-malformed block still returns ok=true with the base palette
+// unchanged for any field it couldn't parse.
+func ParsePost(content string) (Palette, bool) {
+	lines := strings.Split(content, "\n")
+	markerIdx := -1
+	for i, line := range lines {
+		if strings.Contains(strings.ToLower(line), postThemeMarker) {
+			markerIdx = i
+			break
+		}
+	}
+	if markerIdx == -1 {
+		return Palette{}, false
+	}
+
+	end := min(markerIdx+1+postParseWindow, len(lines))
+	fields := make(map[string]string)
+	for _, line := range lines[markerIdx+1 : end] {
+		m := postFieldLineRe.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(m[1]))
+		fields[key] = strings.TrimSpace(m[2])
+	}
+
+	base := CurrentPalette()
+	if name, ok := fields["base theme"]; ok {
+		if bp, ok := builtinPalettes[strings.ToLower(strings.TrimSpace(name))]; ok {
+			base = bp
+		}
+	}
+
+	overlay := func(dst *string, key string) {
+		if v, ok := fields[key]; ok && ValidHex(v) {
+			*dst = v
+		}
+	}
+	overlay(&base.Foreground, "foreground")
+	overlay(&base.Background, "background")
+	overlay(&base.Dimmed, "dimmed")
+	overlay(&base.Border, "border")
+	overlay(&base.Highlight, "code")
+	overlay(&base.CodeBackground, "code bg")
+
+	return base, true
+}
+
 // applyPalette sets the rendered color vars from p's driven fields and
 // rebuilds all styles. Background/CodeBackground have no Color var to drive.
 func applyPalette(p Palette) {
@@ -251,46 +324,62 @@ func applyPalette(p Palette) {
 	applyStyles()
 }
 
+// builtinPalettes holds each built-in theme's full color set as data — the
+// single source of truth the set*() functions below apply from, and also
+// what lets ParsePost read a named built-in's colors (e.g. to resolve a
+// post's "Base Theme: vt320") without actually switching the live theme.
+var builtinPalettes = map[string]Palette{
+	"cyber": {
+		Foreground: "#00FF41",
+		Border:     "#007A1F",
+		Accent:     "#00FFFF",
+		Highlight:  "#FFD700",
+		Error:      "#FF003C",
+		BarText:    "#0D0D0D",
+		Dimmed:     "#888888",
+		Self:       "#E0E0E0",
+		Meta:       "#E0E0E0",
+	},
+	// c64 is a Commodore 64-inspired palette: dark blue background, light
+	// blue-purple text, white titles, C64 yellow highlights.
+	"c64": {
+		Foreground: "#9490F5", // C64 light blue-purple (primary text)
+		Border:     "#5C5AC0", // C64 medium blue (inactive/borders)
+		Accent:     "#FFFFFF", // white (titles)
+		Highlight:  "#F4D020", // C64 yellow (highlights)
+		Error:      "#883932", // C64 red (errors)
+		BarText:    "#3535CE", // C64 cobalt blue (background)
+		Dimmed:     "#6B69C4", // dimmed blue-purple (subtle text)
+		Self:       "#FFFFFF",
+		Meta:       "#FFFFFF",
+	},
+	// vt320 is an amber phosphor terminal palette inspired by DEC VT320.
+	"vt320": {
+		Foreground: "#FFB000", // amber (primary text)
+		Border:     "#8B5E00", // dark amber (inactive)
+		Accent:     "#FFD700", // bright amber (titles)
+		Highlight:  "#FFF176", // bright yellow-white (highlights)
+		Error:      "#FF6600", // orange-red (errors)
+		BarText:    "#1A1200", // near-black amber background
+		Dimmed:     "#6B4800", // very dim amber (subtle text)
+		Self:       "#FFECB3", // cream
+		Meta:       "#FFECB3", // cream
+	},
+	// bland is no color at all — see setBland for the accompanying
+	// Bold/Underline/border-weight overrides that stand in for color.
+	"bland": {},
+}
+
 func setCyber() {
-	ColorGreen = lipgloss.Color("#00FF41")
-	ColorDimGreen = lipgloss.Color("#007A1F")
-	ColorCyan = lipgloss.Color("#00FFFF")
-	ColorYellow = lipgloss.Color("#FFD700")
-	ColorRed = lipgloss.Color("#FF003C")
-	ColorBackground = lipgloss.Color("#0D0D0D")
-	ColorMuted = lipgloss.Color("#888888")
-	ColorWhite = lipgloss.Color("#E0E0E0")
-	ColorMeta = lipgloss.Color("#E0E0E0")
-	applyStyles()
+	applyPalette(builtinPalettes["cyber"])
 }
 
-// setC64 applies a Commodore 64-inspired palette: dark blue background,
-// light blue-purple text, white titles, C64 yellow highlights.
 func setC64() {
-	ColorGreen = lipgloss.Color("#9490F5")      // C64 light blue-purple (primary text)
-	ColorDimGreen = lipgloss.Color("#5C5AC0")   // C64 medium blue (inactive/borders)
-	ColorCyan = lipgloss.Color("#FFFFFF")       // white (titles)
-	ColorYellow = lipgloss.Color("#F4D020")     // C64 yellow (highlights)
-	ColorRed = lipgloss.Color("#883932")        // C64 red (errors)
-	ColorBackground = lipgloss.Color("#3535CE") // C64 cobalt blue (background)
-	ColorMuted = lipgloss.Color("#6B69C4")      // dimmed blue-purple (subtle text)
-	ColorWhite = lipgloss.Color("#FFFFFF")
-	ColorMeta = lipgloss.Color("#FFFFFF")
-	applyStyles()
+	applyPalette(builtinPalettes["c64"])
 }
 
-// setVT320 applies an amber phosphor terminal palette inspired by DEC VT320.
 func setVT320() {
-	ColorGreen = lipgloss.Color("#FFB000")      // amber (primary text)
-	ColorDimGreen = lipgloss.Color("#8B5E00")   // dark amber (inactive)
-	ColorCyan = lipgloss.Color("#FFD700")       // bright amber (titles)
-	ColorYellow = lipgloss.Color("#FFF176")     // bright yellow-white (highlights)
-	ColorRed = lipgloss.Color("#FF6600")        // orange-red (errors)
-	ColorBackground = lipgloss.Color("#1A1200") // near-black amber background
-	ColorMuted = lipgloss.Color("#6B4800")      // very dim amber (subtle text)
-	ColorWhite = lipgloss.Color("#FFECB3")      // cream
-	ColorMeta = lipgloss.Color("#FFECB3")       // cream
-	applyStyles()
+	applyPalette(builtinPalettes["vt320"])
 }
 
 // setBland applies no color at all: every style renders in the terminal's
@@ -299,16 +388,7 @@ func setVT320() {
 // fall back to Bold/Underline and (for the active border) a heavier border
 // glyph, since no background or foreground color is forced.
 func setBland() {
-	ColorGreen = lipgloss.Color("")
-	ColorDimGreen = lipgloss.Color("")
-	ColorCyan = lipgloss.Color("")
-	ColorYellow = lipgloss.Color("")
-	ColorRed = lipgloss.Color("")
-	ColorBackground = lipgloss.Color("")
-	ColorMuted = lipgloss.Color("")
-	ColorWhite = lipgloss.Color("")
-	ColorMeta = lipgloss.Color("")
-	applyStyles()
+	applyPalette(builtinPalettes["bland"])
 
 	ActiveBorder = ActiveBorder.BorderStyle(lipgloss.ThickBorder())
 	TabMnemonic = TabMnemonic.Underline(true)

--- a/internal/ui/theme/theme_test.go
+++ b/internal/ui/theme/theme_test.go
@@ -166,3 +166,110 @@ func TestCurrentPalette_RoundTrips(t *testing.T) {
 		t.Errorf("CurrentPalette() = %+v, want cyber's literal hex values", p)
 	}
 }
+
+const examplePostBody = `Check out my new theme!
+
+/* Cyberspace Custom Theme */
+Base Theme: vt320
+/* Colors */
+Foreground: #d000ff
+Background: #000000
+Dimmed: #270082
+Border: #270082
+Code: #7A5DFF
+Code BG: #5100ff
+/* Fonts */
+Main Font: geist-mono
+Code Font: geist-mono
+/* Options */
+Disable Text Glow: true
+Disable Anti-aliasing: false
+Enable Noise: false
+Enable CRT Box: false
+Enable Ligatures: false
+Base Font Size: normal
+`
+
+func TestParsePost_NoMarker_NotDetected(t *testing.T) {
+	_, ok := ParsePost("just a regular post with no theme in it")
+	if ok {
+		t.Error("expected ok=false when the marker is absent")
+	}
+}
+
+func TestParsePost_KnownBaseTheme_FillsUnmappedFromIt(t *testing.T) {
+	p, ok := ParsePost(examplePostBody)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	vt320 := builtinPalettes["vt320"]
+	if p.Accent != vt320.Accent || p.Error != vt320.Error || p.BarText != vt320.BarText ||
+		p.Self != vt320.Self || p.Meta != vt320.Meta {
+		t.Errorf("unmapped fields = %+v, want vt320's values %+v", p, vt320)
+	}
+	if p.Foreground != "#d000ff" || p.Background != "#000000" || p.Dimmed != "#270082" ||
+		p.Border != "#270082" || p.Highlight != "#7A5DFF" || p.CodeBackground != "#5100ff" {
+		t.Errorf("explicit post fields not overlaid correctly: %+v", p)
+	}
+}
+
+func TestParsePost_UnknownBaseTheme_FallsBackToCurrentPalette(t *testing.T) {
+	Set("c64")
+	current := CurrentPalette()
+
+	body := `/* Cyberspace Custom Theme */
+Base Theme: not-a-real-theme
+/* Colors */
+Foreground: #123456
+`
+	p, ok := ParsePost(body)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if p.Accent != current.Accent || p.Self != current.Self {
+		t.Errorf("unmapped fields = %+v, want current active theme's values %+v", p, current)
+	}
+	if p.Foreground != "#123456" {
+		t.Errorf("Foreground = %q, want overlaid #123456", p.Foreground)
+	}
+}
+
+func TestParsePost_MalformedField_FallsBackToBaseForThatFieldOnly(t *testing.T) {
+	body := `/* Cyberspace Custom Theme */
+Base Theme: vt320
+/* Colors */
+Foreground: not-a-color
+Border: #270082
+`
+	p, ok := ParsePost(body)
+	if !ok {
+		t.Fatal("expected ok=true even with a malformed field")
+	}
+	vt320 := builtinPalettes["vt320"]
+	if p.Foreground != vt320.Foreground {
+		t.Errorf("Foreground = %q, want base fallback %q", p.Foreground, vt320.Foreground)
+	}
+	if p.Border != "#270082" {
+		t.Errorf("Border = %q, want overlaid #270082", p.Border)
+	}
+}
+
+func TestParsePost_NoBaseThemeLine_FallsBackToCurrentPalette(t *testing.T) {
+	Set("cyber")
+	current := CurrentPalette()
+
+	body := `/* Cyberspace Custom Theme */
+/* Colors */
+Foreground: #ABCDEF
+`
+	p, ok := ParsePost(body)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if p.Border != current.Border {
+		t.Errorf("Border = %q, want current theme's %q", p.Border, current.Border)
+	}
+	if p.Foreground != "#ABCDEF" {
+		t.Errorf("Foreground = %q, want overlaid #ABCDEF", p.Foreground)
+	}
+}


### PR DESCRIPTION
﻿## Summary
Post Detail now detects the fixed-format custom-theme block cyberspace.online's web UI lets users post, and lets the user try it before committing.

- **`theme.ParsePost(content string) (Palette, bool)`**: scans for the block's marker (`/* Cyberspace Custom Theme */`), resolves the fields the post doesn't cover (`Accent`, `Error`, `BarText`, `Self`, `Meta`) from the named `Base Theme` if it matches one of our built-ins, else from the currently active theme, and overlays the block's explicit valid-hex fields on top. A malformed individual field falls back to the base rather than invalidating the whole block.
- **`builtinPalettes` data table**: cyber/c64/vt320/bland extracted from imperative literals in `setCyber`/etc into a `map[string]Palette`, so `ParsePost` (and the setters themselves, now just `applyPalette(builtinPalettes["cyber"])`) can read a built-in's colors without switching the live theme. Single source of truth, zero visual change.
- **Post Detail `T` key** (post focused, not a reply): opens the *existing* theme editor prefilled from the parsed palette instead of the current theme — reuses its live preview / `ctrl+s` save / `esc` revert wholesale rather than building a second confirm/cancel flow. The hint only appears when a block is actually detected (`HasThemeInPost()`), in both layouts.

## Bug fix (found while building this)
Canceling the theme editor while `"custom"` was already the active theme didn't restore the prior saved colors — live-preview edits and the saved custom palette shared one package-level variable (`theme.customPalette`), so an abandoned edit was left applied instead of being reverted. Fixed by snapshotting `theme.CurrentPalette()` (`App.themeEditorOrigPalette`) before preview starts and restoring it explicitly on cancel. The new post-import entry path needed this fixed to revert correctly, so the shared root cause was fixed once rather than adding a second, still-buggy path. Covered by a regression test (`TestHandleThemeEditor_Close_RestoresSavedCustomPalette_NotAbandonedEdit`).

## Testing
- `go build ./...`, `go test ./...`, `go vet ./...`, `staticcheck ./...` all clean.
- New tests: `ParsePost` (marker absent, known/unknown base theme resolution, malformed-field fallback, missing base line), Post Detail detection + `T` key (detected/not detected/reply-focused no-op), the editor revert-bug regression.
- Not yet click-tested end-to-end in a live terminal session — unit-level behavior only.

## Definition of Done checklist
- [x] Unit tests pass
- [x] No linter warnings (`go vet`, `staticcheck`)
- [x] Documented (`docs/40-custom-themes.md`, `docs/00-project-reference.md` updated)
- [x] Manual smoke test in a live terminal
