### PR TITLE
feat: export/import the custom theme to a file

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -625,6 +625,9 @@ Color palettes and Lip Gloss style objects for four retro themes, plus a user-ed
 | `SetCustomPalette(p Palette)` | Stores `p` as the "custom" theme's palette; re-applies immediately if "custom" is already active (live preview) |
 | `CurrentPalette() Palette` | Returns the colors currently active, as a `Palette` |
 | `ParsePost(content string) (Palette, bool)` | Detects and parses a cyberspace.online custom-theme post block; `ok=false` only when no block is found. See `docs/40-custom-themes.md`. |
+| `ExpandHome(path string) (string, error)` | Expands a leading `~` to the user's home directory |
+| `ExportToFile(path string, p Palette) error` | Writes `p` as indented JSON (mode 0600), expanding `~` |
+| `ImportFromFile(path string) (Palette, error)` | Reads/validates a theme file; fails on a missing file, invalid JSON, or JSON that fails `Valid()` |
 
 **`Palette` type:** the data-driven counterpart to the literal `setCyber`/`setC64`/etc. themes, named by UI role rather than color so the theme editor and config file read as "what does this control": `Foreground`, `Dimmed`, `Border`, `Accent`, `Highlight`, `Error`, `BarText`, `Self`, `Meta` (all rendered; map internally to `ColorGreen`, `ColorMuted`, `ColorDimGreen`, `ColorCyan`, `ColorYellow`, `ColorRed`, `ColorBackground`, `ColorWhite`, `ColorMeta` respectively), plus `Background`/`CodeBackground` (reserved, unused by the renderer today, hidden from the editor). `Self` and `Meta` were one field until `ColorWhite` turned out to drive both the own-username highlight and unrelated status-bar text — split so each row controls exactly one thing. Used by the "custom" theme (edited in-TUI, see `docs/40-custom-themes.md`) and exposed for a future "detect theme in a post" feature to build/inspect palettes without touching `theme`'s internals — see that doc's post-field mapping table.
 

--- a/docs/40-custom-themes.md
+++ b/docs/40-custom-themes.md
@@ -39,6 +39,16 @@ theme.Set(cfg.Theme)
 
 See `theme.ParsePost`'s doc comment and the post-field mapping table below for how the block's fields resolve.
 
+### Export / Import
+
+Lets a saved custom theme be archived to a plain JSON file and restored from one — only the "custom" slot is ever involved on either side.
+
+1. `x` on the picker's "custom" row — guarded on `App.customPalette != nil` (nothing saved yet → no-op). Opens `screens.PathPromptModel` (`App.pathPromptOpen`, `pathPromptPurpose = pathPromptExport`), prefilled with `~/cyber-tui-theme.json`.
+2. `i` on the "custom" row — always available (no saved-palette guard). Opens the same prompt with the same default path, `pathPromptPurpose = pathPromptImport`, so a plain export-then-import round trip needs no retyping.
+3. `enter` in the prompt emits `screens.PathPromptSubmitMsg{Path}`; `esc` emits `screens.PathPromptCancelMsg{}`. The prompt itself has no filesystem awareness — it's a bare `textinput.Model` plus a settable warning line; all I/O and validation happen in `App.handlePathPrompt`.
+4. **Export**: if the (`~`-expanded) path already exists and this exact path string hasn't already been flagged (`App.pathPromptOverwritePending`), the prompt stays open with a warning ("file exists — enter again to overwrite") instead of writing — an identical resubmit proceeds. Otherwise `theme.ExportToFile(path, *App.customPalette)` writes the *saved* custom palette (never a live/unsaved preview) as indented JSON, mode 0600. Result surfaces via the existing notify banner (`a.notify(notifyInfo/notifyError, ...)`).
+5. **Import**: `theme.ImportFromFile(path)` reads and validates the file. On error (missing file, invalid JSON, or valid JSON that fails `Palette.Valid()`), notifies and the prompt closes — nothing about the saved custom palette changes. On success, it's handled exactly like `PreviewPostThemeMsg`: snapshot for correct revert, preview live, open the theme editor prefilled from the imported palette — reviewed and `ctrl+s`-confirmed, never applied blind.
+
 ### Ephemeral (SSH) Sessions
 
 `saveConfig` already no-ops when `App.ephemeral` is true — editing and live preview work normally in an SSH session, but nothing is written to the host operator's `~/.cyber-tui.json`.
@@ -71,6 +81,9 @@ func (p Palette) Valid() bool     // the 9 rendered fields required; Background/
 func SetCustomPalette(p Palette)
 func CurrentPalette() Palette
 func ParsePost(content string) (Palette, bool)
+func ExpandHome(path string) (string, error)  // "~/..." → the user's home dir; used by both of the below and by App's overwrite check
+func ExportToFile(path string, p Palette) error
+func ImportFromFile(path string) (Palette, error)  // fails closed: ErrInvalidThemeFile if the JSON parses but Valid() doesn't hold
 ```
 
 `Self` and `Meta` were originally one field (`Self`, backed by `ColorWhite`) until it turned out to drive two unrelated things: own-username highlighting *and* the status bar's secondary text/hint descriptions. Split so each row controls exactly one thing — `ColorMeta` is a separate color var from `ColorWhite`, initialized to the same literal in every built-in theme (so no visual change there), letting only custom themes differentiate them.
@@ -126,6 +139,10 @@ type Config struct {
 | `ctrl+s` | editor (row nav) | Save custom palette |
 | `esc` | editor (row nav) | Close without saving, revert theme |
 | `T` | Post Detail, post focused (not a reply) | Preview a detected post theme — opens the editor prefilled from it, when `HasThemeInPost()` |
+| `x` | picker, "custom" row | Export the saved custom theme to a file, when `customPalette != nil` |
+| `i` | picker, "custom" row | Import a theme file — opens the editor prefilled from it for review |
+| `enter` | path prompt | Submit the path (a second identical submit confirms an export overwrite) |
+| `esc` | path prompt | Cancel |
 
 ---
 
@@ -155,3 +172,8 @@ Same as the Settings screen: edits accumulate in memory (with live preview) unti
 - [x] `builtinPalettes` data table + `theme.ParsePost` (detects and resolves a post's theme block)
 - [x] Post Detail's `T` key + `HasThemeInPost()` hint, wired into both layouts
 - [x] Revert-on-cancel bug fixed (`themeEditorOrigPalette` snapshot), covered by a regression test
+- [x] `theme.ExportToFile`/`ImportFromFile`/`ExpandHome`
+- [x] `screens.PathPromptModel` (`internal/ui/screens/pathprompt.go`)
+- [x] Wired into theme picker (`x` export / `i` import on the "custom" row) in both layouts
+- [x] Export overwrite confirmation (`pathPromptOverwritePending`)
+- [x] Import reuses the theme editor for review before commit

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"math/rand"
 	neturl "net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -53,6 +54,10 @@ const (
 // availableThemes is the ordered list of selectable themes shown in the picker.
 var availableThemes = []string{"cyber", "c64", "vt320", "bland", "custom"}
 
+// defaultThemeFilePath prefills the export/import path prompt, so a plain
+// export-then-import round trip needs no retyping.
+const defaultThemeFilePath = "~/cyber-tui-theme.json"
+
 const (
 	logoOrig          = "ᑕ¥βєяรקค¢є"
 	logoHoldFrames    = 5 // frames held fully scrambled (~300ms at 60ms/frame)
@@ -81,6 +86,14 @@ func randomCyberRune(exclude rune) rune {
 	}
 	return logoCyberPool[0]
 }
+
+// pathPromptPurpose distinguishes what App does with a submitted PathPromptModel path.
+type pathPromptPurpose int
+
+const (
+	pathPromptExport pathPromptPurpose = iota
+	pathPromptImport
+)
 
 type App struct {
 	layout      Layout
@@ -127,6 +140,17 @@ type App struct {
 	// customPalette is the persisted custom theme, loaded from config. Nil
 	// means the user has never saved one yet.
 	customPalette *theme.Palette
+
+	// pathPrompt state — opened from the theme picker's "custom" row with
+	// 'x' (export) or 'i' (import), closed by PathPromptSubmitMsg/
+	// PathPromptCancelMsg.
+	pathPromptOpen    bool
+	pathPrompt        screens.PathPromptModel
+	pathPromptPurpose pathPromptPurpose
+	// pathPromptOverwritePending holds the export path once it's been
+	// flagged as already existing — an identical resubmit proceeds without
+	// asking again; any other path (or a fresh Open) resets this.
+	pathPromptOverwritePending string
 
 	// helpModal state — open with '?', close with any key.
 	helpModalOpen bool
@@ -278,6 +302,7 @@ func NewApp(client api.Client) App {
 		topics:             screens.NewTopicsModel(),
 		journal:            screens.NewJournalModel(0),
 		search:             screens.NewSearchModel(),
+		pathPrompt:         screens.NewPathPromptModel(),
 		bookmarkedPostIDs:  make(map[string]struct{}),
 		bookmarkedReplyIDs: make(map[string]struct{}),
 		postBookmarkIDs:    make(map[string]string),
@@ -436,6 +461,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if a2, cmd, ok := a.handleThemeEditor(msg); ok {
 		return a2, cmd
 	}
+	if a2, cmd, ok := a.handlePathPrompt(msg); ok {
+		return a2, cmd
+	}
 	if a2, cmd, ok := a.handleBookmarks(msg); ok {
 		return a2, cmd
 	}
@@ -549,6 +577,10 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 	}
 	if a.themeEditorOpen {
 		model, cmd := a.handleThemeEditorKey(m)
+		return model.(App), cmd, true
+	}
+	if a.pathPromptOpen {
+		model, cmd := a.handlePathPromptKey(m)
 		return model.(App), cmd, true
 	}
 	if a.helpModalOpen {
@@ -1188,6 +1220,57 @@ func (a App) handleThemeEditor(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		theme.Set(a.themeEditorOrig)
 		a.refreshViewports()
+		return a, nil, true
+	}
+	return a, nil, false
+}
+
+// handlePathPrompt processes messages emitted by the export/import path
+// prompt. Export requires a second identical submit once a target file is
+// found to already exist (pathPromptOverwritePending); import validates the
+// file via theme.ImportFromFile and, on success, hands off to the theme
+// editor exactly like PreviewPostThemeMsg — reviewed and confirmed with
+// ctrl+s, never applied blind.
+func (a App) handlePathPrompt(msg tea.Msg) (App, tea.Cmd, bool) {
+	switch msg := msg.(type) {
+	case screens.PathPromptSubmitMsg:
+		switch a.pathPromptPurpose {
+		case pathPromptExport:
+			resolved, _ := theme.ExpandHome(msg.Path)
+			if _, err := os.Stat(resolved); err == nil && msg.Path != a.pathPromptOverwritePending {
+				a.pathPromptOverwritePending = msg.Path
+				a.pathPrompt = a.pathPrompt.SetWarning("file exists — enter again to overwrite")
+				return a, nil, true
+			}
+			a.pathPromptOpen = false
+			if err := theme.ExportToFile(msg.Path, *a.customPalette); err != nil {
+				a2, cmd := a.notify(notifyError, "export failed: "+err.Error())
+				return a2, cmd, true
+			}
+			a2, cmd := a.notify(notifyInfo, "theme exported to "+msg.Path)
+			return a2, cmd, true
+
+		case pathPromptImport:
+			a.pathPromptOpen = false
+			p, err := theme.ImportFromFile(msg.Path)
+			if err != nil {
+				a2, cmd := a.notify(notifyError, "import failed: "+err.Error())
+				return a2, cmd, true
+			}
+			a.themeEditorOrig = theme.CurrentName()
+			a.themeEditorOrigPalette = theme.CurrentPalette()
+			theme.SetCustomPalette(p)
+			theme.Set("custom")
+			a.refreshViewports()
+			a.themeEditorOpen = true
+			a.themeEditor = screens.NewThemeEditorModel(p)
+			return a, nil, true
+		}
+		return a, nil, true
+
+	case screens.PathPromptCancelMsg:
+		a.pathPromptOpen = false
+		a.pathPromptOverwritePending = ""
 		return a, nil, true
 	}
 	return a, nil, false
@@ -1984,6 +2067,28 @@ func (a App) handleThemePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.themeEditorOpen = true
 		a.themeEditor = screens.NewThemeEditorModel(prefill)
 		return a, nil
+	case "x":
+		if availableThemes[a.themePickerCursor] != "custom" || a.customPalette == nil {
+			return a, nil // nothing saved yet to export
+		}
+		a.themePickerOpen = false
+		a.pathPromptOpen = true
+		a.pathPromptPurpose = pathPromptExport
+		a.pathPromptOverwritePending = ""
+		var cmd tea.Cmd
+		a.pathPrompt, cmd = a.pathPrompt.Open("export custom theme to", defaultThemeFilePath)
+		return a, cmd
+	case "i":
+		if availableThemes[a.themePickerCursor] != "custom" {
+			return a, nil
+		}
+		a.themePickerOpen = false
+		a.pathPromptOpen = true
+		a.pathPromptPurpose = pathPromptImport
+		a.pathPromptOverwritePending = ""
+		var cmd tea.Cmd
+		a.pathPrompt, cmd = a.pathPrompt.Open("import custom theme from", defaultThemeFilePath)
+		return a, cmd
 	case "enter":
 		selected := availableThemes[a.themePickerCursor]
 		if selected == "custom" && a.customPalette == nil {
@@ -2012,6 +2117,14 @@ func (a App) handleThemePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (a App) handleThemeEditorKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	a.themeEditor, cmd = a.themeEditor.Update(msg)
+	return a, cmd
+}
+
+// handlePathPromptKey forwards keyboard input to the path prompt model
+// while it's open.
+func (a App) handlePathPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	a.pathPrompt, cmd = a.pathPrompt.Update(msg)
 	return a, cmd
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -2543,5 +2545,185 @@ func TestHandleThemeEditor_Close_RestoresSavedCustomPalette_NotAbandonedEdit(t *
 	}
 	if got := theme.CurrentPalette(); got != saved {
 		t.Errorf("CurrentPalette() after cancel = %+v, want the saved palette %+v", got, saved)
+	}
+}
+
+// --- Theme export / import ---
+
+func testThemePalette() theme.Palette {
+	return theme.Palette{
+		Foreground: "#111111", Dimmed: "#222222", Border: "#333333", Accent: "#444444",
+		Highlight: "#555555", Error: "#666666", BarText: "#777777", Self: "#888888", Meta: "#999999",
+	}
+}
+
+// appOnCustomRow returns a logged-in App with the theme picker open and its
+// cursor on the "custom" row, ready to exercise the 'x'/'i' keys.
+func appOnCustomRow(t *testing.T) App {
+	t.Helper()
+	a := loggedInApp()
+	a.themePickerOpen = true
+	a.themePickerCursor = len(availableThemes) - 1
+	if availableThemes[a.themePickerCursor] != "custom" {
+		t.Fatalf("expected last availableThemes entry to be \"custom\", got %q", availableThemes[a.themePickerCursor])
+	}
+	return a
+}
+
+func TestHandleThemePickerKey_X_NoOp_WhenNoCustomPaletteSaved(t *testing.T) {
+	a := appOnCustomRow(t)
+	a.customPalette = nil
+
+	m, _ := a.handleThemePickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	a2 := m.(App)
+	if a2.pathPromptOpen {
+		t.Error("expected export to no-op with no saved custom palette")
+	}
+}
+
+func TestHandleThemePickerKey_X_OpensExportPrompt(t *testing.T) {
+	a := appOnCustomRow(t)
+	saved := testThemePalette()
+	a.customPalette = &saved
+
+	m, _ := a.handleThemePickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	a2 := m.(App)
+	if !a2.pathPromptOpen || a2.pathPromptPurpose != pathPromptExport {
+		t.Error("expected the export path prompt to open")
+	}
+}
+
+func TestHandleThemePickerKey_I_OpensImportPrompt_EvenWithoutSavedPalette(t *testing.T) {
+	a := appOnCustomRow(t)
+	a.customPalette = nil
+
+	m, _ := a.handleThemePickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("i")})
+	a2 := m.(App)
+	if !a2.pathPromptOpen || a2.pathPromptPurpose != pathPromptImport {
+		t.Error("expected the import path prompt to open regardless of a saved palette")
+	}
+}
+
+func TestHandlePathPrompt_Export_WritesFile(t *testing.T) {
+	a := loggedInApp()
+	saved := testThemePalette()
+	a.customPalette = &saved
+	a.pathPromptOpen = true
+	a.pathPromptPurpose = pathPromptExport
+
+	path := filepath.Join(t.TempDir(), "theme.json")
+	a2, cmd, ok := a.handlePathPrompt(screens.PathPromptSubmitMsg{Path: path})
+	if !ok {
+		t.Fatal("expected PathPromptSubmitMsg to be handled")
+	}
+	if a2.pathPromptOpen {
+		t.Error("expected the prompt to close after a successful export")
+	}
+	if cmd == nil {
+		t.Fatal("expected a notify cmd")
+	}
+	got, err := theme.ImportFromFile(path)
+	if err != nil {
+		t.Fatalf("ImportFromFile: %v", err)
+	}
+	if got != saved {
+		t.Errorf("exported palette = %+v, want %+v", got, saved)
+	}
+}
+
+func TestHandlePathPrompt_Export_WarnsBeforeOverwrite_ThenProceedsOnResubmit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "theme.json")
+	if err := os.WriteFile(path, []byte("pre-existing"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := loggedInApp()
+	first := testThemePalette()
+	a.customPalette = &first
+	a.pathPromptOpen = true
+	a.pathPromptPurpose = pathPromptExport
+
+	a2, _, ok := a.handlePathPrompt(screens.PathPromptSubmitMsg{Path: path})
+	if !ok {
+		t.Fatal("expected PathPromptSubmitMsg to be handled")
+	}
+	if !a2.pathPromptOpen {
+		t.Error("expected the prompt to stay open pending overwrite confirmation")
+	}
+	if a2.pathPromptOverwritePending != path {
+		t.Errorf("pathPromptOverwritePending = %q, want %q", a2.pathPromptOverwritePending, path)
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != "pre-existing" {
+		t.Error("expected the file to be untouched before the overwrite is confirmed")
+	}
+
+	a3, _, ok := a2.handlePathPrompt(screens.PathPromptSubmitMsg{Path: path})
+	if !ok {
+		t.Fatal("expected the resubmit to be handled")
+	}
+	if a3.pathPromptOpen {
+		t.Error("expected the prompt to close once the overwrite is confirmed")
+	}
+	got, err := theme.ImportFromFile(path)
+	if err != nil {
+		t.Fatalf("expected the file to now contain the exported palette: %v", err)
+	}
+	if got != first {
+		t.Errorf("exported palette = %+v, want %+v", got, first)
+	}
+}
+
+func TestHandlePathPrompt_Import_Success_OpensThemeEditor(t *testing.T) {
+	imported := testThemePalette()
+	path := filepath.Join(t.TempDir(), "theme.json")
+	if err := theme.ExportToFile(path, imported); err != nil {
+		t.Fatal(err)
+	}
+
+	a := loggedInApp()
+	a.pathPromptOpen = true
+	a.pathPromptPurpose = pathPromptImport
+
+	a2, _, ok := a.handlePathPrompt(screens.PathPromptSubmitMsg{Path: path})
+	if !ok {
+		t.Fatal("expected PathPromptSubmitMsg to be handled")
+	}
+	if a2.pathPromptOpen {
+		t.Error("expected the prompt to close")
+	}
+	if !a2.themeEditorOpen {
+		t.Fatal("expected the theme editor to open for review")
+	}
+	if theme.CurrentName() != "custom" {
+		t.Errorf("CurrentName() = %q, want custom (previewing the import)", theme.CurrentName())
+	}
+	if theme.CurrentPalette() != imported {
+		t.Errorf("CurrentPalette() = %+v, want the imported palette %+v", theme.CurrentPalette(), imported)
+	}
+}
+
+func TestHandlePathPrompt_Import_Failure_NotifiesAndLeavesCustomPaletteUntouched(t *testing.T) {
+	saved := testThemePalette()
+	a := loggedInApp()
+	a.customPalette = &saved
+	a.pathPromptOpen = true
+	a.pathPromptPurpose = pathPromptImport
+
+	a2, cmd, ok := a.handlePathPrompt(screens.PathPromptSubmitMsg{Path: filepath.Join(t.TempDir(), "missing.json")})
+	if !ok {
+		t.Fatal("expected PathPromptSubmitMsg to be handled")
+	}
+	if a2.pathPromptOpen {
+		t.Error("expected the prompt to close after a failed import")
+	}
+	if a2.themeEditorOpen {
+		t.Error("expected the theme editor to stay closed on import failure")
+	}
+	if cmd == nil {
+		t.Fatal("expected a notify cmd")
+	}
+	if a2.customPalette != &saved {
+		t.Error("expected the saved custom palette to be untouched by a failed import")
 	}
 }

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -127,6 +127,9 @@ func (l MillerLayout) View(a App) string {
 	if a.themeEditorOpen {
 		return overlayCenter(base, l.renderThemeEditor(a), a.width, a.height)
 	}
+	if a.pathPromptOpen {
+		return overlayCenter(base, l.renderPathPrompt(a), a.width, a.height)
+	}
 	if a.helpModalOpen {
 		return overlayCenter(base, l.renderHelpModal(a), a.width, a.height)
 	}
@@ -521,7 +524,7 @@ func (l MillerLayout) renderThemePicker(a App) string {
 		"",
 		strings.Join(rows, "\n"),
 		"",
-		theme.Subtle.Render("↑↓ select   enter apply   e edit custom   esc cancel"),
+		theme.Subtle.Render("↑↓ select   enter apply   e edit   x export   i import   esc cancel"),
 	)
 	return theme.ActiveBorder.Render(body)
 }
@@ -529,6 +532,11 @@ func (l MillerLayout) renderThemePicker(a App) string {
 // renderThemeEditor renders the "custom" theme color editor modal.
 func (l MillerLayout) renderThemeEditor(a App) string {
 	return a.themeEditor.View()
+}
+
+// renderPathPrompt renders the export/import file-path prompt modal.
+func (l MillerLayout) renderPathPrompt(a App) string {
+	return a.pathPrompt.View()
 }
 
 func (l MillerLayout) renderHelpModal(a App) string {
@@ -550,6 +558,7 @@ func (l MillerLayout) renderHelpModal(a App) string {
 		row("/", "search"),
 		row("t", "theme"),
 		row("e", "edit custom theme (in theme picker)"),
+		row("x / i", "export / import custom theme (in theme picker)"),
 		row("v", "density"),
 		row("o", "open url"),
 		row("q", "quit"),

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -52,6 +52,9 @@ func (l TabsLayout) View(a App) string {
 	if a.themeEditorOpen {
 		return overlayCenter(base, l.renderThemeEditor(a), a.width, a.height)
 	}
+	if a.pathPromptOpen {
+		return overlayCenter(base, l.renderPathPrompt(a), a.width, a.height)
+	}
 	if a.helpModalOpen {
 		return overlayCenter(base, l.renderHelpModal(a), a.width, a.height)
 	}
@@ -468,7 +471,7 @@ func (l TabsLayout) renderThemePicker(a App) string {
 			items = append(items, theme.Subtle.Render("  "+name))
 		}
 	}
-	hint := theme.Subtle.Render("↑↓ preview   enter save   e edit custom   esc cancel")
+	hint := theme.Subtle.Render("↑↓ preview   enter save   e edit   x export   i import   esc cancel")
 	body := lipgloss.JoinVertical(lipgloss.Left,
 		title,
 		"",
@@ -482,6 +485,11 @@ func (l TabsLayout) renderThemePicker(a App) string {
 // renderThemeEditor renders the "custom" theme color editor modal.
 func (l TabsLayout) renderThemeEditor(a App) string {
 	return a.themeEditor.View()
+}
+
+// renderPathPrompt renders the export/import file-path prompt modal.
+func (l TabsLayout) renderPathPrompt(a App) string {
+	return a.pathPrompt.View()
 }
 
 func (l TabsLayout) renderHelpModal(a App) string {
@@ -501,6 +509,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		row("/", "search"),
 		row("t", "theme"),
 		row("e", "edit custom theme (in theme picker)"),
+		row("x / i", "export / import custom theme (in theme picker)"),
 		row("v", "density"),
 		row("o", "open url"),
 		row("q", "quit"),

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -237,6 +237,15 @@ type SaveThemeMsg struct{ Palette theme.Palette }
 // not mid-field-edit) to close without saving.
 type CloseThemeEditorMsg struct{}
 
+// PathPromptSubmitMsg is emitted by PathPromptModel on enter, carrying the
+// current input value. The prompt has no filesystem awareness of its own —
+// App decides what the path means (export target, import source) and
+// whether it needs a second confirmation (e.g. overwrite).
+type PathPromptSubmitMsg struct{ Path string }
+
+// PathPromptCancelMsg is emitted by PathPromptModel on esc.
+type PathPromptCancelMsg struct{}
+
 // PreviewPostThemeMsg is emitted by PostDetailModel when the user presses
 // the try-theme key on a post with a detected theme block. App opens the
 // theme editor prefilled with Palette, exactly as if the user had pressed

--- a/internal/ui/screens/pathprompt.go
+++ b/internal/ui/screens/pathprompt.go
@@ -1,0 +1,62 @@
+package screens
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
+)
+
+// PathPromptModel is a minimal single-line file-path prompt, reused for both
+// theme export and import. It has no purpose-specific behavior itself —
+// App sets an appropriate title/default/warning via the fields below.
+type PathPromptModel struct {
+	title   string // e.g. "export theme to" / "import theme from"
+	input   textinput.Model
+	warning string // set by App (e.g. "file exists — enter again to overwrite"); cleared on the next keystroke
+}
+
+func NewPathPromptModel() PathPromptModel {
+	ti := textinput.New()
+	ti.Width = 40
+	return PathPromptModel{input: ti}
+}
+
+// Open resets and focuses the prompt with the given title and prefilled path.
+func (m PathPromptModel) Open(title, defaultPath string) (PathPromptModel, tea.Cmd) {
+	m.title = title
+	m.warning = ""
+	m.input.SetValue(defaultPath)
+	m.input.CursorEnd()
+	return m, m.input.Focus()
+}
+
+// SetWarning attaches a warning line (e.g. an overwrite confirmation
+// prompt) shown below the input until the next keystroke.
+func (m PathPromptModel) SetWarning(text string) PathPromptModel {
+	m.warning = text
+	return m
+}
+
+func (m PathPromptModel) Update(msg tea.KeyMsg) (PathPromptModel, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		path := m.input.Value()
+		return m, func() tea.Msg { return PathPromptSubmitMsg{Path: path} }
+	case "esc":
+		return m, func() tea.Msg { return PathPromptCancelMsg{} }
+	}
+	m.warning = ""
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return m, cmd
+}
+
+func (m PathPromptModel) View() string {
+	rows := []string{theme.Title.Render(m.title), "", m.input.View()}
+	if m.warning != "" {
+		rows = append(rows, "", theme.Error.Render(m.warning))
+	}
+	rows = append(rows, "", theme.Subtle.Render("enter · confirm   esc · cancel"))
+	return theme.ActiveBorder.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}

--- a/internal/ui/screens/pathprompt_test.go
+++ b/internal/ui/screens/pathprompt_test.go
@@ -1,0 +1,64 @@
+package screens
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestPathPromptModel_Open_PrefillsAndFocuses(t *testing.T) {
+	m := NewPathPromptModel()
+	m, _ = m.Open("export theme to", "~/theme.json")
+	if m.input.Value() != "~/theme.json" {
+		t.Errorf("input value = %q, want %q", m.input.Value(), "~/theme.json")
+	}
+	if !m.input.Focused() {
+		t.Error("expected input to be focused after Open")
+	}
+	if m.title != "export theme to" {
+		t.Errorf("title = %q, want %q", m.title, "export theme to")
+	}
+}
+
+func TestPathPromptModel_Enter_EmitsSubmitWithCurrentValue(t *testing.T) {
+	m := NewPathPromptModel()
+	m, _ = m.Open("import theme from", "~/theme.json")
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace}) // "~/theme.jso"
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+
+	_, cmd := m.Update(keyMsg("enter"))
+	if cmd == nil {
+		t.Fatal("expected a cmd from enter")
+	}
+	msg, ok := cmd().(PathPromptSubmitMsg)
+	if !ok {
+		t.Fatalf("expected PathPromptSubmitMsg, got %T", cmd())
+	}
+	if msg.Path != "~/theme.json" {
+		t.Errorf("Path = %q, want %q", msg.Path, "~/theme.json")
+	}
+}
+
+func TestPathPromptModel_Esc_EmitsCancel(t *testing.T) {
+	m := NewPathPromptModel()
+	m, _ = m.Open("export theme to", "~/theme.json")
+
+	_, cmd := m.Update(keyMsg("esc"))
+	if cmd == nil {
+		t.Fatal("expected a cmd from esc")
+	}
+	if _, ok := cmd().(PathPromptCancelMsg); !ok {
+		t.Errorf("expected PathPromptCancelMsg, got %T", cmd())
+	}
+}
+
+func TestPathPromptModel_Keystroke_ClearsWarning(t *testing.T) {
+	m := NewPathPromptModel()
+	m, _ = m.Open("export theme to", "~/theme.json")
+	m = m.SetWarning("file exists — enter again to overwrite")
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	if m.warning != "" {
+		t.Errorf("expected warning to clear on keystroke, got %q", m.warning)
+	}
+}

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -1,6 +1,10 @@
 package theme
 
 import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -307,6 +311,68 @@ func ParsePost(content string) (Palette, bool) {
 	overlay(&base.CodeBackground, "code bg")
 
 	return base, true
+}
+
+// ExpandHome expands a leading "~" (or "~/...") to the user's home
+// directory, matching config.DefaultPath's convention. Paths not starting
+// with "~" are returned unchanged. Exported so callers (e.g. App, checking
+// whether an export target already exists) resolve paths the same way
+// ExportToFile/ImportFromFile do.
+func ExpandHome(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") && !strings.HasPrefix(path, `~\`) {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, path[2:]), nil
+}
+
+// ExportToFile writes p as indented JSON to path (mode 0600, matching the
+// config file's convention), expanding a leading "~" to the user's home
+// directory.
+func ExportToFile(path string, p Palette) error {
+	resolved, err := ExpandHome(path)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(resolved, data, 0600)
+}
+
+// ErrInvalidThemeFile is returned by ImportFromFile when the file parses as
+// JSON but doesn't contain a valid palette (missing/malformed colors).
+var ErrInvalidThemeFile = errors.New("theme file has missing or invalid colors")
+
+// ImportFromFile reads and parses a theme file previously written by
+// ExportToFile (or anything JSON-shaped the same way), expanding a leading
+// "~" to the user's home directory. Returns an error if the file is
+// missing/unreadable, isn't valid JSON, or parses but fails Valid() — a
+// partially-formed file should never silently overwrite a good saved theme.
+func ImportFromFile(path string) (Palette, error) {
+	resolved, err := ExpandHome(path)
+	if err != nil {
+		return Palette{}, err
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return Palette{}, err
+	}
+	var p Palette
+	if err := json.Unmarshal(data, &p); err != nil {
+		return Palette{}, err
+	}
+	if !p.Valid() {
+		return Palette{}, ErrInvalidThemeFile
+	}
+	return p, nil
 }
 
 // applyPalette sets the rendered color vars from p's driven fields and

--- a/internal/ui/theme/theme_test.go
+++ b/internal/ui/theme/theme_test.go
@@ -1,6 +1,9 @@
 package theme
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -271,5 +274,67 @@ Foreground: #ABCDEF
 	}
 	if p.Foreground != "#ABCDEF" {
 		t.Errorf("Foreground = %q, want overlaid #ABCDEF", p.Foreground)
+	}
+}
+
+// --- Export / Import ---
+
+func TestExportImport_RoundTrips(t *testing.T) {
+	p := testPalette9()
+	path := filepath.Join(t.TempDir(), "theme.json")
+
+	if err := ExportToFile(path, p); err != nil {
+		t.Fatalf("ExportToFile: %v", err)
+	}
+	got, err := ImportFromFile(path)
+	if err != nil {
+		t.Fatalf("ImportFromFile: %v", err)
+	}
+	if got != p {
+		t.Errorf("round-tripped palette = %+v, want %+v", got, p)
+	}
+}
+
+func TestExportToFile_ExpandsHome(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	p := testPalette9()
+	if err := ExportToFile("~/theme.json", p); err != nil {
+		t.Fatalf("ExportToFile: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "theme.json")); err != nil {
+		t.Errorf("expected file at expanded home path: %v", err)
+	}
+}
+
+func TestImportFromFile_MissingFile(t *testing.T) {
+	_, err := ImportFromFile(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err == nil {
+		t.Error("expected an error for a missing file")
+	}
+}
+
+func TestImportFromFile_InvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "theme.json")
+	if err := os.WriteFile(path, []byte("not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ImportFromFile(path)
+	if err == nil {
+		t.Error("expected an error for invalid JSON")
+	}
+}
+
+func TestImportFromFile_ValidJSON_InvalidPalette(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "theme.json")
+	// Valid JSON, but missing required color fields (all empty strings).
+	if err := os.WriteFile(path, []byte(`{"Foreground":"not-a-color"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ImportFromFile(path)
+	if !errors.Is(err, ErrInvalidThemeFile) {
+		t.Errorf("expected ErrInvalidThemeFile, got %v", err)
 	}
 }


### PR DESCRIPTION
﻿## Summary
Lets a saved custom theme be exported to a plain JSON file and imported back, so users can archive theirs or exchange them with others. Only the "custom" theme slot is ever involved on either side — you can't export a built-in, and import only ever overwrites the custom slot.

- **`theme.ExportToFile`/`ImportFromFile`**: plain JSON, `Palette` marshaled directly (no struct tags needed — same shape it already has nested inside `~/.cyber-tui.json`'s `customPalette`). `ExpandHome` resolves a leading `~`. `ImportFromFile` fails closed with `ErrInvalidThemeFile` on anything that parses as JSON but doesn't pass `Palette.Valid()` — a partially-formed file can never silently overwrite a good saved theme.
- **`screens.PathPromptModel`**: a minimal single-line file-path prompt shared by export and import. No filesystem awareness of its own — `App` owns all I/O and decides what a submitted path means, matching how it already owns `saveConfig`/API calls.
- **Theme picker**: `x` (export, guarded on a saved custom palette existing) and `i` (import, always available) on the "custom" row.
  - Export warns before overwriting an existing file ("file exists — enter again to overwrite") and requires an identical resubmit to proceed.
  - Import validates the file, then hands off to the *existing* theme editor prefilled from it — reviewed and `ctrl+s`-confirmed, never applied blind, the same contract post-theme-import already established.

## Testing
- `go build ./...`, `go test ./...`, `go vet ./...`, `staticcheck ./...` all clean.
- New tests: export/import round-trip + `~` expansion + missing-file/invalid-JSON/fails-Valid() error cases (`theme_test.go`); `PathPromptModel` open/submit/cancel/warning-clearing (`pathprompt_test.go`); picker `x`/`i` guards, export overwrite-then-resubmit flow, import success opening the editor, import failure leaving the saved palette untouched (`app_test.go`), all using `t.TempDir()` for real (fast, isolated) file I/O.
- Not yet click-tested end-to-end in a live terminal session — unit-level behavior only.

## Definition of Done checklist
- [x] Unit tests pass
- [x] No linter warnings (`go vet`, `staticcheck`)
- [x] Documented (`docs/40-custom-themes.md`, `docs/00-project-reference.md` updated)
- [x] Manual smoke test in a live terminal
