### PR TITLE
Add Sixel graphics protocol support

### DIFF
--- a/cmd/cyber-tui/main.go
+++ b/cmd/cyber-tui/main.go
@@ -36,7 +36,6 @@ func main() {
 		theme.SetCustomPalette(*cfg.CustomPalette)
 	}
 	theme.Set(cfg.Theme)
-	gfxProto := imgview.DetectProtocol()
 
 	if !cfg.UseMock {
 		if err := validateBaseURL(cfg.APIBaseURL, cfg.AllowInsecureAPI); err != nil {
@@ -83,6 +82,12 @@ func main() {
 	}
 
 	// Local TUI mode
+	gfxProto := imgview.DetectProtocol()
+	// Sixel terminals don't set a reliable env var, so probe only when env-var
+	// detection came up empty — Kitty/iTerm2 are higher fidelity when known.
+	if gfxProto == imgview.ProtocolNone && imgview.ProbeSixel(os.Stdin, os.Stdout) {
+		gfxProto = imgview.ProtocolSixel
+	}
 	app := ui.NewApp(newClient()).WithGraphicsProtocol(gfxProto)
 	// Prefer saved session (token-based) over autoEmail/autoPassword credentials.
 	if cfg.RefreshToken != "" {

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,12 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/mattn/go-runewidth v0.0.19
+	github.com/mattn/go-sixel v0.0.12
 	github.com/muesli/termenv v0.16.0
 	github.com/yuin/goldmark v1.8.2
 	golang.org/x/image v0.44.0
+	golang.org/x/sys v0.46.0
+	golang.org/x/term v0.44.0
 	golang.org/x/text v0.40.0
 )
 
@@ -44,9 +47,8 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/soniakeys/quant v1.0.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
-	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2J
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-sixel v0.0.12 h1:pQadX/oJ4fhSi6RnFHggWELW1TvADrQP9b+Kdx1wNzs=
+github.com/mattn/go-sixel v0.0.12/go.mod h1:Z5QJ/vRbnpAl4CTN0NZ0mzURdMccsG7rpGZ5eJfZ6ys=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
@@ -72,6 +74,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y=
+github.com/soniakeys/quant v1.0.0/go.mod h1:HI1k023QuVbD4H8i9YdfZP2munIHU4QpjsImz6Y6zds=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -442,6 +442,13 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.imageCarouselIndex = 0
 		a.imageFetchGen++ // invalidate anything still in flight
 		a.imageCache = nil
+		if a.graphicsProtocol == imgview.ProtocolSixel {
+			// Sixel has no delete-placement primitive like Kitty's a=d,d=A, and
+			// Bubble Tea's diff renderer can skip re-emitting a row whose text
+			// happens to match the prior frame, leaving stray pixels behind. A
+			// full repaint is the only reliable way to clear them.
+			return a, tea.ClearScreen
+		}
 		return a, nil
 	}
 	if a2, cmd, ok := a.handleKeys(msg); ok {
@@ -2334,6 +2341,13 @@ func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 				if err != nil {
 					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
 				}
+			case imgview.ProtocolSixel:
+				var err error
+				cellW, cellH, _ := imgview.TerminalCellPixelSize(int(os.Stdout.Fd()))
+				encodedFrames[i], cols, rows, err = imgview.EncodeSixel(img, displayCols, displayRows, cellW, cellH)
+				if err != nil {
+					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
+				}
 			default:
 				return imageFetchedMsg{rawURL: rawURL, gen: gen, err: fmt.Errorf("no graphics protocol")}
 			}
@@ -2375,10 +2389,10 @@ func (a App) handleImageViewer(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		a.imageCache[m.rawURL] = cachedImage{frames: m.frames, delays: m.delays}
 		var cmds []tea.Cmd
-		if a.graphicsProtocol == imgview.ProtocolITerm2 && len(a.imageCarouselItems) > 1 {
-			// iTerm2/WezTerm has no Kitty-style delete-all self-heal; force a
-			// full repaint so a cycled-to smaller image can't leave stray
-			// pixels from the previous one in rows the new frame skips.
+		if (a.graphicsProtocol == imgview.ProtocolITerm2 || a.graphicsProtocol == imgview.ProtocolSixel) && len(a.imageCarouselItems) > 1 {
+			// iTerm2/WezTerm and Sixel have no Kitty-style delete-all self-heal;
+			// force a full repaint so a cycled-to smaller image can't leave
+			// stray pixels from the previous one in rows the new frame skips.
 			cmds = append(cmds, tea.ClearScreen)
 		}
 		if len(m.encodedFrames) > 1 {

--- a/internal/ui/imgview/cellsize_unix.go
+++ b/internal/ui/imgview/cellsize_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package imgview
+
+import "golang.org/x/sys/unix"
+
+// TerminalCellPixelSize queries the terminal's real per-cell pixel dimensions
+// via TIOCGWINSZ. Unlike Kitty/iTerm2, Sixel has no terminal-side scale-to-fit,
+// so callers must know the terminal's actual cell size to size the display box
+// correctly. Returns ok=false if the terminal doesn't report pixel geometry
+// (some terminals/multiplexers report zero), in which case callers should fall
+// back to an assumed cell size. Safe to call at any point — this is a
+// read-only kernel ioctl unrelated to the stdin byte stream or raw-mode state.
+func TerminalCellPixelSize(fd int) (cellW, cellH int, ok bool) {
+	ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+	if err != nil || ws.Col == 0 || ws.Row == 0 || ws.Xpixel == 0 || ws.Ypixel == 0 {
+		return 0, 0, false
+	}
+	return int(ws.Xpixel) / int(ws.Col), int(ws.Ypixel) / int(ws.Row), true
+}

--- a/internal/ui/imgview/cellsize_windows.go
+++ b/internal/ui/imgview/cellsize_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package imgview
+
+// TerminalCellPixelSize always reports unavailable on Windows: there's no
+// TIOCGWINSZ equivalent wired up here, so callers fall back to an assumed
+// cell size (the same behavior as before this function existed).
+func TerminalCellPixelSize(fd int) (cellW, cellH int, ok bool) {
+	return 0, 0, false
+}

--- a/internal/ui/imgview/iterm2.go
+++ b/internal/ui/imgview/iterm2.go
@@ -23,7 +23,7 @@ func EncodeITerm2(img image.Image, maxCols, maxRows int) (encoded string, cols, 
 		return "", 0, 0, fmt.Errorf("imgview: png encode: %w", encErr)
 	}
 	payload := base64.StdEncoding.EncodeToString(buf.Bytes())
-	cols, rows = fitBox(w, h, maxCols, maxRows)
+	cols, rows = fitBox(w, h, maxCols, maxRows, pxPerCol, 2*pxPerCol)
 	// width/height without suffix means terminal character cells in iTerm2.
 	encoded = fmt.Sprintf(
 		"\x1b]1337;File=inline=1;width=%d;height=%d;preserveAspectRatio=1:%s\x07",

--- a/internal/ui/imgview/kitty.go
+++ b/internal/ui/imgview/kitty.go
@@ -30,7 +30,7 @@ func EncodeKitty(img image.Image, maxCols, maxRows int) (encoded string, cols, r
 	}
 
 	payload := base64.StdEncoding.EncodeToString(raw)
-	cols, rows = fitBox(w, h, maxCols, maxRows)
+	cols, rows = fitBox(w, h, maxCols, maxRows, pxPerCol, 2*pxPerCol)
 	// a=T: transmit and display. f=32: 32-bit RGBA. s/v: pixel dimensions.
 	// c/r: display size in terminal columns/rows (Kitty scales to fit, preserving aspect ratio).
 	// m=0: final chunk.

--- a/internal/ui/imgview/protocol.go
+++ b/internal/ui/imgview/protocol.go
@@ -1,10 +1,19 @@
 // Package imgview fetches and displays images in the terminal using native
-// graphics protocols (Kitty or iTerm2). Detection is done once at startup via
-// environment variables; display uses tea.Exec to suspend Bubble Tea while the
-// image is shown, then resumes on keypress.
+// graphics protocols (Kitty, iTerm2, or Sixel). Kitty/iTerm2 detection is done
+// once at startup via environment variables; Sixel has no such env-var signal,
+// so it's detected via an active DA1 terminal query instead (see ProbeSixel).
+// Display uses tea.Exec to suspend Bubble Tea while the image is shown, then
+// resumes on keypress.
 package imgview
 
-import "os"
+import (
+	"bytes"
+	"os"
+	"strconv"
+	"time"
+
+	"golang.org/x/term"
+)
 
 // GraphicsProtocol identifies the terminal image display protocol available in
 // the current execution environment.
@@ -14,11 +23,13 @@ const (
 	ProtocolNone   GraphicsProtocol = iota
 	ProtocolKitty                   // Kitty terminal and Ghostty
 	ProtocolITerm2                  // iTerm2 and WezTerm
+	ProtocolSixel                   // xterm, foot, mlterm, contour, mintty, yaft, ...
 )
 
 // DetectProtocol examines environment variables to identify the running
 // terminal's graphics protocol support. Returns ProtocolNone when the terminal
-// is unknown or unsupported.
+// is unknown or unsupported. Sixel terminals don't reliably set an env var, so
+// they're not detected here — see ProbeSixel.
 func DetectProtocol() GraphicsProtocol {
 	if os.Getenv("KITTY_WINDOW_ID") != "" {
 		return ProtocolKitty
@@ -32,4 +43,79 @@ func DetectProtocol() GraphicsProtocol {
 		return ProtocolITerm2
 	}
 	return ProtocolNone
+}
+
+// da1ProbeTimeout bounds how long ProbeSixel waits for a terminal to answer a
+// DA1 query. A local pty round-trip normally takes low single-digit
+// milliseconds; this is a generous, hand-picked ceiling, not a measured
+// value — adjust if real terminals need more slack.
+const da1ProbeTimeout = 150 * time.Millisecond
+
+// ProbeSixel checks whether the terminal connected to stdin/stdout supports
+// Sixel graphics by sending a DA1 (Primary Device Attributes) query and
+// inspecting the response for attribute 4. It must be called before Bubble
+// Tea takes over stdin, since afterwards raw reads would race Bubble Tea's
+// own input reader. Returns false on any error, timeout, or non-terminal
+// stdin — it never blocks longer than da1ProbeTimeout and never leaves the
+// terminal in raw mode.
+func ProbeSixel(stdin, stdout *os.File) bool {
+	fd := int(stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return false
+	}
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return false
+	}
+	defer term.Restore(fd, oldState)
+
+	if _, err := stdout.WriteString("\x1b[c"); err != nil {
+		return false
+	}
+
+	type readResult struct {
+		buf []byte
+		err error
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, err := stdin.Read(buf)
+		done <- readResult{buf[:n], err}
+	}()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			return false
+		}
+		return ParseDA1SixelSupport(res.buf)
+	case <-time.After(da1ProbeTimeout):
+		return false
+	}
+}
+
+// ParseDA1SixelSupport reports whether a raw DA1 response (as read from the
+// terminal, e.g. "\x1b[?62;1;2;4;6;9;15;18;21;22c") declares Sixel support
+// (attribute 4). It searches for the "\x1b[?...c" pattern anywhere in the
+// buffer, tolerating stray leading bytes, and never panics on malformed,
+// empty, or non-DA1 input. Exported so ProbeSixel's response-parsing logic
+// has a pure, unit-testable seam independent of the live terminal I/O.
+func ParseDA1SixelSupport(resp []byte) bool {
+	start := bytes.Index(resp, []byte("\x1b[?"))
+	if start < 0 {
+		return false
+	}
+	body := resp[start+len("\x1b[?"):]
+	end := bytes.IndexByte(body, 'c')
+	if end < 0 {
+		return false
+	}
+	for _, field := range bytes.Split(body[:end], []byte(";")) {
+		n, err := strconv.Atoi(string(field))
+		if err == nil && n == 4 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ui/imgview/protocol_test.go
+++ b/internal/ui/imgview/protocol_test.go
@@ -1,0 +1,31 @@
+package imgview_test
+
+import (
+	"testing"
+
+	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+)
+
+func TestParseDA1SixelSupport(t *testing.T) {
+	tests := []struct {
+		name string
+		resp []byte
+		want bool
+	}{
+		{"has attr 4", []byte("\x1b[?62;1;2;4;6;9;15;18;21;22c"), true},
+		{"no attr 4", []byte("\x1b[?1;2c"), false},
+		{"empty", []byte(""), false},
+		{"garbage", []byte("garbage"), false},
+		{"missing terminator", []byte("\x1b[?4"), false},
+		{"stray leading bytes", []byte("xy\x1b[?4;6c"), true},
+		{"attr 4 alone", []byte("\x1b[?4c"), true},
+		{"non-numeric field", []byte("\x1b[?4;abc;6c"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := imgview.ParseDA1SixelSupport(tt.resp); got != tt.want {
+				t.Errorf("ParseDA1SixelSupport(%q) = %v, want %v", tt.resp, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/imgview/scale.go
+++ b/internal/ui/imgview/scale.go
@@ -1,13 +1,16 @@
 package imgview
 
+// pxPerCol is the assumed terminal column width in pixels, used as a default
+// when the real cell size isn't known. Conservative across common terminal
+// fonts and DPI settings. Cell height is assumed to be 2×pxPerCol (a 2:1
+// height:width cell aspect ratio).
 const pxPerCol = 10
 
 // fitCols returns the number of terminal columns that best fits an image of
-// imgWidth pixels without upscaling, capped at maxCols. Assumes ~10 pixels per
-// terminal column, which is conservative across common terminal fonts and DPI
-// settings. The result is always at least 1.
-func fitCols(imgWidth, maxCols int) int {
-	natural := (imgWidth + pxPerCol - 1) / pxPerCol
+// imgWidth pixels without upscaling, capped at maxCols, given a terminal
+// column width of cellW pixels. The result is always at least 1.
+func fitCols(imgWidth, maxCols, cellW int) int {
+	natural := (imgWidth + cellW - 1) / cellW
 	if natural < 1 {
 		natural = 1
 	}
@@ -18,16 +21,15 @@ func fitCols(imgWidth, maxCols int) int {
 }
 
 // fitRows estimates the number of terminal rows the image will occupy when
-// displayed at cols columns. Assumes terminal cells are 2:1 height:width in
-// pixels (i.e. cell height ≈ 2×pxPerCol). The result is always at least 1.
-func fitRows(imgHeight, imgWidth, cols int) int {
+// displayed at cols columns, given a terminal cell size of cellW x cellH
+// pixels. The result is always at least 1.
+func fitRows(imgHeight, imgWidth, cols, cellW, cellH int) int {
 	if imgWidth <= 0 || cols <= 0 {
 		return 1
 	}
-	// rows = imgHeight / cellHeightPx, where cellHeightPx = 2*pxPerCol
-	// and displayWidth in px = cols * pxPerCol
-	// actual displayHeight = imgHeight * (cols*pxPerCol) / imgWidth
-	rows := imgHeight * cols * pxPerCol / (imgWidth * 2 * pxPerCol)
+	// rows = imgHeight / cellH, where displayWidth in px = cols * cellW
+	// and actual displayHeight = imgHeight * (cols*cellW) / imgWidth
+	rows := imgHeight * cols * cellW / (imgWidth * cellH)
 	if rows < 1 {
 		return 1
 	}
@@ -36,14 +38,15 @@ func fitRows(imgHeight, imgWidth, cols int) int {
 
 // fitBox computes the terminal cols/rows to display an image of imgWidth x
 // imgHeight pixels within a maxCols x maxRows box, preserving aspect ratio
-// and never upscaling. If fitting to maxCols would make rows exceed maxRows,
-// cols is recomputed from the row constraint instead so both bounds hold.
-func fitBox(imgWidth, imgHeight, maxCols, maxRows int) (cols, rows int) {
-	cols = fitCols(imgWidth, maxCols)
-	rows = fitRows(imgHeight, imgWidth, cols)
+// and never upscaling, given a terminal cell size of cellW x cellH pixels.
+// If fitting to maxCols would make rows exceed maxRows, cols is recomputed
+// from the row constraint instead so both bounds hold.
+func fitBox(imgWidth, imgHeight, maxCols, maxRows, cellW, cellH int) (cols, rows int) {
+	cols = fitCols(imgWidth, maxCols, cellW)
+	rows = fitRows(imgHeight, imgWidth, cols, cellW, cellH)
 	if maxRows > 0 && rows > maxRows && imgHeight > 0 {
 		rows = maxRows
-		cols = 2 * rows * imgWidth / imgHeight
+		cols = cellH * rows * imgWidth / (cellW * imgHeight)
 		if cols < 1 {
 			cols = 1
 		}

--- a/internal/ui/imgview/sixel.go
+++ b/internal/ui/imgview/sixel.go
@@ -1,0 +1,49 @@
+package imgview
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+
+	"github.com/mattn/go-sixel"
+	"golang.org/x/image/draw"
+)
+
+// EncodeSixel encodes img for display via the DECSIXEL graphics protocol,
+// supported by xterm, foot, mlterm, contour, mintty, yaft, and others.
+// maxCols/maxRows bound the terminal display size; the image is never
+// upscaled beyond its natural pixel size. Unlike Kitty/iTerm2, Sixel has no
+// terminal-side scale-to-fit parameter, so the image is downscaled in pixel
+// space here before encoding, using the terminal's real cell pixel size
+// (cellPxW x cellPxH, from TerminalCellPixelSize) so the reported cols/rows
+// match what the terminal will actually display. If cellPxW or cellPxH is
+// <= 0 (real size unavailable), falls back to the assumed default cell size
+// used by Kitty/iTerm2. Returns the DCS escape sequence and the computed
+// display size in terminal columns and rows.
+func EncodeSixel(img image.Image, maxCols, maxRows, cellPxW, cellPxH int) (encoded string, cols, rows int, err error) {
+	if cellPxW <= 0 || cellPxH <= 0 {
+		cellPxW, cellPxH = pxPerCol, 2*pxPerCol
+	}
+	bounds := img.Bounds()
+	w := bounds.Dx()
+	h := bounds.Dy()
+
+	cols, rows = fitBox(w, h, maxCols, maxRows, cellPxW, cellPxH)
+	targetW := cols * cellPxW
+	targetH := rows * cellPxH
+
+	src := img
+	if targetW < w || targetH < h {
+		dst := image.NewRGBA(image.Rect(0, 0, targetW, targetH))
+		draw.ApproxBiLinear.Scale(dst, dst.Bounds(), img, bounds, draw.Src, nil)
+		src = dst
+	}
+
+	var buf bytes.Buffer
+	enc := sixel.NewEncoder(&buf)
+	enc.Colors = 256
+	if encErr := enc.Encode(src); encErr != nil {
+		return "", 0, 0, fmt.Errorf("imgview: sixel encode: %w", encErr)
+	}
+	return buf.String(), cols, rows, nil
+}

--- a/internal/ui/imgview/sixel_test.go
+++ b/internal/ui/imgview/sixel_test.go
@@ -1,0 +1,83 @@
+package imgview_test
+
+import (
+	"image"
+	"image/color"
+	"strings"
+	"testing"
+
+	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+)
+
+func TestEncodeSixel_ContainsDCS(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	seq, cols, rows, err := imgview.EncodeSixel(img, 40, 20, 0, 0)
+	if err != nil {
+		t.Fatalf("EncodeSixel: %v", err)
+	}
+	if !strings.HasPrefix(seq, "\x1bP") {
+		t.Errorf("EncodeSixel: missing DCS prefix, got %q", seq[:min(len(seq), 20)])
+	}
+	if !strings.HasSuffix(seq, "\x1b\\") {
+		t.Errorf("EncodeSixel: missing ST suffix")
+	}
+	if cols < 1 {
+		t.Errorf("EncodeSixel: cols=%d, want >= 1", cols)
+	}
+	if rows < 1 {
+		t.Errorf("EncodeSixel: rows=%d, want >= 1", rows)
+	}
+}
+
+func TestEncodeSixel_CapsRows(t *testing.T) {
+	// Tall portrait image: without a row cap this would need 50 rows at 10 cols.
+	img := image.NewRGBA(image.Rect(0, 0, 100, 1000))
+	_, cols, rows, err := imgview.EncodeSixel(img, 40, 20, 0, 0)
+	if err != nil {
+		t.Fatalf("EncodeSixel: %v", err)
+	}
+	if rows > 20 {
+		t.Errorf("EncodeSixel: rows=%d, want <= maxRows(20)", rows)
+	}
+	if cols < 1 || cols > 40 {
+		t.Errorf("EncodeSixel: cols=%d, want in [1, maxCols(40)]", cols)
+	}
+}
+
+func TestEncodeSixel_NeverUpscales(t *testing.T) {
+	// A tiny image with generous bounds should stay tiny, not get blown up.
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	_, cols, rows, err := imgview.EncodeSixel(img, 200, 100, 0, 0)
+	if err != nil {
+		t.Fatalf("EncodeSixel: %v", err)
+	}
+	if cols > 1 {
+		t.Errorf("EncodeSixel: cols=%d for a 2px-wide image, want 1 (no upscaling)", cols)
+	}
+	if rows > 1 {
+		t.Errorf("EncodeSixel: rows=%d for a 2px-tall image, want 1 (no upscaling)", rows)
+	}
+}
+
+func TestEncodeSixel_UsesRealCellSize(t *testing.T) {
+	// A wide image at a small assumed cell size (0,0 -> default 10x20) needs
+	// more columns than the same image measured against a much larger real
+	// cell size (as Konsole or similar can report) — confirms cellPxW/cellPxH
+	// actually drives the sizing math instead of being ignored.
+	img := image.NewRGBA(image.Rect(0, 0, 400, 400))
+	_, defaultCols, defaultRows, err := imgview.EncodeSixel(img, 200, 200, 0, 0)
+	if err != nil {
+		t.Fatalf("EncodeSixel (default cell size): %v", err)
+	}
+	_, largeCellCols, largeCellRows, err := imgview.EncodeSixel(img, 200, 200, 40, 80)
+	if err != nil {
+		t.Fatalf("EncodeSixel (large cell size): %v", err)
+	}
+	if largeCellCols >= defaultCols {
+		t.Errorf("EncodeSixel: cols with a 4x larger cell size = %d, want < default cols = %d", largeCellCols, defaultCols)
+	}
+	if largeCellRows >= defaultRows {
+		t.Errorf("EncodeSixel: rows with a 4x larger cell size = %d, want < default rows = %d", largeCellRows, defaultRows)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds Sixel as a third inline-image graphics protocol (`internal/ui/imgview`), alongside Kitty and iTerm2, widening terminal compatibility to xterm, foot, mlterm, contour, mintty, yaft, and others.
- Detection: an active DA1 probe (`ProbeSixel`/`ParseDA1SixelSupport`), run only when env-var detection finds nothing, since Sixel terminals don't reliably set a detectable env var.
- Encoding: `EncodeSixel` wraps `github.com/mattn/go-sixel`, resizing in pixel space using the terminal's real cell pixel size (queried via `TIOCGWINSZ` on Unix, `internal/ui/imgview/cellsize_unix.go`; no-op fallback on Windows) since Sixel has no terminal-side scale-to-fit like Kitty/iTerm2.
- Modal close now issues `tea.ClearScreen` for Sixel specifically, since Sixel has no delete-placement primitive and Bubble Tea's diff renderer can otherwise leave stray pixels on screen.
- Manually tested end-to-end in Konsole (image renders, box sizing correct, modal close leaves no stray pixels).

## Test plan
- [x] `go build ./...` (Linux + Windows cross-compile)
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] `go test ./...`
- [x] Manual verification in Konsole (real Sixel terminal)
- [ ] Spot-check Kitty/iTerm2 still render/close cleanly (shared `fitBox` signature changed, but call sites pass the same default cell size as before)