### PR TITLE
fix: theme editor ctrl+s unreachable after preview/import, or mid-edit

### DIFF
--- a/docs/40-custom-themes.md
+++ b/docs/40-custom-themes.md
@@ -27,7 +27,7 @@ theme.Set(cfg.Theme)
 2. `↑`/`↓` previews each theme live. On the "custom" row, this only applies if a palette has already been saved (`App.customPalette != nil`) — otherwise the current theme stays put.
 3. `e` on the "custom" row opens the editor (`App.themeEditorOpen`), prefilled from the saved palette if one exists, otherwise from `theme.CurrentPalette()` (whatever theme is currently active).
 4. In the editor: `j`/`k` moves between the 9 color rows, `enter` focuses a row's 6-digit hex buffer. Each row shows a fixed, non-removable `#` followed by 6 editable slots. Typing an alphanumeric character overwrites the slot under the cursor (uppercased automatically) and advances to the next slot — except on the last slot, where the cursor stays put since there's nowhere further to go. `←`/`→` move the cursor within the 6 slots (clamped at both ends); `backspace` clears the current slot and steps back. `enter`/`esc` commits the field and returns to row navigation. Every edit emits `screens.PreviewPaletteMsg`, which `App.handleThemeEditor` applies via `theme.SetCustomPalette` + `refreshViewports()` for live preview.
-5. `ctrl+s` (when dirty and all 9 fields are valid `#RRGGBB`) emits `screens.SaveThemeMsg`. `App.handleThemeEditor` updates `App.customPalette` and persists via `saveConfig` (sets both `cfg.Theme = "custom"` and `cfg.CustomPalette`).
+5. `ctrl+s` (whenever all 9 fields are currently valid `#RRGGBB` — regardless of whether a field is focused or anything has actually changed since the prefill) emits `screens.SaveThemeMsg`. This is checked ahead of the editing/nav-mode split in `Update`, not gated on `IsDirty()`: a `T`/import prefill with zero edits must still be savable as-is. `App.handleThemeEditor` updates `App.customPalette` and persists via `saveConfig` (sets both `cfg.Theme = "custom"` and `cfg.CustomPalette`).
 6. `esc` (row-nav mode) emits `screens.CloseThemeEditorMsg`, which reverts to the theme that was active before the editor opened (`App.themeEditorOrig`) and closes without saving. If that theme was `"custom"`, the revert also restores `App.themeEditorOrigPalette` — a snapshot of `theme.CurrentPalette()` taken *before* the preview started — into `theme.customPalette` first; without this, `theme.Set("custom")` alone would just re-apply whatever the abandoned edit left in that shared package-level variable instead of the actual prior saved colors. (This was a real bug in the first version of this feature, fixed alongside Post Theme Import below since that entry path needs the same correct revert.)
 
 ### Post Theme Import
@@ -136,7 +136,7 @@ type Config struct {
 | `←`/`→` | editor (editing) | Move within the 6 hex-digit slots, clamped at both ends |
 | `backspace` | editor (editing) | Clear the current slot, step back |
 | `enter`/`esc` | editor (editing) | Commit the field, back to row nav |
-| `ctrl+s` | editor (row nav) | Save custom palette |
+| `ctrl+s` | editor (row nav or mid-edit) | Save the current palette — works regardless of whether a field is focused, and even with no edits at all (e.g. right after `T`/import, to accept it as-is); blocked only if a color is currently invalid |
 | `esc` | editor (row nav) | Close without saving, revert theme |
 | `T` | Post Detail, post focused (not a reply) | Preview a detected post theme — opens the editor prefilled from it, when `HasThemeInPost()` |
 | `x` | picker, "custom" row | Export the saved custom theme to a file, when `customPalette != nil` |

--- a/internal/ui/screens/themeeditor.go
+++ b/internal/ui/screens/themeeditor.go
@@ -155,6 +155,20 @@ func (m ThemeEditorModel) Update(msg tea.Msg) (ThemeEditorModel, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// ctrl+s always attempts to save, whether or not a field is
+		// currently focused — currentPalette() already reads the live
+		// buffer, so there's nothing to "flush" first. Checked ahead of the
+		// editing/nav split so it can't be silently swallowed mid-edit.
+		if msg.String() == "ctrl+s" {
+			m.editing = false
+			if !m.IsValid() {
+				m.err = "all colors must be #RRGGBB"
+				return m, nil
+			}
+			p := m.currentPalette()
+			return m, func() tea.Msg { return SaveThemeMsg{Palette: p} }
+		}
+
 		if m.editing {
 			return m.updateEditingKey(msg)
 		}
@@ -168,15 +182,6 @@ func (m ThemeEditorModel) Update(msg tea.Msg) (ThemeEditorModel, tea.Cmd) {
 			m.editing = true
 			m.charCursor = 0
 			return m, nil
-		case "ctrl+s":
-			if m.IsDirty() {
-				if !m.IsValid() {
-					m.err = "all colors must be #RRGGBB"
-					return m, nil
-				}
-				p := m.currentPalette()
-				return m, func() tea.Msg { return SaveThemeMsg{Palette: p} }
-			}
 		case "esc":
 			return m, func() tea.Msg { return CloseThemeEditorMsg{} }
 		}
@@ -280,11 +285,9 @@ func (m ThemeEditorModel) View() string {
 	case m.saved:
 		footer = theme.Highlight.Render("saved!")
 	case m.editing:
-		footer = theme.Subtle.Render("type · overwrite & advance   ←→ · move   enter/esc · commit")
-	case m.IsDirty():
-		footer = theme.Subtle.Render("ctrl+s · save   esc · close")
+		footer = theme.Subtle.Render("type · overwrite & advance   ←→ · move   ctrl+s · save   enter/esc · commit")
 	default:
-		footer = theme.Subtle.Render("enter · edit field   j/k · move   esc · close")
+		footer = theme.Subtle.Render("enter · edit field   j/k · move   ctrl+s · save   esc · close")
 	}
 	rows = append(rows, "", footer)
 

--- a/internal/ui/screens/themeeditor_test.go
+++ b/internal/ui/screens/themeeditor_test.go
@@ -147,6 +147,62 @@ func TestThemeEditorModel_CtrlS_NoOp_WhenInvalid(t *testing.T) {
 	}
 }
 
+func TestThemeEditorModel_CtrlS_WorksWhileMidFieldEdit(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter")) // focus row 0, still editing — no commit
+	m, _ = m.Update(runeMsg("9"))
+	if !m.editing {
+		t.Fatal("expected to still be mid-edit before ctrl+s")
+	}
+
+	m, cmd := m.Update(keyMsg("ctrl+s"))
+	if cmd == nil {
+		t.Fatal("expected ctrl+s to save even while a field is focused")
+	}
+	if _, ok := cmd().(SaveThemeMsg); !ok {
+		t.Errorf("expected SaveThemeMsg, got %T", cmd())
+	}
+	if m.editing {
+		t.Error("expected ctrl+s to close the focused field")
+	}
+}
+
+func TestThemeEditorModel_CtrlS_SavesUnchangedPrefill_NotDirty(t *testing.T) {
+	// Mirrors opening the editor via T (post-theme preview) or file import:
+	// the prefill IS the palette to keep, so ctrl+s must work with zero edits.
+	p := testPalette()
+	m := NewThemeEditorModel(p)
+	if m.IsDirty() {
+		t.Fatal("expected a fresh editor to not be dirty")
+	}
+
+	_, cmd := m.Update(keyMsg("ctrl+s"))
+	if cmd == nil {
+		t.Fatal("expected ctrl+s to save an unmodified (but valid) prefill")
+	}
+	msg, ok := cmd().(SaveThemeMsg)
+	if !ok {
+		t.Fatalf("expected SaveThemeMsg, got %T", cmd())
+	}
+	if msg.Palette != p {
+		t.Errorf("saved palette = %+v, want the unmodified prefill %+v", msg.Palette, p)
+	}
+}
+
+func TestThemeEditorModel_CtrlS_MidFieldEdit_InvalidStillBlocks(t *testing.T) {
+	m := NewThemeEditorModel(testPalette())
+	m, _ = m.Update(keyMsg("enter"))
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace}) // clears slot 0 — malformed hex, still mid-edit
+
+	m, cmd := m.Update(keyMsg("ctrl+s"))
+	if cmd != nil {
+		t.Error("expected no cmd from ctrl+s with invalid input, even mid-edit")
+	}
+	if m.err == "" {
+		t.Error("expected err to be set")
+	}
+}
+
 func TestThemeEditorModel_Esc_EmitsCloseThemeEditorMsg(t *testing.T) {
 	m := NewThemeEditorModel(testPalette())
 	_, cmd := m.Update(keyMsg("esc"))


### PR DESCRIPTION
﻿## Summary
Fixes a reported bug: previewing a theme from a post (`T`) had no way to actually apply it, and editing a custom theme manually had no way to save it either.

Two distinct bugs, one root cause in `internal/ui/screens/themeeditor.go`'s `Update`:

1. **`ctrl+s` was unreachable while a field was focused.** `updateEditingKey` (the handler used whenever `m.editing == true`) only recognized enter/esc/left/right/backspace/alnum-rune — `ctrl+s` fell through to a silent no-op. You had to remember to press `enter`/`esc` first to back out of the field before save worked at all.
2. **`ctrl+s` was gated on `IsDirty()`**, which compares the live palette against the editor's *prefill baseline* — not against what's actually persisted. Right after `T` (post-theme preview) or file import, the prefill *is* the palette you want to keep, so nothing looks "dirty" and `ctrl+s` silently did nothing. There was no way to accept a previewed/imported theme as-is without a throwaway edit first.

## Fix
`ctrl+s` is now checked once, ahead of the editing/nav-mode branch, so it works identically regardless of focus state — `currentPalette()` already reads the live buffer directly, nothing needs to be "flushed" first. The `IsDirty()` gate is dropped entirely (a save with nothing changed is a harmless redundant write); `IsValid()` still blocks save on a malformed color. Footer hint updated to always mention `ctrl+s` rather than only when dirty.

## Testing
- New tests: `ctrl+s` while mid-field-edit saves; `ctrl+s` immediately after a fresh (not-dirty) prefill saves — the exact `T`/import scenario; `ctrl+s` with an invalid color mid-edit still blocks and sets the error.
- Existing dirty/invalid tests unaffected.
- `go build ./...`, `go test ./...`, `go vet ./...`, `staticcheck ./...` all clean.
- Not yet click-tested end-to-end in a live terminal session — unit-level behavior only.

## Definition of Done checklist
- [x] Unit tests pass
- [x] No linter warnings (`go vet`, `staticcheck`)
- [x] Documented (`docs/40-custom-themes.md` key bindings + data flow updated)
- [ ] Manual smoke test in a live terminal
