### PR TITLE
feat: detect relabeled/reply theme blocks and CSS color values

### DIFF
--- a/docs/40-custom-themes.md
+++ b/docs/40-custom-themes.md
@@ -4,7 +4,7 @@
 
 Alongside the 4 built-in themes (cyber, c64, vt320, bland), users can build and save their own "custom" theme from inside the TUI. The custom theme is a palette edited via a modal opened from the existing theme picker (`t`), and persisted to `~/.cyber-tui.json`.
 
-Users on cyberspace.online also post custom themes as formatted text blocks (base theme + hex colors + some webui-only font/effect fields). Post Detail's `T` key detects one of these blocks and opens the same theme editor prefilled from it, so trying it out and saving/canceling both reuse the manual editor's existing preview/save/revert contract — see Post Theme Import below.
+Users on cyberspace.online also post custom themes as formatted text blocks (base theme + hex colors + some webui-only font/effect fields), in top-level posts and replies alike. Post Detail's `T` key detects a block in whichever's currently selected — the post itself, or a reply — and opens the same theme editor prefilled from it, so trying it out and saving/canceling both reuse the manual editor's existing preview/save/revert contract — see Post Theme Import below.
 
 ---
 
@@ -32,10 +32,10 @@ theme.Set(cfg.Theme)
 
 ### Post Theme Import
 
-1. `PostDetailModel.SetPost` calls `theme.ParsePost(post.Content)` once per post load (not per keystroke) and stores the result in `postTheme *theme.Palette` (nil if no theme block was detected). `HasThemeInPost()` exposes this for the `T` hint (shown in the footer and help modal only when a block was found) and both layouts' `screenHints`.
-2. `T`, pressed with the post itself focused (not a reply) and a block detected, emits `screens.PreviewPostThemeMsg{Palette}`.
-3. `App`'s handler snapshots `themeEditorOrig`/`themeEditorOrigPalette` (as above), then previews and opens the theme editor exactly like the picker's `e` key — but prefilled from the parsed post palette instead of the current theme. From here it's the same editor: review the swatches, tweak anything, `ctrl+s` to keep it (persists as the new custom theme and activates it) or `esc` to cancel (reverts fully to whatever was active before).
-4. Detection is post-body only, not replies — matches how these blocks are actually shared (their own top-level post) and keeps parsing a one-time cost per post load.
+1. `PostDetailModel.SetPost` calls `theme.ParsePost(post.Content)` once per post load (not per keystroke) and stores the result in `postTheme *theme.Palette` (nil if no theme block was detected). `currentTheme()` returns `postTheme` when the post itself is selected, or parses the currently selected reply's content on demand (`theme.ParsePost(reply.Content)`, not cached — reply content is small and the scan is cheap). `HasTheme()` exposes this for the `T` hint (shown in the footer and help modal only when a block was found in whatever's currently selected) and both layouts' `screenHints`.
+2. `T`, pressed with a block detected in the current selection (post or reply), emits `screens.PreviewPostThemeMsg{Palette}`.
+3. `App`'s handler snapshots `themeEditorOrig`/`themeEditorOrigPalette` (as above), then previews and opens the theme editor exactly like the picker's `e` key — but prefilled from the parsed palette instead of the current theme. From here it's the same editor: review the swatches, tweak anything, `ctrl+s` to keep it (persists as the new custom theme and activates it) or `esc` to cancel (reverts fully to whatever was active before).
+4. Detection is scoped to whatever's currently selected — the post, or one reply at a time — not a scan of the whole thread at once.
 
 See `theme.ParsePost`'s doc comment and the post-field mapping table below for how the block's fields resolve.
 
@@ -107,10 +107,11 @@ Fields are named to line up with the theme blocks users post on cyberspace.onlin
 | *(no post field)* | `Accent`, `Error`, `BarText`, `Self`, `Meta` | TUI-only roles with no webui-post equivalent; resolved from the base theme (see below) |
 
 `ParsePost(content string) (Palette, bool)`:
-1. Looks for the marker line (`/* Cyberspace Custom Theme */`, case-insensitive substring match). Absent → `ok=false`; nothing else matters.
-2. Scans up to 30 lines after the marker for a known field name followed by its value, found *anywhere* within the line (`postFieldLineRe` is deliberately not anchored to the line's start/end); everything not in its 7-name alternation (`Main Font`, `Disable Text Glow`, `/* Colors */`, etc. — webui-only, no `Palette` field) is simply never matched, no special-casing needed to ignore it. Users paste the exported block into a post using whatever markdown styling their client applies — the web UI wraps each line in backticks (e.g. `` `Foreground: #ff5d00` ``), other posts have been seen with `> ` blockquote markers instead, sometimes nested or combined (e.g. `` > `Foreground: #ff5d00` ``) — and since the regex isn't anchored, that decoration just falls outside the match rather than needing to be recognized and stripped. The value alternatives are narrow (an exact 6-digit hex, or a bare word for `Base Theme` names) so decoration stuck directly onto a value's end can't leak into the capture either. This was a real bug in an earlier version of this parser (anchored `^...$` regex, required the whole line to be exactly `Key: value`): `T` would enable normally (the marker is matched by loose substring, unaffected) but the preview silently fell back to the current theme for every field, since none of them ever matched with any wrapping present.
-3. Resolves the base palette: if `Base Theme` names one of our own built-ins (`cyber`/`c64`/`vt320`/`bland`, case-insensitive) → `builtinPalettes[name]`, the actual author-intended values for the unmapped fields; otherwise → `CurrentPalette()` (today's active theme), since inventing values for an unrecognized name would just be guessing.
-4. Overlays each recognized color field onto the base **only if `ValidHex` passes** — a malformed or missing individual field silently falls back to the base's value rather than invalidating the whole block (a typo in one line shouldn't discard an otherwise-good theme). `ok=true` as long as the marker was found, even in this degenerate case.
+1. Looks for the marker line (`/* Cyberspace Custom Theme */`, case-insensitive substring match). If found, fields are scanned from the 30 lines after it (step 2), and `ok=true` regardless of how many fields actually matched.
+2. Scans for a known field name followed by its value, found *anywhere* within the line (`postFieldLineRe` is deliberately not anchored to the line's start/end); everything not in its 7-name alternation (`Main Font`, `Disable Text Glow`, `/* Colors */`, etc. — webui-only, no `Palette` field) is simply never matched, no special-casing needed to ignore it. Users paste the exported block into a post using whatever markdown styling their client applies — the web UI wraps each line in backticks (e.g. `` `Foreground: #ff5d00` ``), other posts have been seen with `> ` blockquote markers instead, sometimes nested or combined (e.g. `` > `Foreground: #ff5d00` ``) — and since the regex isn't anchored, that decoration just falls outside the match rather than needing to be recognized and stripped. The value alternatives are narrow (an exact 6-digit hex, or a bare word for `Base Theme` names) so decoration stuck directly onto a value's end can't leak into the capture either. This was a real bug in an earlier version of this parser (anchored `^...$` regex, required the whole line to be exactly `Key: value`): `T` would enable normally (the marker is matched by loose substring, unaffected) but the preview silently fell back to the current theme for every field, since none of them ever matched with any wrapping present.
+3. **Marker-absent fallback**: some users relabel or edit the marker line when pasting a block into a post, so its absence doesn't end detection — the whole content is scanned for field lines instead of just the 30 lines after a marker. `ok=true` only if at least `minFieldsForDetection` (2) distinct fields matched *and* the matched lines fall within `postParseWindow` (30) lines of each other — one stray matched word, or two unrelated mentions spread across a long post, aren't enough signal on their own.
+4. Resolves the base palette: if `Base Theme` names one of our own built-ins (`cyber`/`c64`/`vt320`/`bland`, case-insensitive) → `builtinPalettes[name]`, the actual author-intended values for the unmapped fields; otherwise → `CurrentPalette()` (today's active theme), since inventing values for an unrecognized name would just be guessing.
+5. Overlays each recognized color field onto the base **only if the value resolves to hex via `parseCSSColor`** — a malformed or missing individual field silently falls back to the base's value rather than invalidating the whole block (a typo in one line shouldn't discard an otherwise-good theme). `parseCSSColor` accepts a value already in `#RRGGBB` form, or an `rgb()`/`rgba()`/`hsl()`/`hsla()` CSS function call (e.g. `hsla(0, 0%, 100%, .75)`), converting it to hex. HSL→RGB math is done by `github.com/lucasb-eyer/go-colorful` (already pulled in transitively via lipgloss/termenv). An alpha component (the `a` variants) is **composited against a fixed black background** rather than discarded — `hsla(0,0%,100%,.4)` becomes `#666666`, not `#FFFFFF` — since theme authors commonly derive a dimmed/border variant of a base color purely via alpha; dropping it would collapse those fields to the same full-opacity color as the base.
 
 ```go
 // internal/config
@@ -140,7 +141,7 @@ type Config struct {
 | `enter`/`esc` | editor (editing) | Commit the field, back to row nav |
 | `ctrl+s` | editor (row nav or mid-edit) | Save the current palette — works regardless of whether a field is focused, and even with no edits at all (e.g. right after `T`/import, to accept it as-is); blocked only if a color is currently invalid |
 | `esc` | editor (row nav) | Close without saving, revert theme |
-| `T` | Post Detail, post focused (not a reply) | Preview a detected post theme — opens the editor prefilled from it, when `HasThemeInPost()` |
+| `T` | Post Detail, post or reply focused | Preview a detected theme block in whatever's currently selected — opens the editor prefilled from it, when `HasTheme()` |
 | `x` | picker, any row | Export the highlighted row's theme to a file (guarded only on the "custom" row having nothing saved yet) |
 | `i` | picker, any row | Import a theme file — opens the editor prefilled from it for review |
 | `enter` | path prompt | Submit the path (a second identical submit confirms an export overwrite) |
@@ -172,7 +173,10 @@ Same as the Settings screen: edits accumulate in memory (with live preview) unti
 - [x] Live preview while editing
 - [x] Ephemeral (SSH) sessions: editing works, persistence no-ops
 - [x] `builtinPalettes` data table + `theme.ParsePost` (detects and resolves a post's theme block)
-- [x] Post Detail's `T` key + `HasThemeInPost()` hint, wired into both layouts
+- [x] Post Detail's `T` key + `HasTheme()` hint, wired into both layouts
+- [x] Marker-absent fallback: field-cluster detection when the marker line is relabeled or missing (`minFieldsForDetection`, `postParseWindow`-bounded clustering), covered by tests
+- [x] Detection extended to replies: `T`/`HasTheme()` scoped to whichever's currently selected (post or reply), parsed on demand
+- [x] `rgb()`/`rgba()`/`hsl()`/`hsla()` color values accepted alongside hex (`parseCSSColor`, alpha composited against black), covered by tests
 - [x] Revert-on-cancel bug fixed (`themeEditorOrigPalette` snapshot), covered by a regression test
 - [x] Markdown-wrapped post fields bug fixed (`postFieldLineRe` is unanchored and matches a known field name + narrowly-typed value anywhere in the line, so backticks/blockquotes/bold/bullets in any combination simply fall outside the match), covered by a regex-level test on the decoration property plus regression tests using two real posted formats (backtick-wrapped, blockquote-wrapped)
 - [x] `theme.ExportToFile`/`ImportFromFile`/`ExpandHome`

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/ssh v0.0.0-20250826160808-ebfa259c7309
 	github.com/charmbracelet/wish v1.4.7
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/muesli/termenv v0.16.0
 	github.com/yuin/goldmark v1.8.2
@@ -38,7 +39,6 @@ require (
 	github.com/creack/pty v1.1.21 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
-	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -443,7 +443,7 @@ func (l MillerLayout) screenHints(a App) []hint {
 		return []hint{{"j/k", "nav"}, {"l/↵", "enter"}, {"1-9 / g+", "jump"}, {"?", "more"}}
 	case focusDetail:
 		hints := []hint{{"h/←", "list"}, {"j/k", "replies"}, {"↵", "thread"}, {"r", "reply"}}
-		if a.active == screenPostDetail && a.postDetail.HasThemeInPost() {
+		if a.active == screenPostDetail && a.postDetail.HasTheme() {
 			hints = append(hints, hint{"T", "try theme"})
 		}
 		return hints

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -382,7 +382,7 @@ func (l TabsLayout) screenHints(a App) []hint {
 			return []hint{{"Ctrl+s", "send"}, {"Esc", "cancel"}}
 		}
 		hints := []hint{{"↑↓", "navigate"}, {"r", "reply"}, {"b", "bookmark"}, {"w", "watch"}, {"c", "message"}}
-		if a.postDetail.HasThemeInPost() {
+		if a.postDetail.HasTheme() {
 			hints = append(hints, hint{"T", "try theme"})
 		}
 		return append(hints, hint{"esc", "back"}, more)

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -169,9 +169,27 @@ func (m PostDetailModel) SetPost(post model.Post) PostDetailModel {
 	return m
 }
 
-// HasThemeInPost reports whether the currently open post's body contains a
+// currentTheme returns the detected theme block for whatever's currently
+// selected — the post itself (cached in postTheme, computed once in
+// SetPost), or the selected reply's content, parsed on demand. Reply content
+// is small and the regex scan is cheap, so this isn't cached per selection
+// the way postTheme is.
+func (m PostDetailModel) currentTheme() *theme.Palette {
+	if m.selectedReply < 0 {
+		return m.postTheme
+	}
+	if m.selectedReply >= len(m.flatTree) {
+		return nil
+	}
+	if p, ok := theme.ParsePost(m.flatTree[m.selectedReply].Reply.Content); ok {
+		return &p
+	}
+	return nil
+}
+
+// HasTheme reports whether the currently selected post or reply contains a
 // detected custom-theme block (see docs/40-custom-themes.md).
-func (m PostDetailModel) HasThemeInPost() bool { return m.postTheme != nil }
+func (m PostDetailModel) HasTheme() bool { return m.currentTheme() != nil }
 
 // HasPost reports whether a post is currently open or persisted in the
 // background — used by activateScreen to decide whether returning to the
@@ -593,11 +611,8 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 			m, cmd = m.OpenCompose()
 			return m, cmd
 		case "T":
-			// Post-only (not replies) — matches how these theme blocks are
-			// actually shared, and keeps detection a one-time SetPost cost.
-			if m.selectedReply < 0 && m.postTheme != nil {
-				p := *m.postTheme
-				return m, func() tea.Msg { return PreviewPostThemeMsg{Palette: p} }
+			if p := m.currentTheme(); p != nil {
+				return m, func() tea.Msg { return PreviewPostThemeMsg{Palette: *p} }
 			}
 			return m, nil
 		case "p":

--- a/internal/ui/screens/postdetail_test.go
+++ b/internal/ui/screens/postdetail_test.go
@@ -390,21 +390,21 @@ Code: #7A5DFF
 Code BG: #5100ff
 `
 
-func TestPostDetail_ThemeBlockDetected_SetsHasThemeInPost(t *testing.T) {
+func TestPostDetail_ThemeBlockDetected_SetsHasTheme(t *testing.T) {
 	m := initPostDetail()
 	m = m.SetPost(model.Post{ID: "p1", AuthorUsername: "op", Content: postWithThemeBlock})
 
-	if !m.HasThemeInPost() {
-		t.Error("expected HasThemeInPost() == true for a post with a theme block")
+	if !m.HasTheme() {
+		t.Error("expected HasTheme() == true for a post with a theme block")
 	}
 }
 
-func TestPostDetail_NoThemeBlock_HasThemeInPostFalse(t *testing.T) {
+func TestPostDetail_NoThemeBlock_HasThemeFalse(t *testing.T) {
 	m := initPostDetail()
 	m = m.SetPost(pdPost("p1")) // plain "original post" content, no theme block
 
-	if m.HasThemeInPost() {
-		t.Error("expected HasThemeInPost() == false for a post without a theme block")
+	if m.HasTheme() {
+		t.Error("expected HasTheme() == false for a post without a theme block")
 	}
 }
 
@@ -435,19 +435,51 @@ func TestPostDetail_T_NoOp_WhenNoThemeBlock(t *testing.T) {
 	}
 }
 
-func TestPostDetail_T_NoOp_WhenReplySelected(t *testing.T) {
+func TestPostDetail_T_NoOp_WhenSelectedReplyHasNoThemeBlock(t *testing.T) {
 	m := initPostDetail()
 	now := time.Now()
 	m = m.SetPost(model.Post{ID: "p1", AuthorUsername: "op", Content: postWithThemeBlock})
-	m = m.SetReplies([]model.Reply{pdReply("r1", "", "alice", now)})
+	m = m.SetReplies([]model.Reply{pdReply("r1", "", "alice", now)}) // plain content, no theme block
 
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}) // select the reply
 	if m.SelectedReplyID() != "r1" {
 		t.Fatal("expected the reply to be selected")
 	}
 
+	if m.HasTheme() {
+		t.Error("expected HasTheme() == false for a reply without a theme block, even though the post has one")
+	}
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("T")})
 	if cmd != nil {
-		t.Error("expected T to no-op when a reply (not the post) is selected, even with a theme block present")
+		t.Error("expected T to no-op when the selected reply has no theme block, even though the post does")
+	}
+}
+
+func TestPostDetail_T_EmitsPreviewPostThemeMsg_WhenSelectedReplyHasThemeBlock(t *testing.T) {
+	m := initPostDetail()
+	now := time.Now()
+	m = m.SetPost(pdPost("p1")) // plain post content, no theme block
+	reply := pdReply("r1", "", "alice", now)
+	reply.Content = postWithThemeBlock
+	m = m.SetReplies([]model.Reply{reply})
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}) // select the reply
+	if m.SelectedReplyID() != "r1" {
+		t.Fatal("expected the reply to be selected")
+	}
+
+	if !m.HasTheme() {
+		t.Error("expected HasTheme() == true for a reply with a theme block")
+	}
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("T")})
+	if cmd == nil {
+		t.Fatal("expected a cmd from T when the selected reply has a theme block")
+	}
+	msg, ok := cmd().(screens.PreviewPostThemeMsg)
+	if !ok {
+		t.Fatalf("expected PreviewPostThemeMsg, got %T", cmd())
+	}
+	if msg.Palette.Foreground != "#d000ff" {
+		t.Errorf("Palette.Foreground = %q, want #d000ff", msg.Palette.Foreground)
 	}
 }

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -3,12 +3,15 @@ package theme
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	colorful "github.com/lucasb-eyer/go-colorful"
 )
 
 // Layout constants — shared across app and screens so viewport heights
@@ -243,14 +246,23 @@ func CurrentPalette() Palette {
 
 // postThemeMarker is the fixed marker line cyberspace.online's web UI emits
 // at the top of a posted custom-theme block. Its presence (case-insensitive
-// substring match) is what triggers detection; everything else is lenient.
+// substring match) is the fast path that triggers detection. Users often
+// relabel or edit this line when pasting a block into a post, so its absence
+// doesn't rule out a theme block — see the fallback in ParsePost.
 const postThemeMarker = "cyberspace custom theme"
 
 // postParseWindow bounds how many lines after the marker ParsePost scans for
 // "Key: value" fields — generous for the known fixed format (under 20 lines)
 // without letting a false-positive scan run into unrelated later content in
-// a long post.
+// a long post. Also used, when the marker is absent, as the maximum spread
+// between the first and last matched field line for the fallback below.
 const postParseWindow = 30
+
+// minFieldsForDetection is the minimum number of distinct recognized fields
+// required to treat a post as containing a theme block when the marker line
+// is missing — one matched word alone (e.g. a post that just says "the
+// border looks off") isn't enough signal on its own.
+const minFieldsForDetection = 2
 
 // postFieldLineRe matches a known field name and its value anywhere within a
 // line, e.g. "Foreground: #d000ff" or "Base Theme: vt320" — deliberately not
@@ -258,12 +270,119 @@ const postParseWindow = 30
 // line in (backticks, blockquotes, bold, bullets, any combination or
 // nesting, e.g. "> `Foreground: #ff5d00`") simply falls outside the match
 // instead of needing to be stripped first. The value alternatives are narrow
-// (an exact 6-digit hex, or a bare word for Base Theme names) so decoration
+// (an exact 6-digit hex, an rgb()/rgba()/hsl()/hsla() CSS function call —
+// see parseCSSColor — or a bare word for Base Theme names) so decoration
 // stuck directly onto a value's end (e.g. "#ff5d00`") can't leak into the
-// capture either. "code bg" is listed before "code" so "Code BG: ..." binds
-// to the more specific alternative. Field names not in this list (comments
-// like "/* Colors */", webui-only fields like "Main Font") never match.
-var postFieldLineRe = regexp.MustCompile(`(?i)(base theme|code bg|foreground|background|dimmed|border|code)\s*:\s*(#[0-9A-Fa-f]{6}|[A-Za-z0-9_-]+)`)
+// capture either. The CSS-function alternative is listed before the bare
+// word one so it wins in full rather than being truncated at the value's
+// leading letters (Go's regexp prefers the first alternative that matches).
+// "code bg" is listed before "code" so "Code BG: ..." binds to the more
+// specific alternative. Field names not in this list (comments like
+// "/* Colors */", webui-only fields like "Main Font") never match.
+var postFieldLineRe = regexp.MustCompile(`(?i)(base theme|code bg|foreground|background|dimmed|border|code)\s*:\s*(#[0-9A-Fa-f]{6}|(?:rgba?|hsla?)\([^)]*\)|[A-Za-z0-9_-]+)`)
+
+// cssColorFuncRe matches an rgb()/rgba()/hsl()/hsla() CSS color function
+// call, e.g. "hsla(0, 0%, 100%, .75)" or "rgb(255,0,128)".
+var cssColorFuncRe = regexp.MustCompile(`(?i)^(rgba?|hsla?)\(([^)]*)\)$`)
+
+// parseCSSColor resolves a post field's color value to a "#RRGGBB" hex
+// string: passes an already-valid hex value through unchanged, or converts
+// an rgb()/rgba()/hsl()/hsla() CSS function call. An alpha component (the
+// "a" variants) is composited against a fixed black background rather than
+// discarded — theme authors commonly derive a dimmed/border variant of a
+// base color purely via alpha (e.g. "hsla(0,0%,100%,.4)" as a faded-white
+// border), and dropping it would collapse every such field to the same
+// full-opacity color. Returns ok=false for anything else (malformed value,
+// unrecognized function, wrong component count).
+func parseCSSColor(v string) (string, bool) {
+	if ValidHex(v) {
+		return v, true
+	}
+	m := cssColorFuncRe.FindStringSubmatch(v)
+	if m == nil {
+		return "", false
+	}
+	parts := strings.Split(m[2], ",")
+	if len(parts) < 3 {
+		return "", false
+	}
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+
+	var r, g, b uint8
+	if strings.HasPrefix(strings.ToLower(m[1]), "rgb") {
+		rr, ok1 := parseByteComponent(parts[0])
+		gg, ok2 := parseByteComponent(parts[1])
+		bb, ok3 := parseByteComponent(parts[2])
+		if !ok1 || !ok2 || !ok3 {
+			return "", false
+		}
+		r, g, b = rr, gg, bb
+	} else {
+		h, err := strconv.ParseFloat(strings.TrimSuffix(parts[0], "deg"), 64)
+		s, ok2 := parsePercentComponent(parts[1])
+		l, ok3 := parsePercentComponent(parts[2])
+		if err != nil || !ok2 || !ok3 {
+			return "", false
+		}
+		c := colorful.Hsl(h, s, l)
+		r = uint8(c.R*255 + 0.5)
+		g = uint8(c.G*255 + 0.5)
+		b = uint8(c.B*255 + 0.5)
+	}
+
+	alpha := 1.0
+	if len(parts) >= 4 {
+		a, ok := parseAlphaComponent(parts[3])
+		if !ok {
+			return "", false
+		}
+		alpha = a
+	}
+	if alpha < 1 {
+		// Black background, so alpha-over compositing reduces to a plain
+		// per-channel scale — not the post's own Background field, which
+		// would need resolving before every other field and is itself
+		// reserved/unused elsewhere in Palette.
+		r = uint8(float64(r)*alpha + 0.5)
+		g = uint8(float64(g)*alpha + 0.5)
+		b = uint8(float64(b)*alpha + 0.5)
+	}
+	return fmt.Sprintf("#%02X%02X%02X", r, g, b), true
+}
+
+// parseByteComponent parses an rgb()/rgba() 0-255 integer component.
+func parseByteComponent(s string) (uint8, bool) {
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 || n > 255 {
+		return 0, false
+	}
+	return uint8(n), true
+}
+
+// parseAlphaComponent parses an rgba()/hsla() alpha component: a 0-1 float
+// (".75", "0.4", "1") or a percentage ("40%").
+func parseAlphaComponent(s string) (float64, bool) {
+	if strings.HasSuffix(s, "%") {
+		return parsePercentComponent(s)
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil || f < 0 || f > 1 {
+		return 0, false
+	}
+	return f, true
+}
+
+// parsePercentComponent parses an hsl()/hsla() saturation or lightness
+// component (e.g. "100%") into the 0-1 range colorful.Hsl expects.
+func parsePercentComponent(s string) (float64, bool) {
+	f, err := strconv.ParseFloat(strings.TrimSuffix(s, "%"), 64)
+	if err != nil {
+		return 0, false
+	}
+	return f / 100, true
+}
 
 // ParsePost scans content for a posted custom-theme block (see
 // docs/40-custom-themes.md) and returns the resulting Palette. Fields the
@@ -272,9 +391,17 @@ var postFieldLineRe = regexp.MustCompile(`(?i)(base theme|code bg|foreground|bac
 // "Base Theme" names one of our own built-ins (case-insensitive), that
 // theme's full palette is used; otherwise CurrentPalette() (today's active
 // theme). The block's explicit, validly-hex fields are then overlaid on
-// top. Returns ok=false only when the marker itself isn't present — an
-// otherwise-malformed block still returns ok=true with the base palette
-// unchanged for any field it couldn't parse.
+// top.
+//
+// Detection has two paths. If the marker line is found, fields are scanned
+// from the 30 lines after it and ok=true regardless of how many fields
+// actually matched — an otherwise-malformed block still returns the base
+// palette unchanged for any field it couldn't parse. If the marker is
+// missing (someone relabeled or edited the header when pasting), the whole
+// content is scanned for field lines instead; ok=true only if at least
+// minFieldsForDetection distinct fields matched within postParseWindow lines
+// of each other, so a lone matched word or two unrelated mentions far apart
+// in a long post don't false-trigger.
 func ParsePost(content string) (Palette, bool) {
 	lines := strings.Split(content, "\n")
 	markerIdx := -1
@@ -284,19 +411,32 @@ func ParsePost(content string) (Palette, bool) {
 			break
 		}
 	}
-	if markerIdx == -1 {
-		return Palette{}, false
+
+	scanFrom, scanTo := 0, len(lines)
+	if markerIdx != -1 {
+		scanFrom = markerIdx + 1
+		scanTo = min(scanFrom+postParseWindow, len(lines))
 	}
 
-	end := min(markerIdx+1+postParseWindow, len(lines))
 	fields := make(map[string]string)
-	for _, line := range lines[markerIdx+1 : end] {
-		m := postFieldLineRe.FindStringSubmatch(line)
+	firstFieldIdx, lastFieldIdx := -1, -1
+	for i := scanFrom; i < scanTo; i++ {
+		m := postFieldLineRe.FindStringSubmatch(lines[i])
 		if m == nil {
 			continue
 		}
+		if firstFieldIdx == -1 {
+			firstFieldIdx = i
+		}
+		lastFieldIdx = i
 		key := strings.ToLower(m[1])
 		fields[key] = m[2]
+	}
+
+	if markerIdx == -1 {
+		if len(fields) < minFieldsForDetection || lastFieldIdx-firstFieldIdx > postParseWindow {
+			return Palette{}, false
+		}
 	}
 
 	base := CurrentPalette()
@@ -307,8 +447,10 @@ func ParsePost(content string) (Palette, bool) {
 	}
 
 	overlay := func(dst *string, key string) {
-		if v, ok := fields[key]; ok && ValidHex(v) {
-			*dst = v
+		if v, ok := fields[key]; ok {
+			if hex, ok := parseCSSColor(v); ok {
+				*dst = hex
+			}
 		}
 	}
 	overlay(&base.Foreground, "foreground")

--- a/internal/ui/theme/theme_test.go
+++ b/internal/ui/theme/theme_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -245,6 +246,46 @@ func TestParsePost_NoMarker_NotDetected(t *testing.T) {
 	}
 }
 
+func TestParsePost_NoMarker_OneFieldOnly_NotDetected(t *testing.T) {
+	_, ok := ParsePost("my new setup, the border looks great: Border: #270082")
+	if ok {
+		t.Error("expected ok=false when only one field matches and the marker is absent")
+	}
+}
+
+func TestParsePost_NoMarker_ClusteredFields_DetectedViaFallback(t *testing.T) {
+	body := `My Custom Theme
+Base Theme: vt320
+Foreground: #d000ff
+Border: #270082
+`
+	p, ok := ParsePost(body)
+	if !ok {
+		t.Fatal("expected ok=true via the field-based fallback when the marker is relabeled")
+	}
+	vt320 := builtinPalettes["vt320"]
+	if p.Accent != vt320.Accent {
+		t.Errorf("Accent = %q, want vt320's %q (base theme should still resolve)", p.Accent, vt320.Accent)
+	}
+	if p.Foreground != "#d000ff" || p.Border != "#270082" {
+		t.Errorf("explicit fields not overlaid correctly: %+v", p)
+	}
+}
+
+func TestParsePost_NoMarker_FieldsTooFarApart_NotDetected(t *testing.T) {
+	lines := make([]string, 0, postParseWindow+10)
+	lines = append(lines, "Foreground: #d000ff")
+	for range postParseWindow + 2 {
+		lines = append(lines, "just some unrelated line of text")
+	}
+	lines = append(lines, "Border: #270082")
+
+	_, ok := ParsePost(strings.Join(lines, "\n"))
+	if ok {
+		t.Error("expected ok=false when matched fields are spread further apart than postParseWindow")
+	}
+}
+
 func TestParsePost_KnownBaseTheme_FillsUnmappedFromIt(t *testing.T) {
 	p, ok := ParsePost(examplePostBody)
 	if !ok {
@@ -370,6 +411,65 @@ func TestParsePost_BlockquoteWrappedFields_StillOverlay(t *testing.T) {
 	if p.Foreground != "#f4a4c0" || p.Background != "#450d59" || p.Dimmed != "#ee719e" ||
 		p.Border != "#e63b7a" || p.Highlight != "#c3d117" || p.CodeBackground != "#6f760a" {
 		t.Errorf("blockquote-wrapped fields not overlaid correctly: %+v", p)
+	}
+}
+
+// --- CSS color functions (rgb/rgba/hsl/hsla) ---
+
+func TestParseCSSColor(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"#D000FF", "#D000FF", true},                    // plain hex passes through unchanged
+		{"rgb(255,0,128)", "#FF0080", true},              // no spaces, no alpha
+		{"rgb(255, 0, 128)", "#FF0080", true},            // spaces after commas
+		{"rgba(255, 0, 128, 0.8)", "#CC0066", true},      // alpha composited against black
+		{"hsl(0,0%,100%)", "#ffffff", true},              // white, no alpha
+		{"hsla(0,0%,100%,.75)", "#BFBFBF", true},         // alpha composited against black
+		{"hsla(0,0%,100%,40%)", "#666666", true},         // alpha as a percentage
+		{"hsla(0, 0%, 0%, 1)", "#000000", true},          // alpha=1, black stays black
+		{"rgb(255,0)", "", false},                        // too few components
+		{"rgb(300,0,0)", "", false},                      // out of range
+		{"rgb(x,0,0)", "", false},                        // non-numeric
+		{"rgba(255,0,0,1.5)", "", false},                 // alpha out of range
+		{"rgba(255,0,0,x)", "", false},                   // alpha non-numeric
+		{"cmyk(0,0,0,0)", "", false},                     // unrecognized function
+		{"hsla(0,0%,100%,.75", "", false},                // unclosed paren
+		{"vt320", "", false},                             // bare word, not a color
+	}
+	for _, c := range cases {
+		got, ok := parseCSSColor(c.in)
+		if ok != c.wantOK {
+			t.Errorf("parseCSSColor(%q) ok = %v, want %v", c.in, ok, c.wantOK)
+			continue
+		}
+		if ok && !strings.EqualFold(got, c.want) {
+			t.Errorf("parseCSSColor(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParsePost_HSLAField_OverlaysConvertedHex(t *testing.T) {
+	body := `/* Cyberspace Custom Theme */
+Base Theme: vt320
+Foreground: hsla(0,0%,100%,.75)
+Border: rgb(39,57,57)
+`
+	p, ok := ParsePost(body)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if !strings.EqualFold(p.Foreground, "#BFBFBF") {
+		t.Errorf("Foreground = %q, want #BFBFBF (converted from hsla, alpha composited against black)", p.Foreground)
+	}
+	if !strings.EqualFold(p.Border, "#273939") {
+		t.Errorf("Border = %q, want #273939 (converted from rgb)", p.Border)
+	}
+	vt320 := builtinPalettes["vt320"]
+	if p.Dimmed != vt320.Dimmed {
+		t.Errorf("Dimmed = %q, want vt320's base value %q (field not present in block)", p.Dimmed, vt320.Dimmed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Improves theme-block detection in Post Detail (`T` key):

1. **Marker-relabel fallback** — `ParsePost` no longer requires the exact `"cyberspace custom theme"` marker line. If it's missing (users often relabel/edit the header when pasting), detection falls back to spotting a cluster of >=2 recognized fields within a bounded window of lines.
2. **Reply-scoped detection** — `T`/`HasTheme()` (renamed from `HasThemeInPost`) now checks whichever is currently selected in Post Detail: the post itself, or a reply, parsed on demand.
3. **CSS color function support** — theme field values may now be `rgb()`/`rgba()`/`hsl()`/`hsla()` in addition to `#RRGGBB` hex, converted via `go-colorful`'s HSL math (already a transitive dependency, promoted to direct). Alpha is composited against a fixed black background rather than discarded, since authors commonly derive dimmed/border color variants purely via alpha (e.g. `hsla(0,0%,100%,.4)` -> `#666666`, not `#FFFFFF`).

## Testing

| Group | Tests | Result |
|---|---|---|
| `internal/ui/theme` | fallback, CSS-color, alpha-compositing (unit + integration) | pass |
| `internal/ui/screens` (postdetail) | reply-theme detection, renamed `HasTheme` cases | pass |
| Full suite (`go test ./...`) | all packages | pass |
| `go vet` / `staticcheck` | — | clean |

## Docs

`docs/40-custom-themes.md` updated: detection steps, key bindings, integration checklist.

## Not included

A full-screen background color fill (rendering `Palette.Background`, currently reserved/unused) was discussed but is scoped to a separate, later feature branch.
