### PR TITLE
feat: inline images (Kitty/Sixel/iTerm2) + Miller layout support

### DIFF
--- a/docs/plan-inline-images-improvements.md
+++ b/docs/plan-inline-images-improvements.md
@@ -17,78 +17,70 @@ were missed.
 
 ---
 
-## 1. Decide MillerLayout's fate (blocking, needs a decision)
+## 1. ~~Decide MillerLayout's fate~~ — Resolved: finished, not deleted
 
-**Files:** `internal/ui/app.go:431-433` (`layoutFromName`, discards its argument, always
-returns `TabsLayout{}`), `internal/ui/layout_miller.go` (whole file).
+**Files:** `internal/ui/app.go` (`layoutFromName`), `internal/ui/layout_miller.go`,
+`internal/ui/screens/settings.go`.
 
-`layoutFromName` predates this branch and makes `MillerLayout` unreachable by any user —
-there's also no settings-screen item to pick a layout at all. This feature nonetheless
-added real logic to `layout_miller.go` (a Kitty-cleanup fix matching the one applied to
-`layout_tabs.go`), and never wired inline-image compositing into it either. This is a
-product decision, not a code decision:
-
-- **(a) Delete** `layout_miller.go` and its dedicated tests (`layout_test.go:66,337,385`,
-  `app_test.go:317`) — it's dead code with no user-facing coverage, and every line added
-  to it is maintenance cost with no corresponding benefit.
-- **(b) Finish it** — fix `layoutFromName` to branch on its argument, add the missing
-  settings-screen item (`internal/ui/screens/settings.go:140-172` currently has no
-  layout picker even though `SettingsModel.layoutName` is tracked and round-tripped),
-  and only then treat it as a real second layout worth keeping in sync with `TabsLayout`.
-
-Resolve this before touching item 2 — it determines whether that item is "fix" or "n/a."
+Decided in follow-up discussion: the two-code-sets concern behind option (a) checked out
+as real but narrow (the overlay-compositing block specifically, not navigation/routing,
+which was already centralized) — so it was cheaper to fix the actual duplication than to
+delete the layout. `layoutFromName` now branches on its argument, Settings has a "layout"
+picker item (`tabs`/`miller`, cycles live via the existing save path), and Feed gained
+its own inline-image support for Miller's compact detail pane (post + reply images),
+which it never had before. See `docs/reviews/2026-08-09-inline-images-greenfield-critique.md`
+for the original analysis and commit `ebb4a64` for the implementation.
 
 ---
 
-## 2. Fix (or remove) the inline-image compositing gap
+## 2. ~~Fix (or remove) the inline-image compositing gap~~ — Resolved: hoisted
 
-**Files:** `internal/ui/layout_tabs.go:112-149` (`injectInlineImages`, only call site
-today) vs `internal/ui/layout_miller.go:147-166`.
+**Files:** `internal/ui/layout.go` (`compositeOverlays`, `modalRenderer`), replacing the
+duplicated tail of `internal/ui/layout_tabs.go`'s and `internal/ui/layout_miller.go`'s
+`View()` methods.
 
-- **If Miller is kept** (1b): hoist `injectInlineImages` and the modal-compositing block
-  to a single call site above both layouts — after `a.layout.View(a)` returns, before
-  the string is returned to the terminal — so a `Layout` implementation cannot forget to
-  call it. This is the shared-pipeline fix both reviews recommend over duplicating the
-  call into `layout_miller.go`.
-- **If Miller is deleted** (1a): this finding disappears with the file — no separate fix
-  needed.
+Implemented the shared-pipeline fix both reviews recommended: `compositeOverlays` is now
+the single place that composites the five simple modals, the fullscreen image modal, the
+Kitty placement-cleanup delete, and inline-image injection, called as the last line of
+both layouts' `View()`. Neither layout can independently forget a step or return early
+partway through anymore — the exact shape of the original MillerLayout bug. Golden-output
+tests (`internal/ui/layout_test.go`) assert on the composited escape sequences for both
+layouts, closing the test-coverage gap both reviews flagged. See commit `ebb4a64`.
 
----
-
-## 3. Bound `inlineImageCache` before removing the "experimental" label
-
-**Files:** `internal/ui/app.go:184-197` (`inlineImageCache`, keyed by slot × URL × column
-width × protocol, never evicted), `app.go:198-243` (`kittyPlacementIDs`,
-`kittyNextPlacementID`, `pendingKittyDeletes` — coupled to the same cut by design).
-
-Add an LRU bounded by encoded-payload byte size — `container/list` plus a map,
-evict-oldest on insert past the cap. Any eviction scheme needs to invalidate the
-matching `kittyPlacementIDs` entry when its cache entry is evicted, since a re-issued id
-without a matching cache invalidation would desync the two.
+A related bug surfaced and was fixed separately while verifying this work: Miller's
+`HasFocusedInput` for Circ/CMail didn't account for Miller's own focus state, trapping
+nav keys inside a backgrounded room — commit `6371452`.
 
 ---
 
-## 4. Compress the Kitty payload
+## 3. ~~Bound `inlineImageCache`~~ — Resolved
 
-**File:** `internal/ui/imgview/kitty.go:28-63` (`EncodeKitty`, currently emits raw
-32-bit RGBA via `f=32`, no compression).
-
-Switch to PNG (`f=100`) the way `EncodeITerm2` already does (`imgview/iterm2.go:21-25`,
-`image/png` is already a dependency). This directly shrinks the same cache memory
-problem as item 3, for the same amount of encoder code, and is cheap enough to bundle
-into the same change.
+`inlineImageCache` is now bounded by `inlineImageCacheMaxBytes` (16 MiB, a starting cap
+rather than a measured one), evicting the oldest-inserted entry first via
+`cacheInlineImage` (`container/list` + map, as scoped). `kittyPlacementIDs` was left
+untouched and permanent, as designed — eviction only removes the cache entry, and since
+`inlineImageCacheKey` doesn't embed the placement id, a slot whose entry gets evicted
+just re-fetches and re-encodes using its already-stable id on the next sync. No coupling
+to handle, since ids themselves are never evicted.
 
 ---
 
-## 5. Stop silently caching fetch failures as retryable blanks
+## 4. ~~Compress the Kitty payload~~ — Resolved
 
-**File:** `internal/ui/app.go:2607-2621` (`handleInlineImageFetched`).
+`EncodeKitty` now emits PNG (`f=100`, no `s=`/`v=` needed — the terminal reads pixel
+dimensions from the PNG header) instead of raw 32-bit RGBA (`f=32`), matching
+`EncodeITerm2`'s existing pattern exactly, including propagating a `png.Encode` error
+through a new `error` return (both real call sites and `encode_test.go` updated to
+match).
 
-On `err != nil`, the in-flight marker is cleared but nothing is written to
-`inlineImageCache`, so `syncInlineImages` retries the same dead URL on every subsequent
-`Update` the slot stays visible for — no backoff. Cache a distinct "failed" sentinel
-with a short cooldown so a permanently-broken image URL doesn't get hammered on every
-keystroke/tick while visible.
+---
+
+## 5. ~~Stop silently caching fetch failures as retryable blanks~~ — Resolved
+
+`handleInlineImageFetched` now records a failure timestamp (`inlineImageFailedAt`) on
+error; `syncInlineImages` skips refetching a key within `inlineImageFailureCooldown`
+(60s) of its last failure, and a subsequent success clears the record so a transient
+blip doesn't leave a stale cooldown once the URL recovers.
 
 ---
 
@@ -109,10 +101,6 @@ circumstances change (noted trigger in parentheses):
   pressure, or before this exact pattern gets reused elsewhere.
 - Sixel hardcoding 256 colors (`imgview/sixel.go:44`) — true for essentially every
   Sixel-capable terminal in practice; leave as a documented assumption.
-- Golden-output `View()` tests per layout/protocol — the test category that would have
-  caught both the MillerLayout gap and the two Ghostty lifecycle bugs; worth adding
-  alongside item 2 specifically (asserting the composited escape sequence appears in
-  `View()`'s output), not as a standalone backlog item.
 
 ---
 

--- a/docs/plan-inline-images-improvements.md
+++ b/docs/plan-inline-images-improvements.md
@@ -1,0 +1,128 @@
+# Plan: Inline-Images Improvements
+
+## Context
+
+`feature/inline-images` shipped experimental Kitty/Sixel/iTerm2 inline image rendering
+for Feed and PostDetail. Two independent solution-architect reviews
+(`docs/reviews/2026-08-09-inline-images-architecture-review.md`,
+`docs/reviews/2026-08-09-inline-images-greenfield-critique.md`) audited the branch and
+converged on the same core findings; a third review
+(`docs/reviews/2026-08-09-inline-images-chafa-review.md`) evaluated and rejected
+replacing the hand-rolled encoders with `chafa`. This plan consolidates all three into
+a single prioritized punch list for taking the feature from "experimental" to shippable.
+
+Items are ordered by real-bug-first, smallest-diff-that-fixes-it — deferred items are
+deferred because both reviews independently judged them low-urgency, not because they
+were missed.
+
+---
+
+## 1. Decide MillerLayout's fate (blocking, needs a decision)
+
+**Files:** `internal/ui/app.go:431-433` (`layoutFromName`, discards its argument, always
+returns `TabsLayout{}`), `internal/ui/layout_miller.go` (whole file).
+
+`layoutFromName` predates this branch and makes `MillerLayout` unreachable by any user —
+there's also no settings-screen item to pick a layout at all. This feature nonetheless
+added real logic to `layout_miller.go` (a Kitty-cleanup fix matching the one applied to
+`layout_tabs.go`), and never wired inline-image compositing into it either. This is a
+product decision, not a code decision:
+
+- **(a) Delete** `layout_miller.go` and its dedicated tests (`layout_test.go:66,337,385`,
+  `app_test.go:317`) — it's dead code with no user-facing coverage, and every line added
+  to it is maintenance cost with no corresponding benefit.
+- **(b) Finish it** — fix `layoutFromName` to branch on its argument, add the missing
+  settings-screen item (`internal/ui/screens/settings.go:140-172` currently has no
+  layout picker even though `SettingsModel.layoutName` is tracked and round-tripped),
+  and only then treat it as a real second layout worth keeping in sync with `TabsLayout`.
+
+Resolve this before touching item 2 — it determines whether that item is "fix" or "n/a."
+
+---
+
+## 2. Fix (or remove) the inline-image compositing gap
+
+**Files:** `internal/ui/layout_tabs.go:112-149` (`injectInlineImages`, only call site
+today) vs `internal/ui/layout_miller.go:147-166`.
+
+- **If Miller is kept** (1b): hoist `injectInlineImages` and the modal-compositing block
+  to a single call site above both layouts — after `a.layout.View(a)` returns, before
+  the string is returned to the terminal — so a `Layout` implementation cannot forget to
+  call it. This is the shared-pipeline fix both reviews recommend over duplicating the
+  call into `layout_miller.go`.
+- **If Miller is deleted** (1a): this finding disappears with the file — no separate fix
+  needed.
+
+---
+
+## 3. Bound `inlineImageCache` before removing the "experimental" label
+
+**Files:** `internal/ui/app.go:184-197` (`inlineImageCache`, keyed by slot × URL × column
+width × protocol, never evicted), `app.go:198-243` (`kittyPlacementIDs`,
+`kittyNextPlacementID`, `pendingKittyDeletes` — coupled to the same cut by design).
+
+Add an LRU bounded by encoded-payload byte size — `container/list` plus a map,
+evict-oldest on insert past the cap. Any eviction scheme needs to invalidate the
+matching `kittyPlacementIDs` entry when its cache entry is evicted, since a re-issued id
+without a matching cache invalidation would desync the two.
+
+---
+
+## 4. Compress the Kitty payload
+
+**File:** `internal/ui/imgview/kitty.go:28-63` (`EncodeKitty`, currently emits raw
+32-bit RGBA via `f=32`, no compression).
+
+Switch to PNG (`f=100`) the way `EncodeITerm2` already does (`imgview/iterm2.go:21-25`,
+`image/png` is already a dependency). This directly shrinks the same cache memory
+problem as item 3, for the same amount of encoder code, and is cheap enough to bundle
+into the same change.
+
+---
+
+## 5. Stop silently caching fetch failures as retryable blanks
+
+**File:** `internal/ui/app.go:2607-2621` (`handleInlineImageFetched`).
+
+On `err != nil`, the in-flight marker is cleared but nothing is written to
+`inlineImageCache`, so `syncInlineImages` retries the same dead URL on every subsequent
+`Update` the slot stays visible for — no backoff. Cache a distinct "failed" sentinel
+with a short cooldown so a permanently-broken image URL doesn't get hammered on every
+keystroke/tick while visible.
+
+---
+
+## 6. Deferred — no action needed now
+
+Both reviews independently judged these low-urgency or fine-as-is; revisit only if
+circumstances change (noted trigger in parentheses):
+
+- Uncancelled inline-fetch goroutines (`app.go:2572-2600`) — bounded by a 20s timeout
+  today; extend the fullscreen modal's existing `imageFetchGen` staleness-guard pattern
+  to the inline path if this gets reused for more expensive fetches later.
+- Kitty/iTerm2 not threading real terminal cell size the way `EncodeSixel` already does
+  (`imgview/kitty.go:48`, `imgview/iterm2.go:26` vs `imgview/sixel.go:23-31`) — low
+  severity since both protocols scale-to-fit terminal-side; worth fixing opportunistically
+  since the ioctl is already being called for Sixel in the same caller, but not urgent.
+- `syncInlineImages` running unconditionally on every `Update` (`app.go:488-495`) — cheap
+  no-op today; gate on message type if a future profiling pass shows `Update` latency
+  pressure, or before this exact pattern gets reused elsewhere.
+- Sixel hardcoding 256 colors (`imgview/sixel.go:44`) — true for essentially every
+  Sixel-capable terminal in practice; leave as a documented assumption.
+- Golden-output `View()` tests per layout/protocol — the test category that would have
+  caught both the MillerLayout gap and the two Ghostty lifecycle bugs; worth adding
+  alongside item 2 specifically (asserting the composited escape sequence appears in
+  `View()`'s output), not as a standalone backlog item.
+
+---
+
+## 7. Chafa: no action
+
+Evaluated in `docs/reviews/2026-08-09-inline-images-chafa-review.md` and rejected as a
+replacement for `internal/ui/imgview` — every integration path (external binary via
+`exec.Command`, cgo bindings, or the one community purego-based Go binding) gives up
+something the current pure-Go implementation has for free: zero runtime dependencies,
+full 5-target cross-compile coverage, or both. The one genuine capability gap chafa
+would close — a rendering fallback for terminals with no detected graphics protocol —
+is real but small enough to build natively if it's ever prioritized as its own feature,
+without reopening this tradeoff.

--- a/docs/reviews/2026-08-09-inline-images-architecture-review.md
+++ b/docs/reviews/2026-08-09-inline-images-architecture-review.md
@@ -1,0 +1,142 @@
+# Inline-Images Architecture Review — 2026-08-09
+
+**Reviewed branch:** `feature/inline-images` (5 commits over `main`, merge-base `2adf4c9`) · **Perspective:** solution architect, first look, design/quality focus (not a security review — see `docs/reviews/2026-07-24-code-security-review.md` for that lens).
+
+Scope: 33 files, +1901/-182 lines. Kitty, Sixel, and iTerm2/WezTerm inline image rendering for post/reply bodies in Feed and PostDetail, plus a preexisting fullscreen image-viewer modal that now shares the same encoders.
+
+---
+
+## Executive Summary
+
+| Severity | Count |
+|---|---|
+| High | 1 |
+| Medium | 3 |
+| Low | 3 |
+| Informational | 3 |
+
+The core design choice — encode everything as Bubble Tea messages/commands and keep all mutable state inside the single-threaded `Update` loop — is the right one, and it's applied consistently: there are no mutexes anywhere in this feature and none are needed, because no goroutine ever touches shared state directly. That part is not a finding, it's a correctly-made architectural decision.
+
+The standout problem is functional, not stylistic: **the feature never renders in `MillerLayout`, only in `TabsLayout`.** `injectInlineImages` is called from exactly one of the two layout files. This is a direct consequence of the second-biggest issue — the fullscreen-modal and inline-image compositing logic is hand-duplicated across `layout_tabs.go` and `layout_miller.go` rather than shared, so a change applied to one silently doesn't apply to the other. Everything else here is smaller: an intentionally-accepted unbounded cache, a sync routine that runs on every message rather than just the relevant ones, un-cancelled fetch goroutines, and a couple of hardcoded protocol assumptions. Two of the five commits on this branch are dedicated post-merge bug fixes for lifecycle issues that were only found on real hardware (Ghostty) — both read as genuine root-cause fixes, but they're a signal about the test suite's blind spot (see the last Informational finding).
+
+---
+
+## Architecture Overview
+
+Everything routes through the standard Elm-architecture loop: `App.Update` (`internal/ui/app.go:488`) delegates to `updateInner`, then unconditionally calls `syncInlineImages` (`app.go:490`) before returning. `syncInlineImages` (`app.go:2514`) is a pure diff — compares the active screen's `VisibleInlineImages()` against `inlineImageCache`/`inlineImageFetching`, and for Kitty additionally diffs a stable per-slot placement-id set to compute create/delete transitions. Missing slots become `fetchInlineImageCmd` (`app.go:2572`), a `tea.Cmd` that Bubble Tea runs as a goroutine, timed out at 20s, returning an `inlineImageFetchedMsg` that's folded back into `App` state inside `Update`. No goroutine ever writes to `App` fields directly — everything comes back as a message. This is why, despite three separate caches/maps and several goroutines in flight at once, there's no data race anywhere in this feature.
+
+View-time compositing is layout-specific rather than shared: `TabsLayout.View` (`layout_tabs.go:112`) calls `injectInlineImages` (`layout_tabs.go:132`) to splice absolute-cursor-positioned escape sequences into the rendered frame. `MillerLayout` has its own, separately-written modal-compositing and cleanup-flag logic (`layout_miller.go:147-166`) but no equivalent inline-image call at all.
+
+The two post-merge fix commits are useful evidence of where this design is fragile in practice: `70925fd` fixed four Kitty lifecycle bugs found on Ghostty (blunt delete-all colliding with the fullscreen modal, single-shot deletes lost to Bubble Tea's throttled renderer, a sticky cleanup flag that permanently disabled inline rendering after the modal closed once, and stale cache entries pointing at already-deleted placement ids); `3ae054c` fixed a stale-placement bug on toggle-off and a goroutine leak in the startup Sixel probe. Both are described accurately in their commit messages (verified against `git show`), and both fixes are structural (stable ids, accumulating delete sets, cancelable reads) rather than papered over — but the fact that four of them surfaced only after merge, on specific real hardware, says something about pre-merge verification coverage (see Informational finding below).
+
+---
+
+## Findings
+
+### HIGH — Inline images never render in `MillerLayout`
+
+**Files:** `internal/ui/layout_tabs.go:112-149` (`injectInlineImages`, only call site) vs. `internal/ui/layout_miller.go:147-166` (parallel modal logic, no inline-image call anywhere)
+
+**The problem:** `grep -rn "injectInlineImages\|activeInlineImageSlots" internal/ui/*.go` shows `activeInlineImageSlots` is read only in `app.go` and `layout_tabs.go`; `injectInlineImages` is defined and called only in `layout_tabs.go`. `MillerLayout.View` has its own independently-written block for the fullscreen-modal composite and its Kitty-cleanup-flag injection, but never splices inline images into the frame at all.
+
+**Failure scenario:** A user who runs the app in Miller (three-pane) layout enables inline images in settings, opens Feed or PostDetail, and sees nothing different — no error, no fallback text, just the same plain-text body they'd see with the setting off. The setting silently does nothing for roughly half of the app's layout surface. No test catches this: `feed_test.go`/`postdetail_test.go`/`render_test.go` test `VisibleInlineImages()` and the pure splice functions, never `MillerLayout.View()`'s actual output.
+
+**Recommendation:** Move `injectInlineImages` (and ideally the near-duplicated modal-compositing/cleanup-flag blocks) out of `TabsLayout` into a shared helper both layouts call, rather than adding a second copy to `MillerLayout`. The duplication is the root cause, not just this one missed call site — fixing only the missing call leaves the same class of drift ready to happen again the next time either layout changes. Add a `MillerLayout` regression test asserting the composited `View()` output contains the expected escape sequence for a visible inline slot, mirroring what's missing in the test list below.
+
+---
+
+### MEDIUM — `inlineImageCache` grows unboundedly for the life of the session
+
+**File:** `internal/ui/app.go:184-196` (field + doc comment), `app.go:2421-2423` (cache key includes column width)
+
+**The problem:** `inlineImageCache` is keyed by slot key × URL × column budget × protocol and is explicitly never evicted — the field comment at `app.go:186-187` names this outright as an accepted spike-scope cut. Every distinct image URL seen, times every distinct terminal width the session was ever resized to, times (for Kitty) every distinct slot position it was ever placed at, stays cached forever. For Kitty specifically, the cached value is base64'd *raw, uncompressed RGBA* pixel data (`kitty.go:28-63`, no PNG/zlib compression), which is the most memory-hungry payload shape available for this data — so this is the single largest unbounded allocation surface in the feature.
+
+**Failure scenario:** A long-running session that scrolls through a lot of image-bearing posts, or gets resized repeatedly (e.g. a terminal window dragged to resize, or a tmux pane reflow), accumulates cache entries indefinitely with no cap and no LRU. This was a reasonable, explicitly-labeled cut for an experimental spike; it stops being reasonable once this feature ships as non-experimental.
+
+**Recommendation:** Bound the cache (LRU by entry count or byte size) before removing the "experimental" label. Note the permanent `kittyPlacementIDs`/`kittyNextPlacementID` maps (`app.go:198-212`) are coupled to this decision by design (a re-issued id on eviction would need to also invalidate the corresponding cache entry) — any eviction scheme has to account for that coupling, not bound the two caches independently.
+
+---
+
+### MEDIUM — `syncInlineImages` runs on every single `Update`, not just image-relevant messages
+
+**File:** `internal/ui/app.go:488-495` (call site), `app.go:2514-2557` (`syncInlineImages` body)
+
+**The problem:** `Update` unconditionally calls `syncInlineImages` after every message — keypresses, ticks, resizes, unrelated screen navigation — not gated on any check for whether the message could plausibly have changed the visible image set. The function itself is cheap (`VisibleInlineImages()` plus a couple of map diffs), so this isn't a measured performance problem today. It's flagged here as a structural habit: "recompute a screen-derived diff on every message rather than only on messages that could change it" is a pattern that scales badly if copied elsewhere in the app, and it makes reasoning about *when* image state changes harder than it needs to be, since the answer is "always, but usually a no-op" rather than "on these specific message types."
+
+**Recommendation:** Not urgent to change alone. Worth revisiting if a future profiling pass shows `Update` latency issues, or before this pattern gets reused for another per-frame derived-state sync.
+
+---
+
+### MEDIUM — Fetch goroutines aren't cancelled on view-change, toggle-off, or quit
+
+**File:** `internal/ui/app.go:2572-2600` (`fetchInlineImageCmd`), `app.go:2612` (only place `inlineImageFetching` is cleared)
+
+**The problem:** Each in-flight fetch is bounded by a 20s `context.WithTimeout`, so this isn't a leak, but there's no cancellation path: navigating away from the screen that requested the fetch, toggling inline images off mid-load, or quitting the app while fetches are in flight all let the goroutine run to completion regardless. `inlineImageFetching[key]` is only cleared when the result message arrives, so nothing double-fires — but nothing stops the wasted network/decode work either, and on quit the result is simply discarded into a closed message channel.
+
+**Recommendation:** Low priority given the 20s cap bounds the damage, but worth a `context.Cancel` tied to view-change/quit if this pattern is extended to more expensive fetches later (e.g. larger images, slower endpoints).
+
+---
+
+### LOW — Fetch failures are silent, with no retry, backoff, or user-visible state
+
+**File:** `internal/ui/app.go:2607-2614` (`handleInlineImageFetched`)
+
+**The problem:** A failed fetch (`err != nil`) is swallowed into a blank cache entry with no retry and no error surfaced to the user. The only way a failed slot gets another attempt is incidentally — a resize changes the cache key's column-width component, which happens to bypass the "already attempted" check.
+
+**Recommendation:** At minimum, avoid caching a hard failure as if it were a successful blank result, so a manual re-trigger (e.g. re-entering the screen) can retry without needing a resize as a workaround.
+
+---
+
+### LOW — Sixel encoding hardcodes 256 colors with no capability negotiation
+
+**File:** `internal/ui/imgview/sixel.go:44`
+
+**The problem:** `enc.Colors = 256` is fixed regardless of what the connecting terminal actually reports supporting. True for most Sixel-capable terminals in practice, but not guaranteed by spec, and there's no fallback path if a terminal reports a smaller register count.
+
+**Recommendation:** Low priority given the practical terminal landscape; note as a known assumption rather than something requiring immediate work.
+
+---
+
+### LOW — `pxPerCol = 10` fallback is an explicitly-flagged untested guess that directly drives Sixel sizing
+
+**File:** `internal/ui/imgview/scale.go:3-7`, `internal/ui/screens/inlineimage.go:34-37`
+
+**The problem:** This is the one spot in the reviewed diff carrying a `ponytail:`-style comment naming it as an untested fudge factor. For Kitty and iTerm2, both of which have terminal-side scale-to-fit parameters, a wrong guess here is low-risk — it just nudges the scaling target. For Sixel's fallback path (used whenever `TerminalCellPixelSize`'s `TIOCGWINSZ` read fails, which its own comment notes is common under tmux/screen), this value directly drives the pixel-space downscale before encoding, with no terminal-side correction available afterward — so a wrong guess here produces a visibly wrong-sized image, not just a suboptimal one.
+
+**Recommendation:** Worth an actual measurement pass (common terminal font metrics) before this ships broadly, specifically for the Sixel-fallback case; the Kitty/iTerm2 usage is fine as-is.
+
+---
+
+### INFORMATIONAL — `EncodeKitty`'s placement-id sentinel is an implicit dual-mode API
+
+**File:** `internal/ui/imgview/kitty.go:28`
+
+`func EncodeKitty(img image.Image, maxCols, maxRows, placementID int)` — passing `placementID == 0` selects "anonymous, blunt delete-all" mode; any nonzero value selects "named, never blunt-deletes" mode. This is a deliberate, documented choice (there's an extensive comment elsewhere justifying the specific nonzero sentinel `kittyModalPlacementID = 999000000` used for the fullscreen modal), and it's exactly what was needed to fix one of the four Ghostty bugs. Still, a sentinel-driven behavior switch on an `int` parameter is easy to misuse from a new call site without reading the doc comment. An explicit mode type would make the two behaviors harder to confuse by accident.
+
+---
+
+### INFORMATIONAL — `pendingKittyDeletes` entries are resent every frame indefinitely, by design
+
+**File:** `internal/ui/app.go:222-241`
+
+Once a placement drops out of view, its delete gets resent on every subsequent `View()` call for the rest of the session unless the slot becomes visible again (which cancels it). This is a deliberate, well-reasoned fix for a real Bubble-Tea-throttled-render race (a countdown-based resend budget was tried first and rejected — noted in the comment itself), and placement ids are never reused so resending a stale delete is a harmless no-op. Flagging only because it's a second structurally-unbounded-but-practically-tiny map alongside the cache findings above — worth knowing about together, not fixing separately.
+
+---
+
+### INFORMATIONAL — Test suite is entirely pure-function/synthetic; the two post-merge fixes were both hardware-discovered
+
+**Files:** `internal/ui/app_test.go` (`TestSyncKittyPlacements_*`, `TestSyncInlineImages_*`, `TestAccumulateKittyDeletes_*`), `internal/ui/imgview/*_test.go`
+
+Coverage is genuinely good at the unit level — encoder framing, row/col capping, id-stability transitions, and both post-merge regressions now have dedicated tests. But every test calls the pure diff functions directly against hand-built state; none exercise `fetchInlineImageCmd`'s actual goroutine racing against a subsequent `Update`, and none assert on the final composited `View()` string (which is exactly the kind of test that would have caught the `MillerLayout` gap above). That gap is consistent with two of five commits on this branch being dedicated fixes for bugs that were only found by hand on a specific real terminal (Ghostty) after merging. Not a criticism of the fixes themselves — both are root-cause, not band-aid — but a signal that terminal-lifecycle behavior in this feature is currently verified by hand more than by test.
+
+**Recommendation:** A small number of golden-output tests asserting the exact composited escape sequence for a fixed `View()` scenario, across both layouts, would close most of this gap cheaply.
+
+---
+
+## Prioritized Recommendations
+
+1. Fix the `MillerLayout` gap by de-duplicating the modal/inline compositing logic into a shared path both layouts call — treat the missing call as a symptom of the duplication, not a standalone one-line fix.
+2. Add a `MillerLayout` (and ideally cross-layout) golden-output test that would have caught #1, plus one for `TabsLayout`.
+3. Bound `inlineImageCache` before this feature leaves "experimental," given the raw-RGBA payload size for Kitty.
+4. Treat fetch-failure caching and Sixel's `pxPerCol` fallback accuracy as pre-GA polish items — both are low effort, low risk if deferred.
+5. Everything else (unconditional per-`Update` sync, un-cancelled fetch goroutines, the `EncodeKitty` sentinel API) is fine to leave as-is; they're documented, low-blast-radius tradeoffs rather than bugs.

--- a/docs/reviews/2026-08-09-inline-images-chafa-review.md
+++ b/docs/reviews/2026-08-09-inline-images-chafa-review.md
@@ -1,0 +1,83 @@
+# Inline-Images Review — chafa as a Complete Replacement
+
+**Reviewed branch:** `feature/inline-images` (5 commits over `main`, merge-base `2adf4c9`) · **Perspective:** feasibility assessment — could [chafa](https://github.com/hpjansson/chafa) (a general-purpose C terminal-image renderer) replace `internal/ui/imgview` entirely? Not covered by either prior review (`docs/reviews/2026-08-09-inline-images-architecture-review.md`, `docs/reviews/2026-08-09-inline-images-greenfield-critique.md`).
+
+Scope: current `internal/ui/imgview` package (pure Go, 974 LOC: `kitty.go`, `sixel.go`, `iterm2.go`, `fetch.go`, `frames.go`, `scale.go`, `protocol.go`, `cellsize_unix.go`/`cellsize_windows.go`) and this project's build/distribution setup, compared against chafa's actual capabilities and packaging.
+
+---
+
+## Executive Summary
+
+| Severity | Count |
+|---|---|
+| Blocker | 1 |
+| Medium | 2 |
+| Informational | 2 |
+
+The blocking issue isn't a code-quality gap in chafa — it's that chafa is a C library with no pure-Go implementation, and this project's entire distribution model (`install.sh` fetching one prebuilt static binary per OS/arch, 5 targets, no runtime dependencies) is built on being pure Go. Every integration path available breaks something the project currently gets for free. Recommendation: do not adopt chafa as a replacement for `imgview`.
+
+---
+
+## What chafa actually is
+
+chafa is [hpjansson/chafa](https://github.com/hpjansson/chafa), a C library plus CLI tool, licensed LGPLv3+ for both. It detects terminal capabilities and renders to Sixel, Kitty, iTerm2, or Unicode block/Braille-character fallback, and reads a substantially wider set of input formats than `imgview` currently handles — JPEG, PNG, GIF (including animation), WebP, AVIF, SVG, TIFF, and JPEG XL, versus `imgview`'s JPEG/PNG/GIF/WebP (`imgview/fetch.go`). There is no official Go port. The one community Go binding found, [ploMP4/chafa-go](https://github.com/ploMP4/chafa-go), avoids cgo at build time via [`purego`](https://github.com/ebitengine/purego): it embeds precompiled `libchafa` shared objects in the Go binary via `//go:embed` and `dlopen`s the correct one for the running platform at startup.
+
+Sources: [hpjansson/chafa](https://github.com/hpjansson/chafa), [hpjansson.org/chafa](https://hpjansson.org/chafa/), [ploMP4/chafa-go](https://github.com/ploMP4/chafa-go).
+
+---
+
+## Findings
+
+### BLOCKER — No integration path exists that preserves this project's distribution model
+
+**Files:** `Makefile:17-23`, `.github/workflows/release.yml:59-65`, `install.sh:21-24` (5 statically cross-compiled targets: linux/darwin amd64+arm64, windows amd64; `grep -rn "cgo\|import \"C\""` across the repo returns zero hits)
+
+**The problem:** cyber-tui is currently pure Go with `CGO_ENABLED` never set, cross-compiled to 5 targets with plain `go build`, and distributed as a single downloaded static binary with no runtime dependencies. Every way to call chafa from Go breaks one side of that:
+
+- `exec.Command("chafa", ...)` — turns an optional terminal capability into a hard external dependency. A user would need chafa separately installed (via their OS package manager) before inline images work at all, and the app needs a "chafa not found" degraded path. This is a materially worse install story than "download one binary," for a feature that today works out of the box wherever a supported terminal is detected.
+- cgo bindings to `libchafa` — requires `CGO_ENABLED=1` and a C toolchain (and target sysroot) for every cross-compile target in `release.yml:59-65`, which the current build has never needed.
+- `ploMP4/chafa-go` (purego + embedded `.so`, no cgo at build time) — closest to viable, but see the two Medium findings below; it isn't a drop-in fix for this Blocker, it trades a build-time problem for a packaging/coverage one.
+
+**Recommendation:** Do not integrate chafa via any of these paths for the core rendering pipeline. If a specific missing capability (see Informational below) is wanted later, evaluate it narrowly rather than reopening this tradeoff wholesale.
+
+---
+
+### MEDIUM — The only cgo-free Go binding is an immature single-maintainer project with narrower platform coverage than cyber-tui ships today
+
+**Source:** [ploMP4/chafa-go](https://github.com/ploMP4/chafa-go) — 54 GitHub stars at time of review, community project, not affiliated with the official chafa project.
+
+**The problem:** `chafa-go`'s README states it embeds precompiled `libchafa` binaries for exactly four platform/arch combinations: linux/amd64, linux/386, darwin/arm64, windows/amd64. cyber-tui's current release matrix (`release.yml:59-65`) ships linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 — five targets. Adopting `chafa-go` would drop linux/arm64 and darwin/amd64 (Intel Mac) support outright, since no precompiled `libchafa` exists for them in that project. This is a platform-coverage regression, not a neutral tradeoff, and it comes from a project with no version-stability track record to lean on if a target needs to be added later.
+
+**Recommendation:** If this path is ever reconsidered, treat "does it cover every platform we currently ship" as a hard gate before any other evaluation criteria.
+
+---
+
+### MEDIUM — LGPLv3+ embedding pattern is an open compliance question, not a resolved one
+
+**Source:** [hpjansson/chafa](https://github.com/hpjansson/chafa) license (LGPLv3+, confirmed for both library and CLI).
+
+**The problem:** Dynamically loading an LGPL shared library at runtime (classic `dlopen`) is the long-established "safe" pattern for linking LGPL code into a differently-licensed application. `chafa-go`'s approach — embedding the compiled `.so` as a Go `//go:embed` asset inside a statically distributed binary, then `dlopen`-ing it from an extracted temp copy at runtime — is a less common variant of that pattern. It's very likely fine (the library is still loaded dynamically, not statically linked into the Go binary), but "very likely fine" based on this review's reading is an inference, not a verified conclusion, and it's the kind of question worth an explicit answer before shipping rather than an assumed one.
+
+**Recommendation:** Not a reason to rule chafa out on its own, but if this path is ever pursued, get an explicit answer on the embedding pattern before shipping, rather than inheriting the assumption from this review.
+
+---
+
+### INFORMATIONAL — What chafa would genuinely add that `imgview` doesn't have today
+
+**Files:** `imgview/protocol.go` (`DetectProtocol`, `ProbeSixel`) — has exactly three positive outcomes (Kitty, iTerm2, Sixel) and one `ProtocolNone`; there is no rendering path at all for `ProtocolNone`, so a terminal with no detected graphics protocol gets no inline images, full stop.
+
+chafa's Unicode block/Braille-character fallback is a real, maintained answer to exactly that gap — a way to show *something* image-like in a terminal with no graphics protocol, instead of nothing. It also reads more input formats (AVIF, SVG, TIFF, JPEG XL) than `imgview.Fetch` currently decodes. Both are genuine capabilities cyber-tui doesn't have. Neither requires adopting chafa specifically — a native Unicode-block renderer is a small, self-contained, pure-Go addition (no protocol detection changes needed, it's just another arm of the existing switch) if this gap is ever prioritized as its own feature.
+
+---
+
+### INFORMATIONAL — chafa doesn't touch any of the actual bugs found in the two prior reviews
+
+**Files:** see `docs/reviews/2026-08-09-inline-images-architecture-review.md` and `docs/reviews/2026-08-09-inline-images-greenfield-critique.md` in full.
+
+The MillerLayout wiring gap, the unbounded `inlineImageCache`, uncancelled fetch goroutines, silent fetch-failure caching, and the missing golden-output test coverage are all in `internal/ui/app.go`'s orchestration layer — fetch scheduling, caching, compositing into `View()` — not in the encoder layer chafa would replace (`fetchInlineImageCmd`, `app.go:2572-2600`, dispatches to `EncodeITerm2`/`EncodeSixel`/`EncodeKitty` and returns a ready-to-print string via `handleInlineImageFetched`, `app.go:2607-2621`; chafa would only ever sit behind that same call). Swapping the encoder backend is orthogonal to fixing any of them.
+
+---
+
+## Recommendation
+
+Do not adopt chafa as a replacement for `internal/ui/imgview`. The current package is pure Go, dependency-free at runtime, and covers every platform the project ships today — properties chafa cannot match through any available integration path without giving something up (a hard external binary dependency, a C toolchain in the cross-compile pipeline, or a smaller, less-proven community binding with narrower platform coverage). The genuine capability gap chafa would close — a fallback for terminals with no detected graphics protocol — is real but small enough to solve natively if it's ever prioritized, without reopening this tradeoff.

--- a/docs/reviews/2026-08-09-inline-images-greenfield-critique.md
+++ b/docs/reviews/2026-08-09-inline-images-greenfield-critique.md
@@ -1,0 +1,181 @@
+# Inline-Images Architecture Critique — Solution Architect First Look
+
+**Reviewed branch:** `feature/inline-images` (5 commits over `main`, merge-base `2adf4c9`) · **Scope:** 33 files, +1901/-182 lines · **Lens:** independent read of the code, not a review of any other document in this repo.
+
+This covers Kitty, Sixel, and iTerm2/WezTerm inline image rendering for post/reply bodies in Feed and PostDetail (`d8c09ca`, `c896ca1`), two post-merge hardware-discovered bug-fix commits (`70925fd`, `3ae054c`), and the pre-existing fullscreen image-viewer modal that these share encoders with.
+
+---
+
+## Executive summary
+
+| Severity | Count |
+|---|---|
+| High | 1 |
+| Medium | 4 |
+| Low | 2 |
+| Informational | 2 |
+
+The core architectural choice — route every image-related state change through Bubble Tea messages and mutate `App` fields only inside the single-threaded `Update` loop — is correct and consistently applied. No goroutine in this feature writes to `App` state directly; results always come back as a typed message (`inlineImageFetchedMsg`, `imageFetchedMsg`) and get folded in by `handleInlineImageFetched`/the modal's handler. There are no mutexes in this feature and none are needed. That is not a finding, it is the right call, made once and followed everywhere.
+
+The standout problem is that the feature was built as **two independently-written pipelines** — a fullscreen modal path (`openImageInTerminal`, `internal/ui/app.go:2634-2696`) and an inline-in-post-body path (`syncInlineImages`/`fetchInlineImageCmd`, `app.go:2504-2621`) — that share only the leaf `imgview` encoder functions, not orchestration, caching, or compositing. That duplication is what let the inline path never get wired into `MillerLayout` at all, and it compounds a pre-existing, independently-confirmed bug: `MillerLayout` cannot be selected by any user at runtime, on `main`, before this branch. This feature's ~35 lines of Miller-specific fullscreen-modal maintenance (`internal/ui/layout_miller.go:139-169`) and its dedicated test coverage (`layout_test.go`, `app_test.go`) are exercising code path no build of this app can ever reach.
+
+Everything else is smaller and mostly self-inflicted scope cuts that are honestly commented in the code — an unbounded session cache, a fetch path with no cancellation, a couple of encoder inconsistencies. The two post-merge commits are genuine root-cause fixes for real hardware bugs, not band-aids; they are evidence of a test suite that verifies pure diff functions well and rendered terminal output not at all.
+
+---
+
+## Architecture overview
+
+`App.Update` (`app.go:488-495`) delegates to `updateInner`, then unconditionally calls `syncInlineImages` on the result and batches its command with whatever `updateInner` returned. `syncInlineImages` (`app.go:2514-2557`) is a pure diff: when `canInlineImages()` is true (user toggle on, not an SSH-ephemeral session, a graphics protocol was detected, image viewer preference isn't "browser" — `app.go:2383-2388`) it reads the active screen's `VisibleInlineImages()`, and for anything not already in `inlineImageCache` or `inlineImageFetching`, appends a `fetchInlineImageCmd` (`app.go:2572-2600`) to a `tea.Batch`. That closure runs as a Bubble Tea-scheduled goroutine, fetches via `imgview.Fetch` under a 20s `context.WithTimeout`, encodes for whichever protocol was detected at startup, and returns `inlineImageFetchedMsg`. `handleInlineImageFetched` (`app.go:2607-2621`) is the only place that writes `inlineImageCache`.
+
+View-time compositing is layout-owned rather than shared. `TabsLayout.View` (`layout_tabs.go:112-115`) calls `activeInlineImageSlots()` and, if anything is visible or a Kitty delete is pending, calls `injectInlineImages` (`layout_tabs.go:132-149`), which splices `\x1b[row;colH<encoded>` sequences directly into the already-rendered frame string — deliberately outside lipgloss's own compositing, because embedding a raw image escape sequence inside a string lipgloss reflows would corrupt it (the same reasoning is documented for the fullscreen modal at `layout_tabs.go:68-70`). `MillerLayout.View` (`layout_miller.go:130-171`) has its own, separately-written block for the fullscreen modal and Kitty-cleanup-flag injection — inherited mostly unchanged from before this branch — but contains no call to `activeInlineImageSlots` or any inline-splice function anywhere in the file.
+
+Both pipelines independently re-implement the same three-way protocol switch (Kitty / iTerm2 / Sixel → `EncodeKitty` / `EncodeITerm2` / `EncodeSixel`) with different placement-id schemes: the modal always uses a single fixed sentinel `kittyModalPlacementID = 999000000` (`app.go:2444`) since only one image is ever shown at once, while inline rendering hands out a permanently-assigned per-slot id via `kittyPlacementIDs`/`kittyNextPlacementID` (`app.go:242-243`) since several images can be on screen simultaneously. Both are reasonable choices for their respective constraints — but they are two designs, arrived at and coded separately, not one design parameterized by "how many images can be visible at once."
+
+---
+
+## Findings
+
+### HIGH — `MillerLayout` cannot be reached by any user, and this feature adds real logic to it anyway
+
+**Files:** `internal/ui/app.go:431-433` (`layoutFromName`), call sites `app.go:426` and `app.go:1243`; `internal/ui/layout_miller.go` (whole file, effectively dead)
+
+**The problem:** `func layoutFromName(_ string) Layout { return TabsLayout{} }` discards its argument and always returns `TabsLayout{}`. Both call sites — restoring a saved session's `Layout` field, and applying a settings-screen save's `layoutName` — route through this function, so `App.layout` can never become `MillerLayout{}` regardless of what's persisted in `~/.cyber-tui.json` or chosen in-app. Confirmed this predates the branch: `git show main:internal/ui/app.go` has the identical discard-argument body. There is also no settings-screen UI item to pick a layout at all — the settings list (`internal/ui/screens/settings.go:140-172`) only exposes "timezone", "image viewer", and "inline images (experimental)"; `SettingsModel.layoutName` is tracked and round-tripped (`settings.go:202,226-241`) but never surfaced as a choosable item. `"miller"` appears in exactly one other place in the whole codebase outside comments/docs: a status-bar label rendered by `MillerLayout` itself (`layout_miller.go:475`) — a label no one can ever see it render.
+
+**Failure scenario:** None, today — no user path exists to reach `MillerLayout`, so its incompleteness has zero live impact. The actual failure is on the team: this branch adds a genuine bug-fix (`imgview.DeleteKittyPlacement(kittyModalPlacementID)` replacing a hardcoded blunt delete, `layout_miller.go:166`, matching the same fix applied to `layout_tabs.go`) to a file that cannot run, and ships without ever wiring `injectInlineImages` into it — an omission nobody manual-testing the app could have caught, because there was no way to select the layout to test in the first place. `layout_test.go:66,337,385` and `app_test.go:317` instantiate `MillerLayout{}` directly in tests, which is the only way this code executes at all; that gives a false signal of coverage for something no shipped build exercises.
+
+**Recommendation:** This is a repo-level bug, not scoped to this feature, but it should block calling `MillerLayout` "supported" going forward. Either fix `layoutFromName` to actually branch on its argument and add the missing settings UI item, or delete `layout_miller.go` and its tests until there's a real plan to finish and expose it. Shipping partial, untestable-in-practice logic into a file that already can't be reached is worse than leaving it alone — it's maintenance cost with no corresponding coverage.
+
+---
+
+### MEDIUM — `inlineImageCache`/`kittyPlacementIDs`/`pendingKittyDeletes` grow for the life of the session, with no cap
+
+**Files:** `app.go:184-197` (`inlineImageCache`), `app.go:198-243` (`kittyPlacementIDs`, `kittyNextPlacementID`, `pendingKittyDeletes`)
+
+**The problem:** `inlineImageCache` is keyed by slot key × URL × column budget × protocol (`inlineImageCacheKey`, `app.go:2415-2423`) and is never evicted — every distinct image seen, at every distinct column width the terminal was ever resized to, stays cached for the session. The doc comment explicitly names this an accepted cut ("see the plan's accepted..."), but no such plan document exists anywhere in the repository (`find`/`grep` across `docs/` and `internal/` for anything inline-image-related turns up nothing — the only "plan" files present are `docs/plan-guild-join-leave.md`, unrelated). For Kitty, the cached value is a base64-encoded raw 32-bit RGBA payload with no compression (`f=32`, `imgview/kitty.go:34-47,58`) — the most memory-expensive encoding available here, since `EncodeITerm2` PNG-encodes first (`imgview/iterm2.go:21-25`). `kittyPlacementIDs` and `kittyNextPlacementID` are coupled to the same cut by design: an id is never reused within a session (`app.go:235`), and the doc comment explains this is necessary given the current no-eviction cache, not incidental.
+
+**Failure scenario:** A long session that scrolls through many image-bearing posts, or gets resized repeatedly (a dragged terminal window, a tmux pane reflow changing the effective column count), accumulates cache entries indefinitely. Each resize multiplies the cache-key space rather than replacing entries in place.
+
+**Recommendation:** Bound `inlineImageCache` (LRU by byte size, given the RGBA payload size varies a lot by image) before removing the "experimental" label from this feature. Any eviction scheme needs to account for the `kittyPlacementIDs` coupling explicitly — evicting a cache entry for a still-visible-but-off-slot Kitty placement without also invalidating its id would desync the two.
+
+---
+
+### MEDIUM — Kitty and iTerm2 never query real terminal cell size; only Sixel does, in the same package
+
+**Files:** `imgview/kitty.go:48`, `imgview/iterm2.go:26` vs `imgview/sixel.go:23-31`; `imgview/cellsize_unix.go`, `imgview/cellsize_windows.go`
+
+**The problem:** `TerminalCellPixelSize(fd int) (cellW, cellH int, ok bool)` reads real cell-pixel geometry via `TIOCGWINSZ` on Unix (`cellsize_unix.go:14-20`; always `ok=false` on Windows, `cellsize_windows.go:8-10`). `EncodeSixel` accepts `cellPxW, cellPxH` and only falls back to the hardcoded `pxPerCol=10, 2*pxPerCol=20` constant when the caller passes `<=0` (`sixel.go:24-26`) — and callers do query the real value first (`app.go:2588` inline, `app.go:2680` modal). `EncodeKitty` and `EncodeITerm2` don't take cell-size parameters at all; they call `fitBox(..., pxPerCol, 2*pxPerCol)` unconditionally (`kitty.go:48`, `iterm2.go:26`), meaning the assumed 10×20px cell is used for every Kitty/iTerm2 render regardless of the terminal's actual font metrics, even on the same machine where the ioctl is already being called for Sixel a few lines away in the caller.
+
+**Failure scenario:** Kitty's `c=%d,r=%d` display-size hint (`kitty.go:59-60`) is computed from a guessed cell size, then the terminal itself scales to fit that hint — so a wrong guess just nudges what fraction of available space the image claims, not a crash or corruption. Low severity in isolation. It's flagged as a finding because it's an inconsistency with no protocol justification: Kitty's protocol has no aversion to precise sizing, the real value is one function call away, and Sixel in the same file already proves the pattern works. This reads like an oversight from writing the three encoders at different times rather than a deliberate simplification.
+
+**Recommendation:** Thread `TerminalCellPixelSize`'s result into `EncodeKitty`/`EncodeITerm2` the same way `EncodeSixel` already receives it, keeping `pxPerCol` only as the genuine last-resort fallback for all three instead of the only path for two of them.
+
+---
+
+### MEDIUM — In-flight inline fetches have no cancellation path
+
+**Files:** `app.go:2572-2600` (`fetchInlineImageCmd`), `app.go:2607-2621` (`handleInlineImageFetched`)
+
+**The problem:** Each fetch is bounded by a 20s `context.WithTimeout` so it's not unbounded, but nothing cancels it early. Scrolling a post's image out of view, toggling inline images off mid-fetch, navigating to a different screen, or quitting the app all let the goroutine run to completion; `inlineImageFetching[key]` is cleared only when the result message arrives (`app.go:2610`). Contrast with the fullscreen modal path, which has a staleness guard: `imageFetchGen` is incremented on every new open (`app.go:2642-2643`) and presumably checked against the message's `gen` field on arrival, so a superseded fetch's result gets discarded rather than applied. The inline path has no equivalent generation check — a slow fetch for a slot that's since scrolled away still writes into `inlineImageCache` when it lands, which is harmless (nothing reads a cache entry for a URL that's not currently visible) but the wasted network+decode work isn't avoided either way.
+
+**Failure scenario:** Rapidly scrolling past many image-bearing posts fires a fetch per distinct slot seen, all of which run to completion even for slots visible for a fraction of a second. Bounded in the worst case by the 20s timeout and this feature's own size/pixel caps, so not a resource exhaustion risk today, but it's the kind of gap that gets worse if this pattern is copied for a more expensive per-item fetch later.
+
+**Recommendation:** Store a `context.CancelFunc` alongside each `inlineImageFetching` entry and call it when a key drops out of `activeInlineImageSlots()`, on toggle-off, and on quit.
+
+---
+
+### MEDIUM — `syncInlineImages` runs unconditionally on every `Update`, not gated to relevant messages
+
+**File:** `app.go:488-495` (call site), `app.go:2514-2557` (body)
+
+**The problem:** Every keypress, tick, resize, or unrelated screen navigation calls `syncInlineImages`, not just messages that could plausibly change the visible image set. The function itself short-circuits cheaply when `canInlineImages()` is false or the visible-slot diff is empty, so this isn't measured as a performance problem — it's flagged as a structural habit. "Recompute a screen-derived diff on every message, relying on the diff being cheap rather than gating on message type" is a pattern that degrades quietly if it's ever copied for something costlier, and it makes "when does image state change" harder to reason about than it needs to be (the honest answer today is "always, but usually a no-op").
+
+**Recommendation:** Not urgent in isolation. Worth revisiting if this exact pattern gets reused for another per-frame derived-state sync, or if a future profiling pass shows `Update` latency pressure.
+
+---
+
+### LOW — Fetch failures are cached as silent blanks, with no retry signal
+
+**File:** `app.go:2607-2621` (`handleInlineImageFetched`)
+
+**The problem:** On `err != nil`, the function clears the in-flight marker and returns without touching `inlineImageCache` (`app.go:2617-2619` only runs on the success path) — so the slot stays permanently un-cached, and `syncInlineImages` retries it on the very next `Update`, since neither map remembers the failure. There is no failure memoization at all: a persistently-failing image URL is refetched on every message while its post stays visible, with no backoff.
+
+**Failure scenario:** A post containing a permanently-broken image URL, left visible while the user is idle-scrolling elsewhere on the same screen, causes a fresh HTTP request (bounded by the 20s timeout) on every `Update` that includes that slot in the visible set — keystrokes, ticks, anything.
+
+**Recommendation:** Cache a "failed" sentinel (distinct from "not yet attempted") with a short cooldown, so a dead link doesn't get hammered every frame it's visible.
+
+---
+
+### LOW — Sixel hardcodes 256 colors with no capability negotiation
+
+**File:** `imgview/sixel.go:44`
+
+**The problem:** `enc.Colors = 256` is fixed regardless of what the connecting terminal reports. True for essentially every Sixel-capable terminal in practice; not guaranteed by spec.
+
+**Recommendation:** Low priority; document as a known assumption rather than treat as urgent.
+
+---
+
+### INFORMATIONAL — Two independently-written encode-dispatch blocks are the root cause behind the Miller gap
+
+**Files:** `app.go:2572-2600` (inline) vs `app.go:2634-2696` (modal)
+
+Both functions contain the identical `switch proto { case ProtocolITerm2: ...; case ProtocolSixel: ...; case ProtocolKitty: ... }` structure, written twice, with different surrounding concerns (placement-id source, GIF-frame looping in the modal only, caching scope). This isn't wrong — Go doesn't make sharing a five-line switch trivially worth abstracting on its own — but it's the same duplication pattern that let one caller (`TabsLayout`) get inline compositing wired up while the other reachable... in principle... layout did not. Flagging as informational because the High finding above already covers the concrete consequence; this is the structural reason a second consequence (silent drift between the two pipelines on any future protocol-handling change) remains open even after `MillerLayout` itself is fixed or removed.
+
+---
+
+### INFORMATIONAL — Test suite verifies pure diff/encode functions well; rendered `View()` output, never
+
+**Files:** `internal/ui/app_test.go` (`TestSyncKittyPlacements_*`, `TestSyncInlineImages_*`, `TestAccumulateKittyDeletes_*`), `internal/ui/imgview/*_test.go`, `internal/ui/screens/feed_test.go`, `postdetail_test.go`
+
+Coverage of the diff/encode logic in isolation is genuinely good — id-stability transitions, row/col capping, fetch size/pixel/frame-count guards, and both post-merge Ghostty regressions now have dedicated regression tests. But every test calls pure functions directly against hand-built state; none assert on `TabsLayout.View()`'s or `MillerLayout.View()`'s actual composited output string. That's precisely the test category that would have caught the Miller gap (an assertion that a visible slot's escape sequence appears in `MillerLayout.View()`'s output would have failed from the day `injectInlineImages` was written), and it's consistent with two of five commits on this branch being fixes for lifecycle bugs found by hand on real hardware (Ghostty) after merge rather than by any test.
+
+**Recommendation:** A small number of golden-output tests — fixed terminal size, fixed image content, assert the exact composited escape sequence appears at the expected cursor position — for each layout, would close most of this gap cheaply.
+
+---
+
+## If no image support existed yet: how I would have built this
+
+Given the constraint that terminal image protocols require splicing raw escape sequences around lipgloss's own rendering (a genuine, unavoidable constraint this codebase already discovered and solved correctly), here is what I'd do differently starting from zero:
+
+**One shared pipeline, not two.** A single `imagePipeline` type owning the cache, in-flight tracking, and Kitty placement-id allocation, parameterized by "how many images can this call site show at once" (1 for the modal, N for inline) rather than being two hand-built implementations of "fetch, encode, cache, track a placement id." The three-way protocol switch gets written once. This is the single highest-leverage change: it removes the class of bug the Miller gap belongs to, not just that one instance of it.
+
+**Compositing lives above the layout, not inside each one.** Instead of every `Layout.View()` implementation being individually responsible for remembering to call `injectInlineImages`, put one call in `App`'s top-level render path — after `a.layout.View(a)` returns, before the string reaches the terminal — so a layout physically cannot skip it. A `Layout` implementation would return its own modal/chrome compositing (which genuinely does vary per layout — border position, overlay centering) but never own the "did I remember to splice in the images" responsibility. This turns the Miller-gap class of bug into something the type system enforces rather than something code review has to catch.
+
+**Bounded cache from day one.** An LRU keyed the same way (`slot × URL × cols × protocol`), capped by total encoded-payload bytes, is barely more code than an unbounded map — `container/list` plus a map, evict-oldest on insert past the cap. There's no real cost to writing this the first time instead of deferring it; the "spike" framing in the current comments buys very little given how small the actual diff would be.
+
+**Real cell size for all three protocols from day one**, since the ioctl already has to be written for Sixel regardless — `pxPerCol` becomes the fallback for all three uniformly (used when `TerminalCellPixelSize` reports `ok=false`), not the only path for two of them and a fallback for the third.
+
+**`context.CancelFunc` stored next to each in-flight marker**, cancelled on scroll-away/toggle-off/quit. This is one extra field in the tracking map and one extra call at three call sites — cheap enough that there's no reason to defer it to "later," unlike genuinely complex work like GIF disposal-method handling.
+
+**Kitty payload PNG-compressed (`f=100`) instead of raw RGBA (`f=32`) from the start.** Given the cache stores the post-encode string, this is a direct multiplier on the single largest memory-allocation surface in the feature, for the same amount of encoder code (Go's `image/png` is already a dependency here via `iterm2.go`).
+
+**`syncInlineImages` gated on message type**, not run unconditionally. A short type-switch on the incoming `tea.Msg` (scroll, resize, selection-change, screen-switch, the toggle setting itself) before doing any diff work — a few lines, and it establishes the right default habit for any future per-frame derived-state sync in this codebase rather than "always recompute, rely on it being cheap."
+
+**Don't build a second `Layout` implementation before there's a way to select it.** If Miller-layout support isn't finished enough to expose in settings, I would not have written fullscreen-modal or inline-image logic into `layout_miller.go` in this branch at all — either finish wiring `layoutFromName` and the settings item in the same change, or leave the file untouched until that's done. Partial logic in unreachable code is a liability with no offsetting benefit; it looks tested (there are unit tests that instantiate it directly) while being unverified in any way that matters to a real user.
+
+**A handful of golden-output `View()` tests per protocol, written alongside the feature, not after.** Fixed terminal size, fixed post content, assert the literal expected escape sequence and its cursor position. This is the one test category proven, by this branch's own history, to catch the bugs that actually shipped (the Miller gap, and arguably the two Ghostty lifecycle bugs — a golden test that pinned the exact sequence of delete/create escapes across a scripted sequence of `Update` calls would have caught the sticky-cleanup-flag and stale-cache-entry bugs without needing real hardware).
+
+None of this changes the core Elm-loop-plus-messages architecture — that part was the right call the first time and I'd keep it unchanged.
+
+---
+
+## What is already right
+
+- Single-threaded state mutation via Bubble Tea messages throughout; no mutexes in this feature, none needed, because no goroutine ever touches `App` fields directly.
+- `imgview/fetch.go` has real, tested guards: `maxImageBytes = 10<<20` matching the API/RTDB clients' cap (`fetch.go:18-20`), a declared-dimension check via `image.DecodeConfig` before the full decode so a small file claiming huge dimensions can't drive allocation (`fetch.go:22-24,72-82`), and both `maxGIFFrames`/`maxGIFTotalPixels` guards for the animated path.
+- The two post-merge commits (`70925fd`, `3ae054c`) are genuine root-cause fixes — stable placement ids, an accumulating (not countdown-based) delete-resend set with the countdown alternative explicitly tried and reverted with its rationale documented (`app.go:222-236`), a cancelable `ProbeSixel` read — not band-aids over the symptoms.
+- The code comments in this branch are unusually good at explaining *why*, not just *what* — e.g. the `q=2` suppress-response flag's rationale (`kitty.go:53-56`, a real bug: unsuppressed Kitty ACKs were read as keystrokes and closed the modal instantly), the anonymous-vs-named placement-id sentinel choice (`kitty.go:12-22`), and the fall-through-not-return requirement in the Kitty cleanup branch (`layout_tabs.go:95-100`). This made the codebase substantially easier to review accurately.
+- `EncodeKitty`/`EncodeSixel`/`EncodeITerm2` all correctly refuse to upscale beyond an image's natural pixel size, tested explicitly (`TestEncodeSixel_NeverUpscales`).
+- Feed capping to the first eligible image (`render.go:106-111`) is a deliberate, documented tradeoff for its truncated-body card layout, not an unexplained inconsistency — PostDetail correctly renders every eligible image since it has no such truncation.
+
+---
+
+## Prioritized recommendations
+
+1. Resolve the `MillerLayout` dead-code situation one way or the other before adding more logic to it — either finish `layoutFromName` and expose a settings item, or delete the file and its tests. This is the one finding with real ambiguity about ownership (pre-existing bug vs. this feature's scope), so it needs a decision, not just a patch.
+2. Add golden-output `View()` tests per layout/protocol — the test category that would have caught both the Miller gap and, plausibly, the Ghostty lifecycle bugs without needing real hardware.
+3. Bound `inlineImageCache` and compress the Kitty payload (`f=100`) before this feature loses its "experimental" label.
+4. Extend the fullscreen modal's fetch-staleness guard (`imageFetchGen`) to the inline path, or add `context.CancelFunc`-based cancellation.
+5. Thread real cell-pixel size into `EncodeKitty`/`EncodeITerm2` the same way `EncodeSixel` already receives it.
+6. Cache-and-cooldown fetch failures instead of retrying a dead URL on every `Update` it stays visible for.
+7. Everything else here (unconditional per-`Update` sync, the fixed Sixel color count) is fine to leave as-is — low blast radius, already understood tradeoffs.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/mattn/go-sixel v0.0.12
+	github.com/muesli/cancelreader v0.2.2
 	github.com/muesli/termenv v0.16.0
 	github.com/yuin/goldmark v1.8.2
 	golang.org/x/image v0.44.0
@@ -45,7 +46,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
-	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/soniakeys/quant v1.0.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -78,6 +78,13 @@ type Config struct {
 	// fullscreen modal; "browser" always opens in the OS default browser.
 	ImageViewer string `json:"imageViewer,omitempty"`
 
+	// InlineImages enables rendering each post's first image attachment
+	// directly in the feed and post detail views, instead of just a link.
+	// Experimental — off by default. Still subject to the same graphics
+	// protocol detection and ImageViewer/ephemeral-session gating as the
+	// fullscreen image viewer.
+	InlineImages bool `json:"inlineImages,omitempty"`
+
 	// Layout selects the UI layout. "" or "tabs" = tab bar (default); "miller" = sidebar columns.
 	Layout string `json:"layout,omitempty"`
 }
@@ -204,4 +211,3 @@ func ShouldWanderNow(cfg Config) bool {
 	return cfg.LastWandered.IsZero() ||
 		time.Since(cfg.LastWandered) >= WanderInterval
 }
-

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -51,8 +51,8 @@ type Follow struct {
 }
 
 // Attachment represents a media attachment on a post or reply.
-// Type is "image" or "audio". Src is always present.
-// Image-specific: Width, Height. Audio-specific: Origin, Artist, Title, Genre.
+// Type is "image", "gif", or "audio". Src is always present.
+// Image/gif-specific: Width, Height. Audio-specific: Origin, Artist, Title, Genre.
 type Attachment struct {
 	Type   string
 	Src    string

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -428,7 +428,10 @@ func (a App) WithSavedSession(s config.Config) App {
 	return a
 }
 
-func layoutFromName(_ string) Layout {
+func layoutFromName(name string) Layout {
+	if name == "miller" {
+		return MillerLayout{}
+	}
 	return TabsLayout{}
 }
 
@@ -2143,7 +2146,12 @@ func (a *App) delegateUpdate(msg tea.Msg) tea.Cmd {
 
 // --- view ---
 
-func (a App) View() string { return a.layout.View(a) }
+func (a App) View() string {
+	if a.active == screenLogin {
+		return a.login.View()
+	}
+	return a.layout.View(a)
+}
 
 // activeScreenHasFocusedInput returns true when the current screen has a
 // text input that is focused, preventing arrow keys from being consumed by
@@ -2389,7 +2397,10 @@ func (a App) canInlineImages() bool {
 
 // activeInlineImageSlots returns the active screen's currently visible
 // inline image slots, or nil for screens that don't support inline images
-// (Search/Guilds/Topics/Miller panes — see renderPostBody's doc comment).
+// (Search/Guilds/Topics). Used by TabsLayout.InlineImageSlots; MillerLayout
+// has its own equivalent since its screen geometry (and, for Feed, which
+// screen method even has the current content — see FeedModel.VisibleDetailInlineImages)
+// differs from Tabs'.
 func (a App) activeInlineImageSlots() []screens.InlineImageSlot {
 	switch a.active {
 	case screenPostDetail:
@@ -2514,7 +2525,7 @@ func accumulateKittyDeletes(pending map[int]struct{}, newlyDropped []int) map[in
 func (a App) syncInlineImages() (App, tea.Cmd) {
 	var slots []screens.InlineImageSlot
 	if a.canInlineImages() {
-		slots = a.activeInlineImageSlots()
+		slots, _, _ = a.layout.InlineImageSlots(a)
 	}
 	var cmds []tea.Cmd
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -182,17 +182,67 @@ type App struct {
 	imageCache map[string]cachedImage
 
 	// inlineImageCache holds encoded inline-image escape sequences for the
-	// life of the session, keyed by inlineImageCacheKey (URL + column budget
-	// + protocol) — never evicted; see the plan's accepted spike-scope cut.
-	// inlineImageFetching tracks keys with a fetch already in flight, so
-	// syncInlineImages (called every Update) doesn't refire the same
-	// request every frame while it's pending. inlineImageLastSig is the
-	// previous frame's visible-slot signature (see inlineImageSignature),
-	// used to detect a scroll/selection change that requires a full clear
-	// for Sixel/iTerm2 (neither has a placement-delete primitive).
+	// life of the session, keyed by inlineImageCacheKey (slot key + URL +
+	// column budget + protocol) — never evicted; see the plan's accepted
+	// spike-scope cut. inlineImageFetching tracks keys with a fetch already
+	// in flight, so syncInlineImages (called every Update) doesn't refire
+	// the same request every frame while it's pending. inlineImageLastSig is
+	// the previous frame's visible-slot signature (see
+	// inlineImageSignature), used to detect a scroll/selection change that
+	// requires a full clear for Sixel/iTerm2 (neither has a placement-delete
+	// primitive — Kitty does, see kittyPlacementIDs, and never uses this).
 	inlineImageCache    map[string]string
 	inlineImageFetching map[string]bool
 	inlineImageLastSig  string
+
+	// kittyPlacementIDs assigns a stable id (used as both image id and
+	// placement id, see imgview.EncodeKitty) to each inline image slot ever
+	// seen, keyed by InlineImageSlot.Key. Entries are PERMANENT — never
+	// removed once assigned, even after the slot scrolls off-screen and gets
+	// deleted on the terminal side. This matters because inlineImageCacheKey
+	// doesn't vary by id (only by slot key/URL/width/protocol): if a key's id
+	// changed on every re-entry into view, a slot scrolling back into view
+	// would hit its OLD cache entry (still embedding the OLD, already-deleted
+	// id) and, since that old id sits permanently in pendingKittyDeletes (see
+	// below), get deleted again the instant it's redrawn — invisible forever
+	// after its first scroll-off. Keeping the id (and thus the cache entry)
+	// stable for a key's whole session lifetime avoids that entirely.
+	// kittyNextPlacementID is the session-lived counter handing out new ids —
+	// never reused/freed within a session, which is fine for a spike (see the
+	// plan's no-cache-eviction cut; the same reasoning applies here).
+	//
+	// kittyVisibleKeys is the set of slot keys visible as of the last sync
+	// call. Because kittyPlacementIDs is never pruned, "not in
+	// kittyPlacementIDs" can no longer be used to detect a drop — nearly
+	// every key ever seen is "not currently visible" at any given moment, not
+	// just ones that just transitioned. Comparing against kittyVisibleKeys
+	// instead of kittyPlacementIDs is what lets syncKittyPlacements detect
+	// exactly the visible->invisible and invisible->visible transitions.
+	//
+	// pendingKittyDeletes is the set of dropped-out placement ids whose
+	// delete sequence gets resent on every subsequent frame. Deletes are the
+	// one part of this feature that's a single-shot event rather than
+	// something re-emitted every frame a slot is visible (creates/
+	// repositions are, by nature of the normal per-frame render loop) — and
+	// Bubble Tea's renderer batches/throttles actual terminal writes, so it
+	// can call View() many times between two real flushes and only the last
+	// computed View() before a flush tick ever reaches the terminal. A
+	// countdown-based resend budget was tried here first, decremented once
+	// per Update; a fast enough scroll can still rack up enough Updates
+	// between two real flushes to exhaust that budget on nothing but
+	// never-flushed intermediate renders, losing the delete exactly like the
+	// original single-shot version. Since Kitty placement ids are never
+	// reused within a session (kittyNextPlacementID only grows), resending an
+	// already-deleted id's delete is always a harmless no-op — so, like
+	// imageNeedsCleanup above (same underlying race, same fix), entries here
+	// are never auto-expired by a countdown; they're only removed early when
+	// syncKittyPlacements reports the same key has become visible again (see
+	// "revived" in syncInlineImages), which cancels the stale delete before it
+	// can wipe out the slot's freshly redrawn placement.
+	kittyPlacementIDs    map[string]int
+	kittyNextPlacementID int
+	kittyVisibleKeys     map[string]struct{}
+	pendingKittyDeletes  map[int]struct{}
 
 	// timezone is the active UTC offset label (e.g. "UTC+2"). Empty = UTC.
 	// loc is the parsed *time.Location derived from timezone.
@@ -2333,12 +2383,7 @@ func (a App) canRenderImageInline(u string) bool {
 func (a App) canInlineImages() bool {
 	return a.inlineImages &&
 		!a.ephemeral &&
-		// ponytail: Sixel/iTerm2 only — Kitty's placement-ID lifecycle isn't
-		// wired into syncInlineImages yet (phase 6). Loosen to
-		// != ProtocolNone once that lands; until then, gating Kitty out here
-		// keeps a Kitty user from losing the "[IMG]" placeholder text to a
-		// reserved blank band that never gets drawn into.
-		(a.graphicsProtocol == imgview.ProtocolSixel || a.graphicsProtocol == imgview.ProtocolITerm2) &&
+		a.graphicsProtocol != imgview.ProtocolNone &&
 		a.imageViewer != "browser"
 }
 
@@ -2368,30 +2413,125 @@ func inlineImageSignature(slots []screens.InlineImageSlot) string {
 }
 
 // inlineImageCacheKey identifies one encoded rendering of a slot's image —
-// URL, column budget, and protocol, matching how a resize (which changes
-// MaxCols) or a protocol change naturally invalidates old entries.
+// slot key, URL, column budget, and protocol. Keying by slot (not just URL)
+// matters for Kitty, whose encoded bytes embed a placement id specific to
+// one on-screen instance (see imgview.EncodeKitty) — two slots showing the
+// same URL must never share an encode. Also matches how a resize (which
+// changes MaxCols) or a protocol change naturally invalidates old entries.
 func inlineImageCacheKey(slot screens.InlineImageSlot, proto imgview.GraphicsProtocol) string {
-	return fmt.Sprintf("%s|%d|%d", slot.URL, slot.MaxCols, proto)
+	return fmt.Sprintf("%s|%s|%d|%d", slot.Key, slot.URL, slot.MaxCols, proto)
+}
+
+// kittyModalPlacementID is a fixed, reserved Kitty placement/image id used
+// exclusively by the fullscreen image modal — distinct from inline
+// rendering's per-slot ids (see App.kittyPlacementIDs), which start from 1
+// and grow with normal use. Giving the modal a dedicated id (rather than
+// the anonymous placementID==0 mode EncodeKitty also supports) means its
+// own open/close/cycle lifecycle never has to blunt-delete-all placements —
+// which would erase every inline image's placement too, now that both
+// features can be on screen at once. Re-sending a=T with this same id on
+// each open/cycle replaces any previous modal placement per the protocol
+// spec, so no separate self-heal delete is needed there either. Deliberately
+// NOT the top of Kitty's 32-bit id range (4294967295 / 0xFFFFFFFF): that
+// exact value is a conventional "no id"/sentinel value in a lot of unsigned-
+// integer code, and terminals implementing the protocol are free to special-
+// case it — consistent with the modal flashing open then immediately
+// vanishing once this id was used, rather than staying on screen like any
+// other named placement. 999000000 is an arbitrary value nowhere near any
+// common sentinel (0, 1, INT32_MAX, UINT32_MAX) yet still astronomically far
+// from the small incrementing counter inline rendering uses, so it can never
+// collide with it either.
+const kittyModalPlacementID = 999000000
+
+// syncKittyPlacements assigns a stable id (used as both image id and
+// placement id, see imgview.EncodeKitty) to every slot ever seen — new keys
+// get the next counter value, permanently; already-tracked keys keep theirs
+// forever, whether currently visible or not (see kittyPlacementIDs' doc
+// comment on the App struct for why). Comparing this sync's visible set
+// against kittyVisibleKeys (last sync's) reports exactly two transitions:
+// toDelete, ids for keys that just became invisible, and revived, ids for
+// keys that just became visible again — the caller cancels any pending
+// delete for a revived id before it can wipe out that key's freshly redrawn
+// placement. Returns the updated App, the current key->id mapping (for
+// fetchInlineImageCmd to look up), toDelete, and revived.
+func (a App) syncKittyPlacements(slots []screens.InlineImageSlot) (App, map[string]int, []int, []int) {
+	if a.kittyPlacementIDs == nil {
+		a.kittyPlacementIDs = make(map[string]int)
+	}
+	current := make(map[string]bool, len(slots))
+	for _, s := range slots {
+		current[s.Key] = true
+		if _, ok := a.kittyPlacementIDs[s.Key]; !ok {
+			a.kittyNextPlacementID++
+			a.kittyPlacementIDs[s.Key] = a.kittyNextPlacementID
+		}
+	}
+	var toDelete, revived []int
+	for key := range a.kittyVisibleKeys {
+		if !current[key] {
+			toDelete = append(toDelete, a.kittyPlacementIDs[key])
+		}
+	}
+	for key := range current {
+		if _, wasVisible := a.kittyVisibleKeys[key]; !wasVisible {
+			revived = append(revived, a.kittyPlacementIDs[key])
+		}
+	}
+	visible := make(map[string]struct{}, len(current))
+	for key := range current {
+		visible[key] = struct{}{}
+	}
+	a.kittyVisibleKeys = visible
+	return a, a.kittyPlacementIDs, toDelete, revived
+}
+
+// accumulateKittyDeletes merges newlyDropped ids into pending. Merging
+// (never overwriting or expiring) is what makes a delete robust against
+// Bubble Tea's throttled renderer processing several Updates before it
+// actually writes a frame — see pendingKittyDeletes' doc comment on the App
+// struct for why even a resend countdown could still lose a delete that was
+// never rendered.
+func accumulateKittyDeletes(pending map[int]struct{}, newlyDropped []int) map[int]struct{} {
+	if pending == nil {
+		pending = make(map[int]struct{})
+	}
+	for _, id := range newlyDropped {
+		pending[id] = struct{}{}
+	}
+	return pending
 }
 
 // syncInlineImages diffs the active screen's current VisibleInlineImages()
 // against inlineImageCache and returns a command that fetches+encodes
 // anything missing. It's called once per Update, after the active screen
-// has already processed the message. A change in the visible-slot signature
-// forces a full-screen clear on Sixel/iTerm2 — neither protocol has a
-// placement-delete primitive, so a moved or removed image can otherwise
-// leave stray pixels behind (the same reasoning already applied to the
-// fullscreen modal's close/cycle handling).
+// has already processed the message. Kitty gets precise per-image
+// create/delete via kittyPlacementIDs/pendingKittyDeletes (see
+// syncKittyPlacements); Sixel/iTerm2 have no placement-delete primitive, so
+// any change in the visible-slot signature instead forces a full-screen
+// clear — a moved or removed image can otherwise leave stray pixels behind
+// (the same reasoning already applied to the fullscreen modal's close/cycle
+// handling).
 func (a App) syncInlineImages() (App, tea.Cmd) {
 	if !a.canInlineImages() {
 		return a, nil
 	}
 	slots := a.activeInlineImageSlots()
 	var cmds []tea.Cmd
-	if sig := inlineImageSignature(slots); sig != a.inlineImageLastSig {
+
+	isKitty := a.graphicsProtocol == imgview.ProtocolKitty
+	var placementIDs map[string]int
+	if isKitty {
+		var toDelete, revived []int
+		a, placementIDs, toDelete, revived = a.syncKittyPlacements(slots)
+		for _, id := range revived {
+			delete(a.pendingKittyDeletes, id)
+		}
+		a.pendingKittyDeletes = accumulateKittyDeletes(a.pendingKittyDeletes, toDelete)
+	} else if sig := inlineImageSignature(slots); sig != a.inlineImageLastSig {
 		a.inlineImageLastSig = sig
 		cmds = append(cmds, tea.ClearScreen)
 	}
+
 	if a.inlineImageFetching == nil {
 		a.inlineImageFetching = make(map[string]bool)
 	}
@@ -2404,7 +2544,11 @@ func (a App) syncInlineImages() (App, tea.Cmd) {
 			continue
 		}
 		a.inlineImageFetching[key] = true
-		cmds = append(cmds, a.fetchInlineImageCmd(slot, key))
+		placementID := 0
+		if isKitty {
+			placementID = placementIDs[slot.Key]
+		}
+		cmds = append(cmds, a.fetchInlineImageCmd(slot, key, placementID))
 	}
 	if len(cmds) == 0 {
 		return a, nil
@@ -2420,11 +2564,12 @@ type inlineImageFetchedMsg struct {
 }
 
 // fetchInlineImageCmd fetches and encodes slot's image for the currently
-// detected protocol (Sixel or iTerm2 — see canInlineImages). Unlike the
+// detected protocol. placementID is only used for Kitty (see
+// imgview.EncodeKitty); callers pass 0 for Sixel/iTerm2. Unlike the
 // fullscreen modal, there's no user-visible loading state to manage: a miss
 // this frame just means the reserved blank band stays blank until the
 // result lands.
-func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string) tea.Cmd {
+func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string, placementID int) tea.Cmd {
 	proto := a.graphicsProtocol
 	maxCols, maxRows := slot.MaxCols, slot.MaxRows
 	url := slot.URL
@@ -2442,6 +2587,8 @@ func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string) tea.C
 		case imgview.ProtocolSixel:
 			cellW, cellH, _ := imgview.TerminalCellPixelSize(int(os.Stdout.Fd()))
 			encoded, _, _, err = imgview.EncodeSixel(img, maxCols, maxRows, cellW, cellH)
+		case imgview.ProtocolKitty:
+			encoded, _, _ = imgview.EncodeKitty(img, maxCols, maxRows, placementID)
 		default:
 			err = fmt.Errorf("inline images: unsupported protocol %v", proto)
 		}
@@ -2521,7 +2668,7 @@ func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 		for i, img := range frames {
 			switch proto {
 			case imgview.ProtocolKitty:
-				encodedFrames[i], cols, rows = imgview.EncodeKitty(img, displayCols, displayRows)
+				encodedFrames[i], cols, rows = imgview.EncodeKitty(img, displayCols, displayRows, kittyModalPlacementID)
 			case imgview.ProtocolITerm2:
 				var err error
 				encodedFrames[i], cols, rows, err = imgview.EncodeITerm2(img, displayCols, displayRows)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -181,6 +181,19 @@ type App struct {
 	// network fetch. Cleared whenever the modal closes.
 	imageCache map[string]cachedImage
 
+	// inlineImageCache holds encoded inline-image escape sequences for the
+	// life of the session, keyed by inlineImageCacheKey (URL + column budget
+	// + protocol) — never evicted; see the plan's accepted spike-scope cut.
+	// inlineImageFetching tracks keys with a fetch already in flight, so
+	// syncInlineImages (called every Update) doesn't refire the same
+	// request every frame while it's pending. inlineImageLastSig is the
+	// previous frame's visible-slot signature (see inlineImageSignature),
+	// used to detect a scroll/selection change that requires a full clear
+	// for Sixel/iTerm2 (neither has a placement-delete primitive).
+	inlineImageCache    map[string]string
+	inlineImageFetching map[string]bool
+	inlineImageLastSig  string
+
 	// timezone is the active UTC offset label (e.g. "UTC+2"). Empty = UTC.
 	// loc is the parsed *time.Location derived from timezone.
 	timezone string
@@ -243,6 +256,10 @@ type App struct {
 	// imageViewer is the user's preference from config.ImageViewer. When "browser",
 	// image URLs always open in the OS browser even if a protocol is detected.
 	imageViewer string
+
+	// inlineImages is the user's raw preference from config.InlineImages.
+	// See canInlineImages for the fully-gated value broadcast to screens.
+	inlineImages bool
 
 	// imageModal holds the state for the inline image overlay. When imageModalOpen
 	// is true, View composites the encoded image sequence over the base content.
@@ -354,6 +371,7 @@ func (a App) WithSavedSession(s config.Config) App {
 	a.wanderLust = s.WanderLust
 	a.maxThreadDepth = s.GetMaxThreadDepth()
 	a.imageViewer = s.ImageViewer
+	a.inlineImages = s.InlineImages
 	a.layoutName = s.Layout
 	a.layout = layoutFromName(s.Layout)
 	a.customPalette = s.CustomPalette
@@ -411,7 +429,22 @@ func (a App) Init() tea.Cmd {
 // handlers so each can claim the message and return early. WindowSizeMsg is
 // handled first and always falls through to delegateUpdate so the active
 // screen can also react to it.
+// Update is the top-level bubbletea entry point. It delegates to updateInner
+// for all existing message handling, then runs syncInlineImages once per
+// message on the resulting state — after the active screen has already
+// processed msg, so VisibleInlineImages() reflects any scroll/selection
+// change from this same message — batching its command (if any) with
+// whatever updateInner returned.
 func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	a2, cmd := a.updateInner(msg)
+	a3, syncCmd := a2.syncInlineImages()
+	if syncCmd == nil {
+		return a3, cmd
+	}
+	return a3, tea.Batch(cmd, syncCmd)
+}
+
+func (a App) updateInner(msg tea.Msg) (App, tea.Cmd) {
 	if m, ok := msg.(tea.WindowSizeMsg); ok {
 		a = a.applyWindowSize(m)
 		contentMsg := tea.WindowSizeMsg{Width: a.layout.ContentWidth(m.Width), Height: a.layout.ContentHeight(m.Height)}
@@ -514,6 +547,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if a2, cmd, ok := a.handleImageViewer(msg); ok {
 		return a2, cmd
 	}
+	if a2, cmd, ok := a.handleInlineImageFetched(msg); ok {
+		return a2, cmd
+	}
 	if a2, cmd, ok := a.handleErr(msg); ok {
 		return a2, cmd
 	}
@@ -542,7 +578,7 @@ func (a App) updateAll(msg tea.Msg) App {
 // Call this whenever loc, relaxed, or dimensions change outside of a
 // WindowSizeMsg (e.g. after login, timezone change, or density toggle).
 func (a *App) broadcastConfig() {
-	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
+	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
 	*a = a.updateAll(msg)
 }
 
@@ -1127,6 +1163,7 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		td := msg.MaxThreadDepth
 		tz := msg.Timezone
 		iv := msg.ImageViewer
+		ii := msg.InlineImages
 		ln := msg.LayoutName
 		return a, func() tea.Msg {
 			if msg.RemoteChanged {
@@ -1139,9 +1176,10 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 				cfg.MaxThreadDepth = td
 				cfg.Timezone = tz
 				cfg.ImageViewer = iv
+				cfg.InlineImages = ii
 				cfg.Layout = ln
 			})
-			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, layoutName: ln}
+			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, inlineImages: ii, layoutName: ln}
 		}, true
 
 	case settingsSavedMsg:
@@ -1150,11 +1188,12 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.maxThreadDepth = msg.maxThreadDepth
 		a.timezone = msg.timezone
 		a.imageViewer = msg.imageViewer
+		a.inlineImages = msg.inlineImages
 		a.layoutName = msg.layoutName
 		a.layout = layoutFromName(msg.layoutName)
 		a.focus = focusMenu
 		a.loc = config.ParseTimezoneLabel(msg.timezone)
-		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.layoutName)
+		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.inlineImages, msg.layoutName)
 		a.broadcastConfig()
 		a.refreshViewports()
 		if min := a.layout.NeedsCompactAutoFill(a.height); min > 0 {
@@ -2286,6 +2325,154 @@ func (a App) canRenderImageInline(u string) bool {
 		a.imageViewer != "browser"
 }
 
+// canInlineImages reports whether Feed/PostDetail should render post
+// attachments inline: the user's InlineImages preference is on, plus the
+// same protocol/imageViewer/ephemeral gates as the fullscreen image viewer
+// (see canRenderImageInline). There's no URL to check yet here — this gates
+// the feature as a whole, per-attachment checks happen when rendering.
+func (a App) canInlineImages() bool {
+	return a.inlineImages &&
+		!a.ephemeral &&
+		// ponytail: Sixel/iTerm2 only — Kitty's placement-ID lifecycle isn't
+		// wired into syncInlineImages yet (phase 6). Loosen to
+		// != ProtocolNone once that lands; until then, gating Kitty out here
+		// keeps a Kitty user from losing the "[IMG]" placeholder text to a
+		// reserved blank band that never gets drawn into.
+		(a.graphicsProtocol == imgview.ProtocolSixel || a.graphicsProtocol == imgview.ProtocolITerm2) &&
+		a.imageViewer != "browser"
+}
+
+// activeInlineImageSlots returns the active screen's currently visible
+// inline image slots, or nil for screens that don't support inline images
+// (Search/Guilds/Topics/Miller panes — see renderPostBody's doc comment).
+func (a App) activeInlineImageSlots() []screens.InlineImageSlot {
+	switch a.active {
+	case screenPostDetail:
+		return a.postDetail.VisibleInlineImages()
+	case screenFeed:
+		return a.feed.VisibleInlineImages()
+	default:
+		return nil
+	}
+}
+
+// inlineImageSignature summarizes a slot list's identity and position —
+// used to detect "did the visible set of inline images change at all this
+// frame" cheaply, without deep-comparing slices.
+func inlineImageSignature(slots []screens.InlineImageSlot) string {
+	var sb strings.Builder
+	for _, s := range slots {
+		fmt.Fprintf(&sb, "%s@%d;", s.Key, s.Row)
+	}
+	return sb.String()
+}
+
+// inlineImageCacheKey identifies one encoded rendering of a slot's image —
+// URL, column budget, and protocol, matching how a resize (which changes
+// MaxCols) or a protocol change naturally invalidates old entries.
+func inlineImageCacheKey(slot screens.InlineImageSlot, proto imgview.GraphicsProtocol) string {
+	return fmt.Sprintf("%s|%d|%d", slot.URL, slot.MaxCols, proto)
+}
+
+// syncInlineImages diffs the active screen's current VisibleInlineImages()
+// against inlineImageCache and returns a command that fetches+encodes
+// anything missing. It's called once per Update, after the active screen
+// has already processed the message. A change in the visible-slot signature
+// forces a full-screen clear on Sixel/iTerm2 — neither protocol has a
+// placement-delete primitive, so a moved or removed image can otherwise
+// leave stray pixels behind (the same reasoning already applied to the
+// fullscreen modal's close/cycle handling).
+func (a App) syncInlineImages() (App, tea.Cmd) {
+	if !a.canInlineImages() {
+		return a, nil
+	}
+	slots := a.activeInlineImageSlots()
+	var cmds []tea.Cmd
+	if sig := inlineImageSignature(slots); sig != a.inlineImageLastSig {
+		a.inlineImageLastSig = sig
+		cmds = append(cmds, tea.ClearScreen)
+	}
+	if a.inlineImageFetching == nil {
+		a.inlineImageFetching = make(map[string]bool)
+	}
+	for _, slot := range slots {
+		key := inlineImageCacheKey(slot, a.graphicsProtocol)
+		if _, cached := a.inlineImageCache[key]; cached {
+			continue
+		}
+		if a.inlineImageFetching[key] {
+			continue
+		}
+		a.inlineImageFetching[key] = true
+		cmds = append(cmds, a.fetchInlineImageCmd(slot, key))
+	}
+	if len(cmds) == 0 {
+		return a, nil
+	}
+	return a, tea.Batch(cmds...)
+}
+
+// inlineImageFetchedMsg reports the result of one fetchInlineImageCmd.
+type inlineImageFetchedMsg struct {
+	key     string
+	encoded string
+	err     error
+}
+
+// fetchInlineImageCmd fetches and encodes slot's image for the currently
+// detected protocol (Sixel or iTerm2 — see canInlineImages). Unlike the
+// fullscreen modal, there's no user-visible loading state to manage: a miss
+// this frame just means the reserved blank band stays blank until the
+// result lands.
+func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string) tea.Cmd {
+	proto := a.graphicsProtocol
+	maxCols, maxRows := slot.MaxCols, slot.MaxRows
+	url := slot.URL
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		img, err := imgview.Fetch(ctx, url)
+		if err != nil {
+			return inlineImageFetchedMsg{key: key, err: err}
+		}
+		var encoded string
+		switch proto {
+		case imgview.ProtocolITerm2:
+			encoded, _, _, err = imgview.EncodeITerm2(img, maxCols, maxRows)
+		case imgview.ProtocolSixel:
+			cellW, cellH, _ := imgview.TerminalCellPixelSize(int(os.Stdout.Fd()))
+			encoded, _, _, err = imgview.EncodeSixel(img, maxCols, maxRows, cellW, cellH)
+		default:
+			err = fmt.Errorf("inline images: unsupported protocol %v", proto)
+		}
+		if err != nil {
+			return inlineImageFetchedMsg{key: key, err: err}
+		}
+		return inlineImageFetchedMsg{key: key, encoded: encoded}
+	}
+}
+
+// handleInlineImageFetched processes an inlineImageFetchedMsg: on success,
+// caches the encoded result so the next frame's render picks it up; on
+// failure, just clears the in-flight marker so a future frame (e.g. after a
+// resize) can retry — there's no modal to fall back to here, the slot
+// simply stays blank.
+func (a App) handleInlineImageFetched(msg tea.Msg) (App, tea.Cmd, bool) {
+	m, ok := msg.(inlineImageFetchedMsg)
+	if !ok {
+		return a, nil, false
+	}
+	delete(a.inlineImageFetching, m.key)
+	if m.err != nil {
+		return a, nil, true
+	}
+	if a.inlineImageCache == nil {
+		a.inlineImageCache = make(map[string]string)
+	}
+	a.inlineImageCache[m.key] = m.encoded
+	return a, nil, true
+}
+
 // openExternalURL opens u in the OS default browser as a fire-and-forget command.
 func openExternalURL(u string) tea.Cmd {
 	return func() tea.Msg {
@@ -2604,6 +2791,7 @@ type feedPageMsg struct {
 	cursor string
 }
 type roomsLoadedMsg struct{ rooms []model.Room }
+
 // roomCommandReplyMsg/cmailCommandReplyMsg carry a reply-only slash command's
 // text (e.g. /help) back from the send response, for local display only —
 // nothing was posted, so nothing arrives via the RTDB subscription.
@@ -2640,6 +2828,7 @@ type settingsSavedMsg struct {
 	maxThreadDepth int
 	timezone       string
 	imageViewer    string
+	inlineImages   bool
 	layoutName     string
 }
 type wanderTickMsg struct{ gen int }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"container/list"
 	"context"
 	"errors"
 	"fmt"
@@ -181,19 +182,29 @@ type App struct {
 	// network fetch. Cleared whenever the modal closes.
 	imageCache map[string]cachedImage
 
-	// inlineImageCache holds encoded inline-image escape sequences for the
-	// life of the session, keyed by inlineImageCacheKey (slot key + URL +
-	// column budget + protocol) — never evicted; see the plan's accepted
-	// spike-scope cut. inlineImageFetching tracks keys with a fetch already
-	// in flight, so syncInlineImages (called every Update) doesn't refire
-	// the same request every frame while it's pending. inlineImageLastSig is
-	// the previous frame's visible-slot signature (see
+	// inlineImageCache holds encoded inline-image escape sequences, keyed by
+	// inlineImageCacheKey (slot key + URL + column budget + protocol),
+	// bounded by inlineImageCacheMaxBytes — see cacheInlineImage, which
+	// evicts the oldest-inserted entry first once exceeded.
+	// inlineImageCacheOrder/inlineImageCacheElems/inlineImageCacheBytes are
+	// cacheInlineImage's bookkeeping for that eviction; nothing else should
+	// touch them. inlineImageFetching tracks keys with a fetch already in
+	// flight, so syncInlineImages (called every Update) doesn't refire the
+	// same request every frame while it's pending. inlineImageFailedAt
+	// records when a key last failed to fetch, so a permanently-broken URL
+	// gets a cooldown (inlineImageFailureCooldown) instead of being retried
+	// on every single Update its slot stays visible for. inlineImageLastSig
+	// is the previous frame's visible-slot signature (see
 	// inlineImageSignature), used to detect a scroll/selection change that
 	// requires a full clear for Sixel/iTerm2 (neither has a placement-delete
 	// primitive — Kitty does, see kittyPlacementIDs, and never uses this).
-	inlineImageCache    map[string]string
-	inlineImageFetching map[string]bool
-	inlineImageLastSig  string
+	inlineImageCache      map[string]string
+	inlineImageCacheOrder *list.List
+	inlineImageCacheElems map[string]*list.Element
+	inlineImageCacheBytes int
+	inlineImageFetching   map[string]bool
+	inlineImageFailedAt   map[string]time.Time
+	inlineImageLastSig    string
 
 	// kittyPlacementIDs assigns a stable id (used as both image id and
 	// placement id, see imgview.EncodeKitty) to each inline image slot ever
@@ -208,8 +219,14 @@ type App struct {
 	// after its first scroll-off. Keeping the id (and thus the cache entry)
 	// stable for a key's whole session lifetime avoids that entirely.
 	// kittyNextPlacementID is the session-lived counter handing out new ids —
-	// never reused/freed within a session, which is fine for a spike (see the
-	// plan's no-cache-eviction cut; the same reasoning applies here).
+	// never reused/freed within a session. This stays safe even now that
+	// inlineImageCache is bounded (see its doc comment): evicting a cache
+	// entry doesn't touch its id, since inlineImageCacheKey doesn't embed
+	// one — a slot whose entry got evicted just re-fetches and re-encodes
+	// using its already-stable id, same as any other cache miss. If ids were
+	// ever evicted too, that would have to happen in the same step as
+	// evicting the matching cache entry, or a reissued id could collide with
+	// a still-cached payload embedding the old one.
 	//
 	// kittyVisibleKeys is the set of slot keys visible as of the last sync
 	// call. Because kittyPlacementIDs is never pruned, "not in
@@ -2554,6 +2571,9 @@ func (a App) syncInlineImages() (App, tea.Cmd) {
 		if a.inlineImageFetching[key] {
 			continue
 		}
+		if failedAt, failed := a.inlineImageFailedAt[key]; failed && time.Since(failedAt) < inlineImageFailureCooldown {
+			continue
+		}
 		a.inlineImageFetching[key] = true
 		placementID := 0
 		if isKitty {
@@ -2599,7 +2619,7 @@ func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string, place
 			cellW, cellH, _ := imgview.TerminalCellPixelSize(int(os.Stdout.Fd()))
 			encoded, _, _, err = imgview.EncodeSixel(img, maxCols, maxRows, cellW, cellH)
 		case imgview.ProtocolKitty:
-			encoded, _, _ = imgview.EncodeKitty(img, maxCols, maxRows, placementID)
+			encoded, _, _, err = imgview.EncodeKitty(img, maxCols, maxRows, placementID)
 		default:
 			err = fmt.Errorf("inline images: unsupported protocol %v", proto)
 		}
@@ -2610,11 +2630,21 @@ func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string, place
 	}
 }
 
+// inlineImageFailureCooldown bounds how often a permanently-broken image URL
+// gets refetched — without it, a dead link left visible while the user is
+// idle-scrolling elsewhere on the same screen fires a fresh HTTP request on
+// every single Update (keystroke, tick, anything) that includes its slot in
+// the visible set. Not tied to a resize/navigation-triggered retry: the slot
+// naturally gets another attempt on its own once the cooldown lapses.
+const inlineImageFailureCooldown = 60 * time.Second
+
 // handleInlineImageFetched processes an inlineImageFetchedMsg: on success,
-// caches the encoded result so the next frame's render picks it up; on
-// failure, just clears the in-flight marker so a future frame (e.g. after a
-// resize) can retry — there's no modal to fall back to here, the slot
-// simply stays blank.
+// caches the encoded result so the next frame's render picks it up, and
+// clears any earlier failure record for the key; on failure, records when it
+// failed (see inlineImageFailureCooldown) so syncInlineImages doesn't retry
+// it on every subsequent Update — there's no modal to fall back to here, the
+// slot simply stays blank until either the cooldown lapses or something
+// invalidates the key outright (e.g. a resize changing its column budget).
 func (a App) handleInlineImageFetched(msg tea.Msg) (App, tea.Cmd, bool) {
 	m, ok := msg.(inlineImageFetchedMsg)
 	if !ok {
@@ -2622,13 +2652,61 @@ func (a App) handleInlineImageFetched(msg tea.Msg) (App, tea.Cmd, bool) {
 	}
 	delete(a.inlineImageFetching, m.key)
 	if m.err != nil {
+		if a.inlineImageFailedAt == nil {
+			a.inlineImageFailedAt = make(map[string]time.Time)
+		}
+		a.inlineImageFailedAt[m.key] = time.Now()
 		return a, nil, true
 	}
+	delete(a.inlineImageFailedAt, m.key)
+	return a.cacheInlineImage(m.key, m.encoded), nil, true
+}
+
+// inlineImageCacheMaxBytes bounds inlineImageCache's total payload size —
+// see cacheInlineImage. A long scrolling session or a terminal resized many
+// times would otherwise grow the cache for the life of the process. Chosen
+// as a reasonable starting cap, not derived from measurement (ponytail:
+// revisit if real sessions show it's too tight or too loose in practice).
+const inlineImageCacheMaxBytes = 16 << 20 // 16 MiB
+
+// cacheInlineImage stores encoded under key in inlineImageCache, evicting
+// the oldest-inserted entries first once inlineImageCacheMaxBytes is
+// exceeded. Eviction only removes the cache entry, never the corresponding
+// kittyPlacementIDs id (see that field's doc comment) — cache keys don't
+// embed the id, so a slot whose entry gets evicted just re-fetches and
+// re-encodes using its already-stable id on the next sync, the same as any
+// other cache miss.
+func (a App) cacheInlineImage(key, encoded string) App {
+	return a.cacheInlineImageBounded(key, encoded, inlineImageCacheMaxBytes)
+}
+
+// cacheInlineImageBounded is cacheInlineImage with an injectable cap, so
+// tests can exercise eviction with a small maxBytes instead of megabytes of
+// fixture data.
+func (a App) cacheInlineImageBounded(key, encoded string, maxBytes int) App {
 	if a.inlineImageCache == nil {
 		a.inlineImageCache = make(map[string]string)
+		a.inlineImageCacheOrder = list.New()
+		a.inlineImageCacheElems = make(map[string]*list.Element)
 	}
-	a.inlineImageCache[m.key] = m.encoded
-	return a, nil, true
+	if old, exists := a.inlineImageCache[key]; exists {
+		a.inlineImageCacheBytes -= len(old)
+		a.inlineImageCacheOrder.MoveToBack(a.inlineImageCacheElems[key])
+	} else {
+		a.inlineImageCacheElems[key] = a.inlineImageCacheOrder.PushBack(key)
+	}
+	a.inlineImageCache[key] = encoded
+	a.inlineImageCacheBytes += len(encoded)
+
+	for a.inlineImageCacheBytes > maxBytes && a.inlineImageCacheOrder.Len() > 1 {
+		oldest := a.inlineImageCacheOrder.Front()
+		oldestKey := oldest.Value.(string)
+		a.inlineImageCacheBytes -= len(a.inlineImageCache[oldestKey])
+		delete(a.inlineImageCache, oldestKey)
+		delete(a.inlineImageCacheElems, oldestKey)
+		a.inlineImageCacheOrder.Remove(oldest)
+	}
+	return a
 }
 
 // openExternalURL opens u in the OS default browser as a fire-and-forget command.
@@ -2679,7 +2757,11 @@ func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 		for i, img := range frames {
 			switch proto {
 			case imgview.ProtocolKitty:
-				encodedFrames[i], cols, rows = imgview.EncodeKitty(img, displayCols, displayRows, kittyModalPlacementID)
+				var err error
+				encodedFrames[i], cols, rows, err = imgview.EncodeKitty(img, displayCols, displayRows, kittyModalPlacementID)
+				if err != nil {
+					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
+				}
 			case imgview.ProtocolITerm2:
 				var err error
 				encodedFrames[i], cols, rows, err = imgview.EncodeITerm2(img, displayCols, displayRows)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2512,10 +2512,10 @@ func accumulateKittyDeletes(pending map[int]struct{}, newlyDropped []int) map[in
 // (the same reasoning already applied to the fullscreen modal's close/cycle
 // handling).
 func (a App) syncInlineImages() (App, tea.Cmd) {
-	if !a.canInlineImages() {
-		return a, nil
+	var slots []screens.InlineImageSlot
+	if a.canInlineImages() {
+		slots = a.activeInlineImageSlots()
 	}
-	slots := a.activeInlineImageSlots()
 	var cmds []tea.Cmd
 
 	isKitty := a.graphicsProtocol == imgview.ProtocolKitty

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3016,6 +3016,81 @@ func TestSyncKittyPlacements_AssignsStableIDsAndDetectsDrops(t *testing.T) {
 // TestSyncInlineImages_DisablingClearsStaleKittyPlacements is a regression
 // test: syncInlineImages used to early-return the moment canInlineImages()
 // went false (e.g. the user toggled inline images off), skipping the
+// --- inline-image fetch-failure cooldown ---
+
+// feedAppWithOneImage builds an App on Feed/Tabs with one post whose image
+// is currently visible, for tests exercising syncInlineImages/
+// handleInlineImageFetched against a real slot rather than hand-built state.
+func feedAppWithOneImage(t *testing.T) (a App, key string) {
+	t.Helper()
+	a = loggedInApp()
+	a.width, a.height = 80, 40
+	a.inlineImages = true
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.feed, _ = a.feed.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	a.feed, _ = a.feed.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	a.feed = a.feed.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hi\n\n![a](https://example.com/a.png)\n\nbye"},
+	}, "")
+	slots := a.feed.VisibleInlineImages()
+	if len(slots) != 1 {
+		t.Fatalf("setup: expected 1 visible slot, got %d", len(slots))
+	}
+	return a, inlineImageCacheKey(slots[0], a.graphicsProtocol)
+}
+
+// TestInlineImageFailureCooldown_SkipsRefetchUntilCooldownLapses is a
+// regression test: before this fix, a failed fetch left no record at all, so
+// syncInlineImages (called on every Update) refired the same doomed request
+// every keystroke/tick the slot stayed visible.
+func TestInlineImageFailureCooldown_SkipsRefetchUntilCooldownLapses(t *testing.T) {
+	a, key := feedAppWithOneImage(t)
+
+	a, cmd := a.syncInlineImages()
+	if cmd == nil || !a.inlineImageFetching[key] {
+		t.Fatal("setup: expected the first sync to schedule a fetch")
+	}
+
+	a, _, _ = a.handleInlineImageFetched(inlineImageFetchedMsg{key: key, err: errors.New("boom")})
+	if _, failed := a.inlineImageFailedAt[key]; !failed {
+		t.Fatal("expected the failure to be recorded")
+	}
+	if a.inlineImageFetching[key] {
+		t.Error("expected the in-flight marker to be cleared after the failure")
+	}
+
+	a, _ = a.syncInlineImages()
+	if a.inlineImageFetching[key] {
+		t.Error("expected syncInlineImages to skip refetching within the cooldown window")
+	}
+
+	// Backdate the failure past the cooldown and confirm it retries.
+	a.inlineImageFailedAt[key] = time.Now().Add(-inlineImageFailureCooldown - time.Second)
+	a, _ = a.syncInlineImages()
+	if !a.inlineImageFetching[key] {
+		t.Error("expected syncInlineImages to retry once the cooldown has lapsed")
+	}
+}
+
+// TestInlineImageFailureCooldown_ClearedBySubsequentSuccess confirms a
+// success wipes any earlier failure record, so a transient blip doesn't
+// leave a stale cooldown blocking future retries after the URL recovers.
+func TestInlineImageFailureCooldown_ClearedBySubsequentSuccess(t *testing.T) {
+	a, key := feedAppWithOneImage(t)
+	a, _, _ = a.handleInlineImageFetched(inlineImageFetchedMsg{key: key, err: errors.New("boom")})
+	if _, failed := a.inlineImageFailedAt[key]; !failed {
+		t.Fatal("setup: expected the failure to be recorded")
+	}
+
+	a, _, _ = a.handleInlineImageFetched(inlineImageFetchedMsg{key: key, encoded: "\x1b_Gfake\x1b\\"})
+	if _, failed := a.inlineImageFailedAt[key]; failed {
+		t.Error("expected the failure record to be cleared after a subsequent success")
+	}
+	if got := a.inlineImageCache[key]; got != "\x1b_Gfake\x1b\\" {
+		t.Errorf("expected the successful encode to be cached, got %q", got)
+	}
+}
+
 // diff/delete logic entirely and leaving previously-drawn Kitty placements
 // on screen. It must still diff down to an empty slot list so every
 // previously-visible key gets queued for deletion.
@@ -3082,5 +3157,69 @@ func TestAccumulateKittyDeletes_MergesRatherThanOverwrites(t *testing.T) {
 	}
 	if _, ok := pending[2]; !ok {
 		t.Errorf("expected id 2 to be pending, got %v", pending)
+	}
+}
+
+// --- cacheInlineImage (bounded LRU) ---
+
+func TestCacheInlineImage_EvictsOldestFirstPastCap(t *testing.T) {
+	var a App
+	a = a.cacheInlineImageBounded("k1", "aaaaa", 12) // 5 bytes
+	a = a.cacheInlineImageBounded("k2", "bbbbb", 12) // 10 bytes total, still under cap
+	a = a.cacheInlineImageBounded("k3", "ccccc", 12) // 15 bytes would exceed 12 — evict k1
+
+	if _, ok := a.inlineImageCache["k1"]; ok {
+		t.Error("expected k1 (oldest) to be evicted once the cap was exceeded")
+	}
+	if _, ok := a.inlineImageCache["k2"]; !ok {
+		t.Error("expected k2 to survive")
+	}
+	if _, ok := a.inlineImageCache["k3"]; !ok {
+		t.Error("expected k3 (just inserted) to survive")
+	}
+	if a.inlineImageCacheBytes != 10 {
+		t.Errorf("expected inlineImageCacheBytes to track only the surviving entries (10), got %d", a.inlineImageCacheBytes)
+	}
+}
+
+// TestCacheInlineImage_ReinsertMovesToBackWithoutDoubleCounting confirms
+// re-caching an existing key (e.g. a resize that re-encodes the same slot)
+// updates its size correctly rather than accumulating stale bytes, and
+// treats it as freshly inserted for eviction ordering rather than leaving it
+// at its original (now stale) position.
+func TestCacheInlineImage_ReinsertMovesToBackWithoutDoubleCounting(t *testing.T) {
+	var a App
+	a = a.cacheInlineImageBounded("k1", "aaaaa", 12)   // 5 bytes
+	a = a.cacheInlineImageBounded("k2", "bb", 12)      // 7 bytes total
+	a = a.cacheInlineImageBounded("k1", "aaaaaaa", 12) // k1 grows to 7 bytes: 7+2=9, still under cap
+
+	if got := a.inlineImageCache["k1"]; got != "aaaaaaa" {
+		t.Errorf("expected k1's value to be updated, got %q", got)
+	}
+	if a.inlineImageCacheBytes != 9 {
+		t.Errorf("expected inlineImageCacheBytes=9 (7+2, not double-counting k1's old 5), got %d", a.inlineImageCacheBytes)
+	}
+
+	// Now push over the cap: k2 (never re-touched) should be evicted first,
+	// not k1 (re-inserted more recently, even though it existed earlier).
+	a = a.cacheInlineImageBounded("k3", "c", 12)    // 9+1=10, still under 12... push further
+	a = a.cacheInlineImageBounded("k4", "dddd", 12) // 10+4=14 > 12: evict oldest (k2)
+	if _, ok := a.inlineImageCache["k2"]; ok {
+		t.Error("expected k2 to be evicted first — it's the least-recently-(re)inserted key")
+	}
+	if _, ok := a.inlineImageCache["k1"]; !ok {
+		t.Error("expected k1 to survive — it was re-inserted after k2 and moved to the back of eviction order")
+	}
+}
+
+// TestCacheInlineImage_NeverEvictsTheJustInsertedEntry confirms a single
+// entry larger than the whole cap is still kept (better to go over budget by
+// one entry than to evict the image that was just fetched for the frame
+// asking for it).
+func TestCacheInlineImage_NeverEvictsTheJustInsertedEntry(t *testing.T) {
+	var a App
+	a = a.cacheInlineImageBounded("k1", "aaaaaaaaaaaaaaaaaaaa", 5) // 20 bytes >> cap of 5
+	if _, ok := a.inlineImageCache["k1"]; !ok {
+		t.Error("expected the sole, just-inserted entry to survive even though it alone exceeds the cap")
 	}
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3013,6 +3013,39 @@ func TestSyncKittyPlacements_AssignsStableIDsAndDetectsDrops(t *testing.T) {
 	}
 }
 
+// TestSyncInlineImages_DisablingClearsStaleKittyPlacements is a regression
+// test: syncInlineImages used to early-return the moment canInlineImages()
+// went false (e.g. the user toggled inline images off), skipping the
+// diff/delete logic entirely and leaving previously-drawn Kitty placements
+// on screen. It must still diff down to an empty slot list so every
+// previously-visible key gets queued for deletion.
+func TestSyncInlineImages_DisablingClearsStaleKittyPlacements(t *testing.T) {
+	a := App{
+		graphicsProtocol: imgview.ProtocolKitty,
+		inlineImages:     false, // disabled: canInlineImages() is false
+		kittyPlacementIDs: map[string]int{
+			"post:p1:0": 1,
+			"post:p2:0": 2,
+		},
+		kittyVisibleKeys: map[string]struct{}{
+			"post:p1:0": {},
+			"post:p2:0": {},
+		},
+	}
+
+	a, _ = a.syncInlineImages()
+
+	if len(a.kittyVisibleKeys) != 0 {
+		t.Errorf("expected kittyVisibleKeys to be cleared, got %v", a.kittyVisibleKeys)
+	}
+	if _, ok := a.pendingKittyDeletes[1]; !ok {
+		t.Errorf("expected placement id 1 to be queued for deletion, got %v", a.pendingKittyDeletes)
+	}
+	if _, ok := a.pendingKittyDeletes[2]; !ok {
+		t.Errorf("expected placement id 2 to be queued for deletion, got %v", a.pendingKittyDeletes)
+	}
+}
+
 // TestAccumulateKittyDeletes_SurvivesSkippedRenders is a regression test for
 // fast-scroll ghosting: a delete computed by one Update must not be lost if
 // Bubble Tea's throttled renderer processes several Updates (each recomputing

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2903,3 +2903,49 @@ func TestHandlePathPrompt_Import_Failure_NotifiesAndLeavesCustomPaletteUntouched
 		t.Error("expected the saved custom palette to be untouched by a failed import")
 	}
 }
+
+// TestInlineImageSignature_DistinguishesPositionAndIdentity confirms the
+// signature used to detect "did the visible inline-image set change this
+// frame" actually changes when a slot's Key or Row changes, and stays equal
+// for an identical slot list — the one thing syncInlineImages depends on to
+// decide whether Sixel/iTerm2 need a full-screen clear.
+func TestInlineImageSignature_DistinguishesPositionAndIdentity(t *testing.T) {
+	a := []screens.InlineImageSlot{{Key: "post:p1", Row: 3}, {Key: "reply:r1", Row: 20}}
+	b := []screens.InlineImageSlot{{Key: "post:p1", Row: 3}, {Key: "reply:r1", Row: 20}}
+	if inlineImageSignature(a) != inlineImageSignature(b) {
+		t.Error("expected identical slot lists to produce the same signature")
+	}
+
+	scrolled := []screens.InlineImageSlot{{Key: "post:p1", Row: 2}, {Key: "reply:r1", Row: 19}}
+	if inlineImageSignature(a) == inlineImageSignature(scrolled) {
+		t.Error("expected a scroll (Row change) to change the signature")
+	}
+
+	oneGone := []screens.InlineImageSlot{{Key: "post:p1", Row: 3}}
+	if inlineImageSignature(a) == inlineImageSignature(oneGone) {
+		t.Error("expected a removed slot to change the signature")
+	}
+}
+
+// TestInlineImageCacheKey_VariesByColsAndProtocol confirms the cache key
+// changes when the column budget (resize) or protocol changes, and stays
+// stable otherwise — a resize or protocol switch must invalidate stale
+// encodes rather than reuse a wrongly-sized/wrongly-encoded one.
+func TestInlineImageCacheKey_VariesByColsAndProtocol(t *testing.T) {
+	slot := screens.InlineImageSlot{URL: "https://example.com/a.png", MaxCols: 76}
+	key1 := inlineImageCacheKey(slot, imgview.ProtocolSixel)
+	key2 := inlineImageCacheKey(slot, imgview.ProtocolSixel)
+	if key1 != key2 {
+		t.Error("expected the same slot+protocol to produce the same key")
+	}
+
+	wider := slot
+	wider.MaxCols = 100
+	if inlineImageCacheKey(wider, imgview.ProtocolSixel) == key1 {
+		t.Error("expected a different MaxCols to produce a different key")
+	}
+
+	if inlineImageCacheKey(slot, imgview.ProtocolITerm2) == key1 {
+		t.Error("expected a different protocol to produce a different key")
+	}
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2949,3 +2949,105 @@ func TestInlineImageCacheKey_VariesByColsAndProtocol(t *testing.T) {
 		t.Error("expected a different protocol to produce a different key")
 	}
 }
+
+// TestSyncKittyPlacements_AssignsStableIDsAndDetectsDrops confirms the
+// placement-id lifecycle Kitty inline rendering depends on: a slot's id
+// stays the same across syncs as long as it's still visible, a slot that
+// drops out of the visible set is reported for deletion exactly once, and a
+// newly-visible slot gets a fresh distinct id.
+func TestSyncKittyPlacements_AssignsStableIDsAndDetectsDrops(t *testing.T) {
+	var a App
+	slots1 := []screens.InlineImageSlot{{Key: "post:p1:0"}, {Key: "post:p2:0"}}
+	// The very first sync reports every slot as "revived" too (nothing was
+	// visible before), which is harmless: the caller's revive step just
+	// deletes from an empty pendingKittyDeletes map, a no-op.
+	a, ids1, toDelete1, _ := a.syncKittyPlacements(slots1)
+	if len(toDelete1) != 0 {
+		t.Errorf("expected no deletes on first sync, got %v", toDelete1)
+	}
+	id1, id2 := ids1["post:p1:0"], ids1["post:p2:0"]
+	if id1 == 0 || id2 == 0 || id1 == id2 {
+		t.Fatalf("expected distinct non-zero ids, got %d and %d", id1, id2)
+	}
+
+	// Same slots again: ids must stay stable, no deletes/revives.
+	a, ids2, toDelete2, revived2 := a.syncKittyPlacements(slots1)
+	if ids2["post:p1:0"] != id1 || ids2["post:p2:0"] != id2 {
+		t.Errorf("expected ids to stay stable across syncs, got %v", ids2)
+	}
+	if len(toDelete2) != 0 || len(revived2) != 0 {
+		t.Errorf("expected no deletes/revives when the visible set didn't change, got toDelete=%v revived=%v", toDelete2, revived2)
+	}
+
+	// p1 scrolls out of view, p3 comes into view.
+	slots2 := []screens.InlineImageSlot{{Key: "post:p2:0"}, {Key: "post:p3:0"}}
+	a, ids3, toDelete3, revived3 := a.syncKittyPlacements(slots2)
+	if len(toDelete3) != 1 || toDelete3[0] != id1 {
+		t.Errorf("expected exactly p1's id (%d) to be reported for deletion, got %v", id1, toDelete3)
+	}
+	if len(revived3) != 1 || revived3[0] != ids3["post:p3:0"] {
+		t.Errorf("expected p3 (newly visible) reported as revived, got %v", revived3)
+	}
+	if ids3["post:p2:0"] != id2 {
+		t.Errorf("expected p2's id to remain stable, got %d want %d", ids3["post:p2:0"], id2)
+	}
+	id3 := ids3["post:p3:0"]
+	if id3 == 0 || id3 == id1 || id3 == id2 {
+		t.Errorf("expected p3 to get a fresh distinct id, got %d", id3)
+	}
+
+	// p1 scrolls back into view: it must reuse its ORIGINAL id (not a fresh
+	// one) — this is what keeps its id-less cache entry (see
+	// inlineImageCacheKey) valid, and is reported as revived so the caller
+	// cancels its still-pending delete.
+	slots3 := []screens.InlineImageSlot{{Key: "post:p1:0"}, {Key: "post:p2:0"}, {Key: "post:p3:0"}}
+	_, ids4, toDelete4, revived4 := a.syncKittyPlacements(slots3)
+	if ids4["post:p1:0"] != id1 {
+		t.Errorf("expected p1 to be revived with its original id %d, got %d", id1, ids4["post:p1:0"])
+	}
+	if len(toDelete4) != 0 {
+		t.Errorf("expected no new deletes when p1 returns, got %v", toDelete4)
+	}
+	if len(revived4) != 1 || revived4[0] != id1 {
+		t.Errorf("expected p1's id (%d) reported as revived, got %v", id1, revived4)
+	}
+}
+
+// TestAccumulateKittyDeletes_SurvivesSkippedRenders is a regression test for
+// fast-scroll ghosting: a delete computed by one Update must not be lost if
+// Bubble Tea's throttled renderer processes several Updates (each recomputing
+// syncKittyPlacements' fresh, single-frame diff) before actually writing a
+// frame. A prior version of this used a resend countdown, decremented once
+// per Update — but a fast enough scroll can still rack up enough Updates
+// between two real flushes to exhaust that budget on nothing but
+// never-flushed intermediate renders, losing the delete. Simulates many such
+// skipped-render Updates (empty newlyDropped batches) and confirms an
+// earlier delete survives indefinitely, never expiring on its own.
+func TestAccumulateKittyDeletes_SurvivesSkippedRenders(t *testing.T) {
+	pending := accumulateKittyDeletes(nil, []int{7})
+	if _, ok := pending[7]; !ok {
+		t.Fatal("expected id 7 to be pending immediately after being seeded")
+	}
+
+	for i := 0; i < 50; i++ {
+		pending = accumulateKittyDeletes(pending, nil)
+		if _, ok := pending[7]; !ok {
+			t.Fatalf("id 7 disappeared after %d extra call(s), expected it to never auto-expire", i+1)
+		}
+	}
+}
+
+// TestAccumulateKittyDeletes_MergesRatherThanOverwrites confirms a second
+// batch of newly-dropped ids doesn't wipe out a still-pending id from an
+// earlier batch — the exact failure mode a single-value (not accumulating)
+// pendingKittyDeletes had.
+func TestAccumulateKittyDeletes_MergesRatherThanOverwrites(t *testing.T) {
+	pending := accumulateKittyDeletes(nil, []int{1})
+	pending = accumulateKittyDeletes(pending, []int{2})
+	if _, ok := pending[1]; !ok {
+		t.Errorf("expected id 1 to still be pending after a second batch introduced id 2, got %v", pending)
+	}
+	if _, ok := pending[2]; !ok {
+		t.Errorf("expected id 2 to be pending, got %v", pending)
+	}
+}

--- a/internal/ui/imgview/encode_test.go
+++ b/internal/ui/imgview/encode_test.go
@@ -12,7 +12,7 @@ import (
 func TestEncodeKitty_ContainsAPC(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{R: 255, A: 255})
-	seq, cols, rows := imgview.EncodeKitty(img, 40, 20)
+	seq, cols, rows := imgview.EncodeKitty(img, 40, 20, 0)
 	if !strings.HasPrefix(seq, "\x1b_G") {
 		t.Errorf("EncodeKitty: missing APC prefix, got %q", seq[:min(len(seq), 20)])
 	}
@@ -30,7 +30,7 @@ func TestEncodeKitty_ContainsAPC(t *testing.T) {
 func TestEncodeKitty_CapsRows(t *testing.T) {
 	// Tall portrait image: without a row cap this would need 50 rows at 10 cols.
 	img := image.NewRGBA(image.Rect(0, 0, 100, 1000))
-	_, cols, rows := imgview.EncodeKitty(img, 40, 20)
+	_, cols, rows := imgview.EncodeKitty(img, 40, 20, 0)
 	if rows > 20 {
 		t.Errorf("EncodeKitty: rows=%d, want <= maxRows(20)", rows)
 	}
@@ -40,21 +40,73 @@ func TestEncodeKitty_CapsRows(t *testing.T) {
 }
 
 func TestEncodeKitty_PrependsDeleteAllPlacements(t *testing.T) {
-	// EncodeKitty always leads with a delete-all-placements command so
-	// opening a new image self-heals a leftover placement from a previous
-	// image whose own close-cleanup frame never reached the terminal (e.g.
-	// dropped behind a slow flush of a large prior image).
+	// placementID==0 (anonymous mode, used by the fullscreen modal) always
+	// leads with a delete-all-placements command so opening a new image
+	// self-heals a leftover placement from a previous image whose own
+	// close-cleanup frame never reached the terminal (e.g. dropped behind a
+	// slow flush of a large prior image).
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	seq, _, _ := imgview.EncodeKitty(img, 40, 20)
+	seq, _, _ := imgview.EncodeKitty(img, 40, 20, 0)
 	if !strings.HasPrefix(seq, "\x1b_Ga=d,d=A\x1b\\") {
 		t.Errorf("EncodeKitty: expected delete-all-placements prefix, got %q", seq[:min(len(seq), 30)])
 	}
 
 	// Back-to-back calls (as would happen opening several images in a row)
 	// must each still lead with the delete-all command.
-	seq2, _, _ := imgview.EncodeKitty(img, 40, 20)
+	seq2, _, _ := imgview.EncodeKitty(img, 40, 20, 0)
 	if !strings.HasPrefix(seq2, "\x1b_Ga=d,d=A\x1b\\") {
 		t.Errorf("EncodeKitty: expected delete-all-placements prefix on repeated call, got %q", seq2[:min(len(seq2), 30)])
+	}
+}
+
+// TestEncodeKitty_NamedPlacement_NeverBluntDeletes confirms that a non-zero
+// placementID (inline rendering, where several images are on screen at
+// once) never emits the blunt a=d,d=A delete-all — that would erase every
+// other inline image's placement, not just this one — and instead embeds
+// the id as both the image id and placement id so DeleteKittyPlacement can
+// target it precisely later.
+func TestEncodeKitty_NamedPlacement_NeverBluntDeletes(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	seq, _, _ := imgview.EncodeKitty(img, 40, 20, 7)
+	if strings.Contains(seq, "d=A") {
+		t.Errorf("EncodeKitty with a named placement must never blunt-delete-all, got %q", seq)
+	}
+	if !strings.Contains(seq, "i=7") || !strings.Contains(seq, "p=7") {
+		t.Errorf("expected i=7 and p=7 in the encoded sequence, got %q", seq)
+	}
+}
+
+// TestEncodeKitty_SuppressesTerminalResponse confirms every EncodeKitty mode
+// sets q=2, suppressing the terminal's OK/error acknowledgment. Without it,
+// the terminal writes that acknowledgment back over the same stream used for
+// keyboard input, which Bubble Tea's input reader can't distinguish from a
+// real keystroke — and the fullscreen modal treats any keypress while open
+// as "close", so an unsuppressed response closed the modal the instant it
+// opened.
+func TestEncodeKitty_SuppressesTerminalResponse(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+
+	seqAnon, _, _ := imgview.EncodeKitty(img, 40, 20, 0)
+	if !strings.Contains(seqAnon, "q=2") {
+		t.Errorf("anonymous-mode EncodeKitty must set q=2, got %q", seqAnon)
+	}
+
+	seqNamed, _, _ := imgview.EncodeKitty(img, 40, 20, 7)
+	if !strings.Contains(seqNamed, "q=2") {
+		t.Errorf("named-placement EncodeKitty must set q=2, got %q", seqNamed)
+	}
+}
+
+func TestDeleteKittyPlacement_TargetsExactIDPair(t *testing.T) {
+	seq := imgview.DeleteKittyPlacement(7)
+	if !strings.HasPrefix(seq, "\x1b_G") || !strings.HasSuffix(seq, "\x1b\\") {
+		t.Errorf("expected a well-formed APC sequence, got %q", seq)
+	}
+	if !strings.Contains(seq, "d=i") || !strings.Contains(seq, "i=7") || !strings.Contains(seq, "p=7") {
+		t.Errorf("expected a targeted delete (d=i,i=7,p=7), got %q", seq)
+	}
+	if strings.Contains(seq, "d=A") {
+		t.Errorf("expected a targeted delete, not delete-all, got %q", seq)
 	}
 }
 

--- a/internal/ui/imgview/encode_test.go
+++ b/internal/ui/imgview/encode_test.go
@@ -1,6 +1,8 @@
 package imgview_test
 
 import (
+	"bytes"
+	"encoding/base64"
 	"image"
 	"image/color"
 	"strings"
@@ -12,7 +14,10 @@ import (
 func TestEncodeKitty_ContainsAPC(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{R: 255, A: 255})
-	seq, cols, rows := imgview.EncodeKitty(img, 40, 20, 0)
+	seq, cols, rows, err := imgview.EncodeKitty(img, 40, 20, 0)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
 	if !strings.HasPrefix(seq, "\x1b_G") {
 		t.Errorf("EncodeKitty: missing APC prefix, got %q", seq[:min(len(seq), 20)])
 	}
@@ -30,7 +35,10 @@ func TestEncodeKitty_ContainsAPC(t *testing.T) {
 func TestEncodeKitty_CapsRows(t *testing.T) {
 	// Tall portrait image: without a row cap this would need 50 rows at 10 cols.
 	img := image.NewRGBA(image.Rect(0, 0, 100, 1000))
-	_, cols, rows := imgview.EncodeKitty(img, 40, 20, 0)
+	_, cols, rows, err := imgview.EncodeKitty(img, 40, 20, 0)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
 	if rows > 20 {
 		t.Errorf("EncodeKitty: rows=%d, want <= maxRows(20)", rows)
 	}
@@ -46,14 +54,20 @@ func TestEncodeKitty_PrependsDeleteAllPlacements(t *testing.T) {
 	// close-cleanup frame never reached the terminal (e.g. dropped behind a
 	// slow flush of a large prior image).
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	seq, _, _ := imgview.EncodeKitty(img, 40, 20, 0)
+	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
 	if !strings.HasPrefix(seq, "\x1b_Ga=d,d=A\x1b\\") {
 		t.Errorf("EncodeKitty: expected delete-all-placements prefix, got %q", seq[:min(len(seq), 30)])
 	}
 
 	// Back-to-back calls (as would happen opening several images in a row)
 	// must each still lead with the delete-all command.
-	seq2, _, _ := imgview.EncodeKitty(img, 40, 20, 0)
+	seq2, _, _, err := imgview.EncodeKitty(img, 40, 20, 0)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
 	if !strings.HasPrefix(seq2, "\x1b_Ga=d,d=A\x1b\\") {
 		t.Errorf("EncodeKitty: expected delete-all-placements prefix on repeated call, got %q", seq2[:min(len(seq2), 30)])
 	}
@@ -67,7 +81,10 @@ func TestEncodeKitty_PrependsDeleteAllPlacements(t *testing.T) {
 // target it precisely later.
 func TestEncodeKitty_NamedPlacement_NeverBluntDeletes(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	seq, _, _ := imgview.EncodeKitty(img, 40, 20, 7)
+	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 7)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
 	if strings.Contains(seq, "d=A") {
 		t.Errorf("EncodeKitty with a named placement must never blunt-delete-all, got %q", seq)
 	}
@@ -86,14 +103,52 @@ func TestEncodeKitty_NamedPlacement_NeverBluntDeletes(t *testing.T) {
 func TestEncodeKitty_SuppressesTerminalResponse(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 
-	seqAnon, _, _ := imgview.EncodeKitty(img, 40, 20, 0)
+	seqAnon, _, _, err := imgview.EncodeKitty(img, 40, 20, 0)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
 	if !strings.Contains(seqAnon, "q=2") {
 		t.Errorf("anonymous-mode EncodeKitty must set q=2, got %q", seqAnon)
 	}
 
-	seqNamed, _, _ := imgview.EncodeKitty(img, 40, 20, 7)
+	seqNamed, _, _, err := imgview.EncodeKitty(img, 40, 20, 7)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
 	if !strings.Contains(seqNamed, "q=2") {
 		t.Errorf("named-placement EncodeKitty must set q=2, got %q", seqNamed)
+	}
+}
+
+// TestEncodeKitty_UsesPNGFormat is a regression test for switching from raw
+// f=32 RGBA (uncompressed, the largest payload shape available) to f=100
+// PNG: confirms the format flag says PNG, no s=/v= pixel-dimension keys are
+// sent (not needed for PNG — the terminal reads them from the PNG header
+// itself), and the base64 payload actually decodes to valid PNG data rather
+// than raw pixels.
+func TestEncodeKitty_UsesPNGFormat(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	img.Set(1, 1, color.RGBA{B: 255, A: 255})
+	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
+	if !strings.Contains(seq, "f=100") {
+		t.Errorf("expected f=100 (PNG), got %q", seq)
+	}
+	if strings.Contains(seq, "s=") || strings.Contains(seq, "v=") {
+		t.Errorf("expected no s=/v= pixel-dimension keys for PNG payloads, got %q", seq)
+	}
+	// Extract the base64 payload (after the last ';', before the trailing ST)
+	// and confirm it decodes to a PNG (magic bytes 0x89 'P' 'N' 'G').
+	semi := strings.LastIndex(seq, ";")
+	payload := strings.TrimSuffix(seq[semi+1:], "\x1b\\")
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		t.Fatalf("payload did not decode as base64: %v", err)
+	}
+	if len(raw) < 8 || !bytes.HasPrefix(raw, []byte("\x89PNG\r\n\x1a\n")) {
+		t.Errorf("expected the payload to be a PNG (magic bytes), got %d bytes starting %x", len(raw), raw[:min(len(raw), 8)])
 	}
 }
 

--- a/internal/ui/imgview/kitty.go
+++ b/internal/ui/imgview/kitty.go
@@ -1,9 +1,11 @@
 package imgview
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"image"
+	"image/png"
 )
 
 // EncodeKitty encodes img for display via the Kitty terminal graphics
@@ -25,39 +27,32 @@ import (
 //     a=T again with the same id/placement (e.g. after scrolling) replaces
 //     the existing placement in place per the protocol spec — this is how
 //     an inline image "moves" without a separate reposition command.
-func EncodeKitty(img image.Image, maxCols, maxRows, placementID int) (encoded string, cols, rows int) {
+func EncodeKitty(img image.Image, maxCols, maxRows, placementID int) (encoded string, cols, rows int, err error) {
 	bounds := img.Bounds()
 	w := bounds.Max.X - bounds.Min.X
 	h := bounds.Max.Y - bounds.Min.Y
 
-	// Build raw RGBA pixel data.
-	raw := make([]byte, w*h*4)
-	i := 0
-	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			r, g, b, a := img.At(x, y).RGBA()
-			raw[i] = byte(r >> 8)
-			raw[i+1] = byte(g >> 8)
-			raw[i+2] = byte(b >> 8)
-			raw[i+3] = byte(a >> 8)
-			i += 4
-		}
+	var buf bytes.Buffer
+	if encErr := png.Encode(&buf, img); encErr != nil {
+		return "", 0, 0, fmt.Errorf("imgview: png encode: %w", encErr)
 	}
-
-	payload := base64.StdEncoding.EncodeToString(raw)
+	payload := base64.StdEncoding.EncodeToString(buf.Bytes())
 	cols, rows = fitBox(w, h, maxCols, maxRows, pxPerCol, 2*pxPerCol)
-	// a=T: transmit and display. f=32: 32-bit RGBA. s/v: pixel dimensions.
-	// c/r: display size in terminal columns/rows (Kitty scales to fit, preserving aspect ratio).
-	// m=0: final chunk. q=2: suppress the terminal's OK/error response — by
-	// default (q unset) the terminal writes one back over the same stream
-	// used for keyboard input, and Bubble Tea's input reader has no way to
-	// tell it apart from a real keystroke. The fullscreen modal treats any
-	// keypress while open as "close" (see app.go), so that phantom response
-	// was closing the modal the instant it opened — every single time.
+	// a=T: transmit and display. f=100: PNG-encoded payload — no s=/v= needed,
+	// the terminal reads pixel dimensions from the PNG data itself (unlike the
+	// raw-RGBA f=32 this used to send, which required them explicitly). c/r:
+	// display size in terminal columns/rows (Kitty scales to fit, preserving
+	// aspect ratio). m=0: final chunk. q=2: suppress the terminal's OK/error
+	// response — by default (q unset) the terminal writes one back over the
+	// same stream used for keyboard input, and Bubble Tea's input reader has
+	// no way to tell it apart from a real keystroke. The fullscreen modal
+	// treats any keypress while open as "close" (see app.go), so that
+	// phantom response was closing the modal the instant it opened — every
+	// single time.
 	if placementID == 0 {
-		encoded = fmt.Sprintf("\x1b_Ga=d,d=A\x1b\\\x1b_Ga=T,f=32,s=%d,v=%d,c=%d,r=%d,m=0,q=2;%s\x1b\\", w, h, cols, rows, payload)
+		encoded = fmt.Sprintf("\x1b_Ga=d,d=A\x1b\\\x1b_Ga=T,f=100,c=%d,r=%d,m=0,q=2;%s\x1b\\", cols, rows, payload)
 	} else {
-		encoded = fmt.Sprintf("\x1b_Ga=T,f=32,s=%d,v=%d,c=%d,r=%d,m=0,q=2,i=%d,p=%d;%s\x1b\\", w, h, cols, rows, placementID, placementID, payload)
+		encoded = fmt.Sprintf("\x1b_Ga=T,f=100,c=%d,r=%d,m=0,q=2,i=%d,p=%d;%s\x1b\\", cols, rows, placementID, placementID, payload)
 	}
 	return
 }

--- a/internal/ui/imgview/kitty.go
+++ b/internal/ui/imgview/kitty.go
@@ -6,11 +6,26 @@ import (
 	"image"
 )
 
-// EncodeKitty encodes img for display via the Kitty terminal graphics protocol.
-// maxCols/maxRows bound the terminal display size; the image is never
-// upscaled beyond its natural pixel size. Returns the APC escape sequence and
-// the computed display size in terminal columns and rows.
-func EncodeKitty(img image.Image, maxCols, maxRows int) (encoded string, cols, rows int) {
+// EncodeKitty encodes img for display via the Kitty terminal graphics
+// protocol. maxCols/maxRows bound the terminal display size; the image is
+// never upscaled beyond its natural pixel size. Returns the APC escape
+// sequence and the computed display size in terminal columns and rows.
+//
+// placementID selects one of two modes:
+//   - 0: anonymous placement (used by the fullscreen modal, where only one
+//     image is ever shown at a time). Prefixed with a blunt a=d,d=A
+//     (delete-all) self-heal — a no-op if nothing is displayed, but clears a
+//     leftover placement from a previous image whose own close-cleanup
+//     frame never reached the terminal.
+//   - non-zero: a named placement (used for inline rendering, where several
+//     images are on screen at once). Uses that value as both the image id
+//     and placement id — deliberately never blunt-deletes, since that would
+//     erase every other inline image's placement too; see
+//     DeleteKittyPlacement for this mode's targeted counterpart. Sending
+//     a=T again with the same id/placement (e.g. after scrolling) replaces
+//     the existing placement in place per the protocol spec — this is how
+//     an inline image "moves" without a separate reposition command.
+func EncodeKitty(img image.Image, maxCols, maxRows, placementID int) (encoded string, cols, rows int) {
 	bounds := img.Bounds()
 	w := bounds.Max.X - bounds.Min.X
 	h := bounds.Max.Y - bounds.Min.Y
@@ -33,12 +48,26 @@ func EncodeKitty(img image.Image, maxCols, maxRows int) (encoded string, cols, r
 	cols, rows = fitBox(w, h, maxCols, maxRows, pxPerCol, 2*pxPerCol)
 	// a=T: transmit and display. f=32: 32-bit RGBA. s/v: pixel dimensions.
 	// c/r: display size in terminal columns/rows (Kitty scales to fit, preserving aspect ratio).
-	// m=0: final chunk.
-	//
-	// Prefixed with a=d,d=A (delete all placements): a no-op if nothing is
-	// currently displayed, but self-heals a leftover placement from a
-	// previous image whose own close-cleanup frame never reached the
-	// terminal (e.g. dropped behind a slow flush of a large prior image).
-	encoded = fmt.Sprintf("\x1b_Ga=d,d=A\x1b\\\x1b_Ga=T,f=32,s=%d,v=%d,c=%d,r=%d,m=0;%s\x1b\\", w, h, cols, rows, payload)
+	// m=0: final chunk. q=2: suppress the terminal's OK/error response — by
+	// default (q unset) the terminal writes one back over the same stream
+	// used for keyboard input, and Bubble Tea's input reader has no way to
+	// tell it apart from a real keystroke. The fullscreen modal treats any
+	// keypress while open as "close" (see app.go), so that phantom response
+	// was closing the modal the instant it opened — every single time.
+	if placementID == 0 {
+		encoded = fmt.Sprintf("\x1b_Ga=d,d=A\x1b\\\x1b_Ga=T,f=32,s=%d,v=%d,c=%d,r=%d,m=0,q=2;%s\x1b\\", w, h, cols, rows, payload)
+	} else {
+		encoded = fmt.Sprintf("\x1b_Ga=T,f=32,s=%d,v=%d,c=%d,r=%d,m=0,q=2,i=%d,p=%d;%s\x1b\\", w, h, cols, rows, placementID, placementID, payload)
+	}
 	return
+}
+
+// DeleteKittyPlacement returns the escape sequence to delete exactly one
+// named placement (image id + placement id, both set to id by EncodeKitty's
+// non-zero-placementID mode) without disturbing any other placement — the
+// targeted counterpart to EncodeKitty's anonymous-mode blunt a=d,d=A
+// self-heal, which cannot be used here since inline rendering has several
+// placements on screen simultaneously.
+func DeleteKittyPlacement(id int) string {
+	return fmt.Sprintf("\x1b_Ga=d,d=i,i=%d,p=%d\x1b\\", id, id)
 }

--- a/internal/ui/imgview/protocol.go
+++ b/internal/ui/imgview/protocol.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/muesli/cancelreader"
 	"golang.org/x/term"
 )
 
@@ -73,6 +74,12 @@ func ProbeSixel(stdin, stdout *os.File) bool {
 		return false
 	}
 
+	cr, err := cancelreader.NewReader(stdin)
+	if err != nil {
+		return false
+	}
+	defer cr.Close()
+
 	type readResult struct {
 		buf []byte
 		err error
@@ -80,7 +87,7 @@ func ProbeSixel(stdin, stdout *os.File) bool {
 	done := make(chan readResult, 1)
 	go func() {
 		buf := make([]byte, 64)
-		n, err := stdin.Read(buf)
+		n, err := cr.Read(buf)
 		done <- readResult{buf[:n], err}
 	}()
 
@@ -91,6 +98,7 @@ func ProbeSixel(stdin, stdout *os.File) bool {
 		}
 		return ParseDA1SixelSupport(res.buf)
 	case <-time.After(da1ProbeTimeout):
+		cr.Cancel()
 		return false
 	}
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -1,12 +1,15 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+	"github.com/ragnar/cyber-tui/internal/ui/screens"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 	"github.com/ragnar/cyber-tui/internal/version"
 )
@@ -27,6 +30,140 @@ type Layout interface {
 	// column at the given terminal height. Returns 0 if the layout has no compact list column.
 	// App uses this to auto-fetch additional pages after the initial load.
 	NeedsCompactAutoFill(termHeight int) int
+	// InlineImageSlots returns the active screen's visible inline-image slots
+	// and this layout's screen origin for them — see modalRenderer's method
+	// of the same name (Layout and modalRenderer both need it: App.syncInlineImages
+	// calls it via the Layout interface to know what to fetch, independent of
+	// rendering, while compositeOverlays calls it via modalRenderer to know
+	// where to composite the result).
+	InlineImageSlots(a App) (slots []screens.InlineImageSlot, rowOrigin, colOrigin int)
+}
+
+// modalRenderer is implemented by both TabsLayout and MillerLayout so
+// compositeOverlays can render each layout's own modal content while the
+// compositing order — and, critically, the inline-image injection step —
+// lives in exactly one place. Everything here genuinely varies per layout
+// (chrome, colors, sizing); the order overlays get checked and composited
+// in does not, and used to be duplicated by hand between layout_tabs.go and
+// layout_miller.go, which is how MillerLayout ended up never calling
+// injectInlineImages at all.
+type modalRenderer interface {
+	renderThemePicker(a App) string
+	renderThemeEditor(a App) string
+	renderPathPrompt(a App) string
+	renderHelpModal(a App) string
+	renderURLPicker(a App) string
+	renderImageModal(a App) string
+	// InlineImageSlots returns the active screen's visible inline-image
+	// slots plus this layout's screen origin (rowOrigin, colOrigin) for
+	// them — the origin varies per layout (and, within Miller, per screen)
+	// since it depends on chrome that differs between layouts.
+	InlineImageSlots(a App) (slots []screens.InlineImageSlot, rowOrigin, colOrigin int)
+}
+
+// compositeOverlays applies every overlay — the five simple modals, the
+// fullscreen image modal, the Kitty placement-cleanup delete, and inline
+// image injection — on top of base, in that fixed order. Called once as the
+// last line of each Layout's View(), so no implementation can skip a step
+// or return early partway through.
+func compositeOverlays(l modalRenderer, a App, base string) string {
+	switch {
+	case a.themePickerOpen:
+		return overlayCenter(base, l.renderThemePicker(a), a.width, a.height)
+	case a.themeEditorOpen:
+		return overlayCenter(base, l.renderThemeEditor(a), a.width, a.height)
+	case a.pathPromptOpen:
+		return overlayCenter(base, l.renderPathPrompt(a), a.width, a.height)
+	case a.helpModalOpen:
+		return overlayCenter(base, l.renderHelpModal(a), a.width, a.height)
+	case a.urlPickerOpen:
+		return overlayCenter(base, l.renderURLPicker(a), a.width, a.height)
+	}
+	if a.imageModalOpen {
+		textModal := l.renderImageModal(a)
+		composed := overlayCenter(base, textModal, a.width, a.height)
+		// Compute the same offsets overlayCenter used so we can position
+		// the image sequence inside the border without embedding it in the
+		// overlay string (which would corrupt overlayCenter's ANSI splicing).
+		modalW := lipgloss.Width(textModal)
+		modalH := len(strings.Split(textModal, "\n"))
+		xOff := (a.width - modalW) / 2
+		yOff := (a.height - modalH) / 2
+		if xOff < 0 {
+			xOff = 0
+		}
+		if yOff < 0 {
+			yOff = 0
+		}
+		// theme.ActiveBorder: 1-char border + 1-char horizontal padding on each
+		// side. Image content therefore starts 2 cols right of the border edge.
+		// ANSI cursor sequences are 1-indexed; the border top row is yOff+1.
+		imgRow := yOff + 2
+		imgCol := xOff + 3
+		return composed + fmt.Sprintf("\x1b[%d;%dH%s\x1b[%d;1H", imgRow, imgCol, a.imageModalEncoded, a.height)
+	}
+	if a.imageNeedsCleanup && a.graphicsProtocol == imgview.ProtocolKitty {
+		// Inject the targeted delete for the modal's own reserved placement
+		// (kittyModalPlacementID) onto the line that held the modal's top
+		// border so Bubble Tea's diff renderer delivers it to the terminal.
+		// Never a blunt delete-all: that would also erase any inline
+		// images' placements, which can be on screen at the same time.
+		//
+		// This must fall through to the inline-image injection below rather
+		// than returning early: imageNeedsCleanup stays true indefinitely
+		// (see its doc comment — it's never auto-cleared, only cleared by the
+		// next modal image opening), so an early return here would silently
+		// stop all inline-image rendering for the rest of the session after
+		// the very first Kitty modal close.
+		modalH := a.imageModalRows + 2
+		yOff := (a.height - modalH) / 2
+		if yOff < 0 {
+			yOff = 0
+		}
+		lines := strings.Split(base, "\n")
+		if yOff < len(lines) {
+			lines[yOff] = imgview.DeleteKittyPlacement(kittyModalPlacementID) + lines[yOff]
+		}
+		base = strings.Join(lines, "\n")
+	}
+	slots, rowOrigin, colOrigin := l.InlineImageSlots(a)
+	if len(slots) > 0 || len(a.pendingKittyDeletes) > 0 {
+		return injectInlineImages(a, base, slots, rowOrigin, colOrigin)
+	}
+	return base
+}
+
+// injectInlineImages appends absolute-cursor-positioned escape sequences for
+// each slot with a cache hit, same technique as the modal's imgRow/imgCol
+// (base + "\x1b[row;colH" + encoded, cursor parked at the bottom line after).
+// A slot with no cache hit yet is skipped — its reserved band just stays the
+// blank text the screen already rendered into base. rowOrigin/colOrigin are
+// the calling layout's screen origin for slot-relative coordinates (see
+// modalRenderer.InlineImageSlots) — they differ per layout, and within
+// Miller, per which screen/pane is active.
+//
+// Kitty's pendingKittyDeletes don't need cursor positioning — placements are
+// addressed by id, not screen coordinates — so they're just appended
+// anywhere in the frame. This is why the caller invokes this function even
+// when slots is empty: a delete can be pending with nothing currently
+// visible (e.g. every inline image just scrolled off-screen).
+func injectInlineImages(a App, base string, slots []screens.InlineImageSlot, rowOrigin, colOrigin int) string {
+	var sb strings.Builder
+	sb.WriteString(base)
+	for _, slot := range slots {
+		encoded, ok := a.inlineImageCache[inlineImageCacheKey(slot, a.graphicsProtocol)]
+		if !ok {
+			continue
+		}
+		row := rowOrigin + slot.Row
+		col := colOrigin + slot.ColIndent
+		sb.WriteString(fmt.Sprintf("\x1b[%d;%dH%s", row, col, encoded))
+	}
+	for id := range a.pendingKittyDeletes {
+		sb.WriteString(imgview.DeleteKittyPlacement(id))
+	}
+	sb.WriteString(fmt.Sprintf("\x1b[%d;1H", a.height))
+	return sb.String()
 }
 
 // CompactListRenderer is optionally implemented by screens that can display as a compact

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -12,9 +12,9 @@ import (
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
-const millerSidebarWidth = 22  // nav pane (21 chars) + "│" separator (1 char)
-const millerListMaxWidth = 70  // hard cap on the list pane; above this, excess goes to the detail pane
-const millerHeaderHeight = 1   // column title row at the top of the layout
+const millerSidebarWidth = 22 // nav pane (21 chars) + "│" separator (1 char)
+const millerListMaxWidth = 70 // hard cap on the list pane; above this, excess goes to the detail pane
+const millerHeaderHeight = 1  // column title row at the top of the layout
 
 // MillerLayout renders a left navigation sidebar alongside the active screen.
 type MillerLayout struct{}
@@ -154,6 +154,8 @@ func (l MillerLayout) View(a App) string {
 		return composed + fmt.Sprintf("\x1b[%d;%dH%s\x1b[%d;1H", imgRow, imgCol, a.imageModalEncoded, a.height)
 	}
 	if a.imageNeedsCleanup && a.graphicsProtocol == imgview.ProtocolKitty {
+		// Targeted delete for the modal's own reserved placement, not a
+		// blunt delete-all — see the matching comment in layout_tabs.go.
 		modalH := a.imageModalRows + 2
 		yOff := (a.height - modalH) / 2
 		if yOff < 0 {
@@ -161,7 +163,7 @@ func (l MillerLayout) View(a App) string {
 		}
 		lines := strings.Split(base, "\n")
 		if yOff < len(lines) {
-			lines[yOff] = "\x1b_Ga=d,d=A\x1b\\" + lines[yOff]
+			lines[yOff] = imgview.DeleteKittyPlacement(kittyModalPlacementID) + lines[yOff]
 		}
 		return strings.Join(lines, "\n")
 	}

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -7,7 +7,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/ragnar/cyber-tui/internal/ui/imgview"
 	"github.com/ragnar/cyber-tui/internal/ui/screens"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
@@ -59,10 +58,6 @@ func (l MillerLayout) activeCompactRenderer(a App) CompactListRenderer {
 }
 
 func (l MillerLayout) View(a App) string {
-	if a.active == screenLogin {
-		return a.login.View()
-	}
-
 	contentH := a.height - 1 - millerHeaderHeight // full height minus bottom bar and column header
 	contentW := a.width - millerSidebarWidth
 
@@ -121,53 +116,39 @@ func (l MillerLayout) View(a App) string {
 		base = lipgloss.JoinVertical(lipgloss.Left, hdrRow, mainRow, l.renderBottomBar(a))
 	}
 
-	if a.themePickerOpen {
-		return overlayCenter(base, l.renderThemePicker(a), a.width, a.height)
-	}
-	if a.themeEditorOpen {
-		return overlayCenter(base, l.renderThemeEditor(a), a.width, a.height)
-	}
-	if a.pathPromptOpen {
-		return overlayCenter(base, l.renderPathPrompt(a), a.width, a.height)
-	}
-	if a.helpModalOpen {
-		return overlayCenter(base, l.renderHelpModal(a), a.width, a.height)
-	}
-	if a.urlPickerOpen {
-		return overlayCenter(base, l.renderURLPicker(a), a.width, a.height)
-	}
-	if a.imageModalOpen {
-		textModal := l.renderImageModal(a)
-		composed := overlayCenter(base, textModal, a.width, a.height)
-		modalW := lipgloss.Width(textModal)
-		modalH := len(strings.Split(textModal, "\n"))
-		xOff := (a.width - modalW) / 2
-		yOff := (a.height - modalH) / 2
-		if xOff < 0 {
-			xOff = 0
+	return compositeOverlays(l, a, base)
+}
+
+// InlineImageSlots returns the visible inline-image slots for whichever
+// screen is active, plus this layout's screen origin for them — which
+// depends on whether the active screen is shown via the compact-list/detail
+// split (Feed) or the plain content pane (PostDetail), since the detail
+// pane's left edge sits further right when a list pane precedes it. This
+// replicates the exact width/height View() computes for the same screen, so
+// a slot's position always matches what's actually on screen this frame —
+// Feed's detail pane in particular has no other source of truth for its
+// current width, since it's derived fresh from paneWidths on every View()
+// call rather than stored anywhere Update() can see.
+func (l MillerLayout) InlineImageSlots(a App) ([]screens.InlineImageSlot, int, int) {
+	const rowOrigin = 2 // 1: header row, so content's own row 0 is ANSI row 2
+	contentH := a.height - 1 - millerHeaderHeight
+	contentW := a.width - millerSidebarWidth
+
+	if r := l.activeCompactRenderer(a); r != nil {
+		if a.active != screenFeed {
+			return nil, 0, 0
 		}
-		if yOff < 0 {
-			yOff = 0
+		listW, detailW := l.paneWidths(contentW)
+		if cc, ok := r.(CompactComposer); ok && cc.ComposeActive() {
+			contentH = max(0, contentH-cc.ComposeHeight())
 		}
-		imgRow := yOff + 2
-		imgCol := xOff + 3
-		return composed + fmt.Sprintf("\x1b[%d;%dH%s\x1b[%d;1H", imgRow, imgCol, a.imageModalEncoded, a.height)
+		colOrigin := millerSidebarWidth + 1 + listW + 1
+		return a.feed.VisibleDetailInlineImages(detailW, contentH), rowOrigin, colOrigin
 	}
-	if a.imageNeedsCleanup && a.graphicsProtocol == imgview.ProtocolKitty {
-		// Targeted delete for the modal's own reserved placement, not a
-		// blunt delete-all — see the matching comment in layout_tabs.go.
-		modalH := a.imageModalRows + 2
-		yOff := (a.height - modalH) / 2
-		if yOff < 0 {
-			yOff = 0
-		}
-		lines := strings.Split(base, "\n")
-		if yOff < len(lines) {
-			lines[yOff] = imgview.DeleteKittyPlacement(kittyModalPlacementID) + lines[yOff]
-		}
-		return strings.Join(lines, "\n")
+	if a.active == screenPostDetail {
+		return a.postDetail.VisibleInlineImages(), rowOrigin, millerSidebarWidth + 1
 	}
-	return base
+	return nil, 0, 0
 }
 
 func (l MillerLayout) HandleNav(msg tea.KeyMsg, a App) (App, tea.Cmd, bool) {

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -240,9 +240,15 @@ func (l MillerLayout) DelegateUpdate(msg tea.Msg, a App) (App, tea.Cmd) {
 func (l MillerLayout) HasFocusedInput(a App) bool {
 	switch a.active {
 	case screenChatrooms:
-		return a.chatrooms.InputFocused()
+		// InputFocused is true for the entire time a room is open, not just
+		// while its compose box has the cursor — so it must also check that
+		// Miller's own focus hasn't already moved away to the spaces column
+		// (via HandleNav's left/h), or nav keys pressed there would still be
+		// swallowed into the backgrounded room instead of reaching
+		// navigateTabBy. Same reasoning for screenCMail below.
+		return a.focus != focusMenu && a.chatrooms.InputFocused()
 	case screenCMail:
-		return a.cmail.InputFocused()
+		return a.focus != focusMenu && a.cmail.InputFocused()
 	case screenPostDetail:
 		return a.postDetail.ComposeActive()
 	case screenFeed:

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+	"github.com/ragnar/cyber-tui/internal/ui/screens"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
 
@@ -98,7 +99,33 @@ func (l TabsLayout) View(a App) string {
 		}
 		return strings.Join(lines, "\n")
 	}
+	if slots := a.activeInlineImageSlots(); len(slots) > 0 {
+		return l.injectInlineImages(a, base, slots)
+	}
 	return base
+}
+
+// injectInlineImages appends absolute-cursor-positioned escape sequences for
+// each slot with a cache hit, same technique as the modal's imgRow/imgCol
+// (base + "\x1b[row;colH" + encoded, cursor parked at the bottom line after).
+// A slot with no cache hit yet is skipped — its reserved band just stays the
+// blank text the screen already rendered into base. Row 1 is the tab bar,
+// row 2 the feed-pending/separator row, so content's own row 0 is ANSI row 3;
+// column 1 is the content pane's left edge (no left margin in this layout).
+func (l TabsLayout) injectInlineImages(a App, base string, slots []screens.InlineImageSlot) string {
+	var sb strings.Builder
+	sb.WriteString(base)
+	for _, slot := range slots {
+		encoded, ok := a.inlineImageCache[inlineImageCacheKey(slot, a.graphicsProtocol)]
+		if !ok {
+			continue
+		}
+		row := 3 + slot.Row
+		col := 1 + slot.ColIndent
+		sb.WriteString(fmt.Sprintf("\x1b[%d;%dH%s", row, col, encoded))
+	}
+	sb.WriteString(fmt.Sprintf("\x1b[%d;1H", a.height))
+	return sb.String()
 }
 
 // HandleNav processes navigation key presses for the tabs layout: the "1"-"9"

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -86,8 +86,18 @@ func (l TabsLayout) View(a App) string {
 		return composed + fmt.Sprintf("\x1b[%d;%dH%s\x1b[%d;1H", imgRow, imgCol, a.imageModalEncoded, a.height)
 	}
 	if a.imageNeedsCleanup && a.graphicsProtocol == imgview.ProtocolKitty {
-		// Inject the Kitty delete-all command onto the line that held the modal's
-		// top border so Bubble Tea's diff renderer delivers it to the terminal.
+		// Inject the targeted delete for the modal's own reserved placement
+		// (kittyModalPlacementID) onto the line that held the modal's top
+		// border so Bubble Tea's diff renderer delivers it to the terminal.
+		// Never a blunt delete-all: that would also erase any inline
+		// images' placements, which can be on screen at the same time.
+		//
+		// This must fall through to the inline-image injection below rather
+		// than returning early: imageNeedsCleanup stays true indefinitely
+		// (see its doc comment — it's never auto-cleared, only cleared by the
+		// next modal image opening), so an early return here would silently
+		// stop all inline-image rendering for the rest of the session after
+		// the very first Kitty modal close.
 		modalH := a.imageModalRows + 2
 		yOff := (a.height - modalH) / 2
 		if yOff < 0 {
@@ -95,11 +105,12 @@ func (l TabsLayout) View(a App) string {
 		}
 		lines := strings.Split(base, "\n")
 		if yOff < len(lines) {
-			lines[yOff] = "\x1b_Ga=d,d=A\x1b\\" + lines[yOff]
+			lines[yOff] = imgview.DeleteKittyPlacement(kittyModalPlacementID) + lines[yOff]
 		}
-		return strings.Join(lines, "\n")
+		base = strings.Join(lines, "\n")
 	}
-	if slots := a.activeInlineImageSlots(); len(slots) > 0 {
+	slots := a.activeInlineImageSlots()
+	if len(slots) > 0 || len(a.pendingKittyDeletes) > 0 {
 		return l.injectInlineImages(a, base, slots)
 	}
 	return base
@@ -112,6 +123,12 @@ func (l TabsLayout) View(a App) string {
 // blank text the screen already rendered into base. Row 1 is the tab bar,
 // row 2 the feed-pending/separator row, so content's own row 0 is ANSI row 3;
 // column 1 is the content pane's left edge (no left margin in this layout).
+//
+// Kitty's pendingKittyDeletes don't need cursor positioning — placements are
+// addressed by id, not screen coordinates — so they're just appended
+// anywhere in the frame. This is why the caller invokes this method even
+// when slots is empty: a delete can be pending with nothing currently
+// visible (e.g. every inline image just scrolled off-screen).
 func (l TabsLayout) injectInlineImages(a App, base string, slots []screens.InlineImageSlot) string {
 	var sb strings.Builder
 	sb.WriteString(base)
@@ -123,6 +140,9 @@ func (l TabsLayout) injectInlineImages(a App, base string, slots []screens.Inlin
 		row := 3 + slot.Row
 		col := 1 + slot.ColIndent
 		sb.WriteString(fmt.Sprintf("\x1b[%d;%dH%s", row, col, encoded))
+	}
+	for id := range a.pendingKittyDeletes {
+		sb.WriteString(imgview.DeleteKittyPlacement(id))
 	}
 	sb.WriteString(fmt.Sprintf("\x1b[%d;1H", a.height))
 	return sb.String()

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -7,7 +7,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/ragnar/cyber-tui/internal/ui/imgview"
 	"github.com/ragnar/cyber-tui/internal/ui/screens"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 )
@@ -36,9 +35,6 @@ func (l TabsLayout) NeedsCompactAutoFill(termHeight int) int { return 0 }
 
 // View renders the full terminal output for the tabs layout.
 func (l TabsLayout) View(a App) string {
-	if a.active == screenLogin {
-		return a.login.View()
-	}
 	contentHeight := a.height - theme.ChromeHeight
 	content := lipgloss.NewStyle().Height(contentHeight).MaxHeight(contentHeight).Render(l.renderActiveScreen(a))
 	base := lipgloss.JoinVertical(lipgloss.Left,
@@ -47,105 +43,15 @@ func (l TabsLayout) View(a App) string {
 		content,
 		l.renderBottomBar(a),
 	)
-	if a.themePickerOpen {
-		return overlayCenter(base, l.renderThemePicker(a), a.width, a.height)
-	}
-	if a.themeEditorOpen {
-		return overlayCenter(base, l.renderThemeEditor(a), a.width, a.height)
-	}
-	if a.pathPromptOpen {
-		return overlayCenter(base, l.renderPathPrompt(a), a.width, a.height)
-	}
-	if a.helpModalOpen {
-		return overlayCenter(base, l.renderHelpModal(a), a.width, a.height)
-	}
-	if a.urlPickerOpen {
-		return overlayCenter(base, l.renderURLPicker(a), a.width, a.height)
-	}
-	if a.imageModalOpen {
-		textModal := l.renderImageModal(a)
-		composed := overlayCenter(base, textModal, a.width, a.height)
-		// Compute the same offsets overlayCenter used so we can position
-		// the image sequence inside the border without embedding it in the
-		// overlay string (which would corrupt overlayCenter's ANSI splicing).
-		modalW := lipgloss.Width(textModal)
-		modalH := len(strings.Split(textModal, "\n"))
-		xOff := (a.width - modalW) / 2
-		yOff := (a.height - modalH) / 2
-		if xOff < 0 {
-			xOff = 0
-		}
-		if yOff < 0 {
-			yOff = 0
-		}
-		// theme.ActiveBorder: 1-char border + 1-char horizontal padding on each
-		// side. Image content therefore starts 2 cols right of the border edge.
-		// ANSI cursor sequences are 1-indexed; the border top row is yOff+1.
-		imgRow := yOff + 2
-		imgCol := xOff + 3
-		return composed + fmt.Sprintf("\x1b[%d;%dH%s\x1b[%d;1H", imgRow, imgCol, a.imageModalEncoded, a.height)
-	}
-	if a.imageNeedsCleanup && a.graphicsProtocol == imgview.ProtocolKitty {
-		// Inject the targeted delete for the modal's own reserved placement
-		// (kittyModalPlacementID) onto the line that held the modal's top
-		// border so Bubble Tea's diff renderer delivers it to the terminal.
-		// Never a blunt delete-all: that would also erase any inline
-		// images' placements, which can be on screen at the same time.
-		//
-		// This must fall through to the inline-image injection below rather
-		// than returning early: imageNeedsCleanup stays true indefinitely
-		// (see its doc comment — it's never auto-cleared, only cleared by the
-		// next modal image opening), so an early return here would silently
-		// stop all inline-image rendering for the rest of the session after
-		// the very first Kitty modal close.
-		modalH := a.imageModalRows + 2
-		yOff := (a.height - modalH) / 2
-		if yOff < 0 {
-			yOff = 0
-		}
-		lines := strings.Split(base, "\n")
-		if yOff < len(lines) {
-			lines[yOff] = imgview.DeleteKittyPlacement(kittyModalPlacementID) + lines[yOff]
-		}
-		base = strings.Join(lines, "\n")
-	}
-	slots := a.activeInlineImageSlots()
-	if len(slots) > 0 || len(a.pendingKittyDeletes) > 0 {
-		return l.injectInlineImages(a, base, slots)
-	}
-	return base
+	return compositeOverlays(l, a, base)
 }
 
-// injectInlineImages appends absolute-cursor-positioned escape sequences for
-// each slot with a cache hit, same technique as the modal's imgRow/imgCol
-// (base + "\x1b[row;colH" + encoded, cursor parked at the bottom line after).
-// A slot with no cache hit yet is skipped — its reserved band just stays the
-// blank text the screen already rendered into base. Row 1 is the tab bar,
-// row 2 the feed-pending/separator row, so content's own row 0 is ANSI row 3;
-// column 1 is the content pane's left edge (no left margin in this layout).
-//
-// Kitty's pendingKittyDeletes don't need cursor positioning — placements are
-// addressed by id, not screen coordinates — so they're just appended
-// anywhere in the frame. This is why the caller invokes this method even
-// when slots is empty: a delete can be pending with nothing currently
-// visible (e.g. every inline image just scrolled off-screen).
-func (l TabsLayout) injectInlineImages(a App, base string, slots []screens.InlineImageSlot) string {
-	var sb strings.Builder
-	sb.WriteString(base)
-	for _, slot := range slots {
-		encoded, ok := a.inlineImageCache[inlineImageCacheKey(slot, a.graphicsProtocol)]
-		if !ok {
-			continue
-		}
-		row := 3 + slot.Row
-		col := 1 + slot.ColIndent
-		sb.WriteString(fmt.Sprintf("\x1b[%d;%dH%s", row, col, encoded))
-	}
-	for id := range a.pendingKittyDeletes {
-		sb.WriteString(imgview.DeleteKittyPlacement(id))
-	}
-	sb.WriteString(fmt.Sprintf("\x1b[%d;1H", a.height))
-	return sb.String()
+// InlineImageSlots returns the active screen's visible inline-image slots and
+// this layout's fixed screen origin for them: row 1 is the tab bar, row 2 the
+// feed-pending/separator row, so content's own row 0 is ANSI row 3; column 1
+// is the content pane's left edge (no left margin in this layout).
+func (l TabsLayout) InlineImageSlots(a App) ([]screens.InlineImageSlot, int, int) {
+	return a.activeInlineImageSlots(), 3, 1
 }
 
 // HandleNav processes navigation key presses for the tabs layout: the "1"-"9"

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -7,6 +7,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/ragnar/cyber-tui/internal/model"
+	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+	"github.com/ragnar/cyber-tui/internal/ui/screens"
 )
 
 // --- visibleTabs ---
@@ -500,5 +502,124 @@ func TestSplitMnemonic_NotFound(t *testing.T) {
 	before, ch, after := splitMnemonic("feed", 'z')
 	if before != "feed" || ch != "" || after != "" {
 		t.Errorf("got (%q, %q, %q), want (\"feed\", \"\", \"\")", before, ch, after)
+	}
+}
+
+// --- layoutFromName ---
+
+func TestLayoutFromName(t *testing.T) {
+	if _, ok := layoutFromName("miller").(MillerLayout); !ok {
+		t.Errorf("expected layoutFromName(%q) to return MillerLayout", "miller")
+	}
+	for _, name := range []string{"", "tabs", "unknown"} {
+		if _, ok := layoutFromName(name).(TabsLayout); !ok {
+			t.Errorf("expected layoutFromName(%q) to return TabsLayout", name)
+		}
+	}
+}
+
+// --- compositeOverlays ---
+
+// fakeModalRenderer is a minimal modalRenderer test double so
+// compositeOverlays' shared logic can be tested in isolation, without a full
+// TabsLayout/MillerLayout render pipeline — see TestTabsLayoutView_ and
+// TestMillerLayoutView_InjectsInlineImages below for the real-pipeline
+// smoke tests that exercise each layout's own InlineImageSlots.
+type fakeModalRenderer struct {
+	slots                []screens.InlineImageSlot
+	rowOrigin, colOrigin int
+}
+
+func (f fakeModalRenderer) renderThemePicker(a App) string { return "" }
+func (f fakeModalRenderer) renderThemeEditor(a App) string { return "" }
+func (f fakeModalRenderer) renderPathPrompt(a App) string  { return "" }
+func (f fakeModalRenderer) renderHelpModal(a App) string   { return "" }
+func (f fakeModalRenderer) renderURLPicker(a App) string   { return "" }
+func (f fakeModalRenderer) renderImageModal(a App) string  { return "" }
+func (f fakeModalRenderer) InlineImageSlots(a App) ([]screens.InlineImageSlot, int, int) {
+	return f.slots, f.rowOrigin, f.colOrigin
+}
+
+// TestCompositeOverlays_KittyCleanupFallsThroughToInlineImages is a
+// regression test for the bug MillerLayout originally shipped with: the
+// Kitty placement-cleanup block must fall through to inline-image
+// injection in the same frame, not return early — an early return there
+// silently drops all inline-image rendering for the rest of the session
+// (see app.go's imageNeedsCleanup doc comment). Since compositeOverlays is
+// now the one place this logic lives, this test alone covers both layouts.
+func TestCompositeOverlays_KittyCleanupFallsThroughToInlineImages(t *testing.T) {
+	slot := screens.InlineImageSlot{Key: "post:p1:0", URL: "https://example.com/a.png", Row: 1, ColIndent: 2}
+	a := App{
+		width: 40, height: 10,
+		graphicsProtocol:  imgview.ProtocolKitty,
+		imageNeedsCleanup: true,
+		imageModalRows:    3,
+		inlineImageCache:  map[string]string{inlineImageCacheKey(slot, imgview.ProtocolKitty): "\x1b_Gfake\x1b\\"},
+	}
+	l := fakeModalRenderer{slots: []screens.InlineImageSlot{slot}, rowOrigin: 5, colOrigin: 7}
+	out := compositeOverlays(l, a, strings.Repeat("x\n", 9)+"x")
+
+	if !strings.Contains(out, imgview.DeleteKittyPlacement(kittyModalPlacementID)) {
+		t.Error("expected the Kitty modal placement delete in the composited output")
+	}
+	if !strings.Contains(out, "\x1b_Gfake\x1b\\") {
+		t.Error("expected the inline image's cached escape sequence in the same composited output — cleanup must fall through, not return early")
+	}
+	if !strings.Contains(out, "\x1b[6;9H") { // rowOrigin(5)+slot.Row(1)=6, colOrigin(7)+slot.ColIndent(2)=9
+		t.Errorf("expected the inline image positioned at rowOrigin+Row, colOrigin+ColIndent; got %q", out)
+	}
+}
+
+// TestTabsLayoutView_InjectsInlineImages is the golden-output test category
+// both prior architecture reviews flagged as missing: an assertion on
+// TabsLayout.View()'s actual composited output, not just the pure diff
+// functions underneath it.
+func TestTabsLayoutView_InjectsInlineImages(t *testing.T) {
+	a := loggedInApp()
+	a.width, a.height = 80, 40
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.feed, _ = a.feed.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	a.feed, _ = a.feed.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	a.feed = a.feed.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hi\n\n![a](https://example.com/a.png)\n\nbye"},
+	}, "")
+	slots := a.feed.VisibleInlineImages()
+	if len(slots) != 1 {
+		t.Fatalf("setup: expected 1 slot from the feed, got %d: %+v", len(slots), slots)
+	}
+	a.inlineImageCache = map[string]string{inlineImageCacheKey(slots[0], a.graphicsProtocol): "\x1b_Gfake\x1b\\"}
+
+	out := (TabsLayout{}).View(a)
+	if !strings.Contains(out, "\x1b_Gfake\x1b\\") {
+		t.Errorf("expected TabsLayout.View to composite the cached inline image, got: %q", out)
+	}
+}
+
+// TestMillerLayoutView_InjectsInlineImages is the same golden-output check
+// for MillerLayout's Feed detail pane specifically — the exact code path
+// that silently rendered nothing before this branch (MillerLayout never
+// called injectInlineImages at all, and Feed's detail pane has no other
+// source of truth for its rendering width than MillerLayout.InlineImageSlots
+// computing it fresh, so this exercises that whole chain end to end).
+func TestMillerLayoutView_InjectsInlineImages(t *testing.T) {
+	a := loggedInApp()
+	a.width, a.height = 100, 40
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.feed, _ = a.feed.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	a.feed, _ = a.feed.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	a.feed = a.feed.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hi\n\n![a](https://example.com/a.png)\n\nbye"},
+	}, "")
+	a.feed, _ = a.feed.Update(screens.FeedDetailRepliesMsg{PostID: "p1", Replies: nil})
+
+	slots, _, _ := MillerLayout{}.InlineImageSlots(a)
+	if len(slots) != 1 {
+		t.Fatalf("setup: expected 1 slot from Miller's Feed detail pane, got %d: %+v", len(slots), slots)
+	}
+	a.inlineImageCache = map[string]string{inlineImageCacheKey(slots[0], a.graphicsProtocol): "\x1b_Gfake\x1b\\"}
+
+	out := (MillerLayout{}).View(a)
+	if !strings.Contains(out, "\x1b_Gfake\x1b\\") {
+		t.Errorf("expected MillerLayout.View to composite the cached inline image in the Feed detail pane, got: %q", out)
 	}
 }

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -623,3 +623,57 @@ func TestMillerLayoutView_InjectsInlineImages(t *testing.T) {
 		t.Errorf("expected MillerLayout.View to composite the cached inline image in the Feed detail pane, got: %q", out)
 	}
 }
+
+// --- MillerLayout.HasFocusedInput: backgrounded Circ/CMail room ---
+
+// TestMillerHasFocusedInput_ChatroomsDoesNotTrapNavAtFocusMenu is a
+// regression test: a Circ room stays in chatroomModeDetail (so
+// ChatroomsModel.InputFocused() stays true) for as long as it's open, even
+// after the user has pressed "left" to move Miller's own focus away to the
+// spaces column. Before this fix, HasFocusedInput only checked
+// InputFocused(), so every subsequent j/k/up/down was swallowed into the
+// backgrounded room's Update instead of reaching HandleNav's focusMenu case
+// (navigateTabBy) — the room was reachable but effectively un-leavable via
+// vertical nav.
+func TestMillerHasFocusedInput_ChatroomsDoesNotTrapNavAtFocusMenu(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenChatrooms
+	a.chatrooms = a.chatrooms.SetRooms([]model.Room{{Slug: "r1", Name: "r1"}})
+	a.chatrooms, _ = a.chatrooms.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !a.chatrooms.InputFocused() {
+		t.Fatal("setup: expected the room to be open (InputFocused true)")
+	}
+
+	a.focus = focusList
+	if !(MillerLayout{}).HasFocusedInput(a) {
+		t.Error("expected HasFocusedInput true while focus is still on the room")
+	}
+
+	a.focus = focusMenu
+	if (MillerLayout{}).HasFocusedInput(a) {
+		t.Error("expected HasFocusedInput false once focus has moved to the spaces column, even with the room still open")
+	}
+}
+
+// TestMillerHasFocusedInput_CMailDoesNotTrapNavAtFocusMenu mirrors the Circ
+// case above for CMail, which has the identical mode-based InputFocused
+// pattern (cmailModeDetail).
+func TestMillerHasFocusedInput_CMailDoesNotTrapNavAtFocusMenu(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenCMail
+	a.cmail = a.cmail.SetConversations([]model.Conversation{{ID: "c1"}})
+	a.cmail, _ = a.cmail.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !a.cmail.InputFocused() {
+		t.Fatal("setup: expected the conversation to be open (InputFocused true)")
+	}
+
+	a.focus = focusList
+	if !(MillerLayout{}).HasFocusedInput(a) {
+		t.Error("expected HasFocusedInput true while focus is still on the conversation")
+	}
+
+	a.focus = focusMenu
+	if (MillerLayout{}).HasFocusedInput(a) {
+		t.Error("expected HasFocusedInput false once focus has moved to the spaces column, even with the conversation still open")
+	}
+}

--- a/internal/ui/markdown/renderer.go
+++ b/internal/ui/markdown/renderer.go
@@ -88,27 +88,105 @@ var mdInstance = goldmark.New(
 // Render parses content as GFM and returns an ANSI-styled string suitable for
 // viewport display. width is the inner content width for word-wrapping.
 func Render(content string, width int) string {
+	src, width, empty := preprocessMarkdown(content, width)
+	if empty {
+		return ""
+	}
+	doc := mdInstance.Parser().Parse(text.NewReader(src))
+	r := &renderer{source: src, width: width}
+	docNode, ok := doc.(*ast.Document)
+	if !ok {
+		return theme.Base.Width(width).Render(string(src))
+	}
+	return r.renderDocument(docNode)
+}
+
+// ImageHit reports the location of one eligible inline image found by
+// RenderLocatingImages.
+type ImageHit struct {
+	URL  string
+	Line int // 0-based index into strings.Split(out, "\n")
+}
+
+// RenderLocatingImages is Render plus a report of every markdown image
+// eligible for inline graphics rendering, in document order: each is
+// considered only when it is the sole child of a top-level paragraph (alone
+// on its own line — not mixed with other text, not nested in a
+// list/blockquote/table/heading; see eligibleImageParagraphs). hits is empty
+// when there are none. out is byte-identical to what Render would produce
+// either way — this is a pure side-channel report of where each image's
+// placeholder line landed, so a caller can splice each one out and overlay
+// the real image there.
+func RenderLocatingImages(content string, width int) (out string, hits []ImageHit) {
+	src, width, empty := preprocessMarkdown(content, width)
+	if empty {
+		return "", nil
+	}
+	doc := mdInstance.Parser().Parse(text.NewReader(src))
+	docNode, docOK := doc.(*ast.Document)
+	if !docOK {
+		return theme.Base.Width(width).Render(string(src)), nil
+	}
+	targets, urls := eligibleImageParagraphs(docNode)
+	r := &renderer{source: src, width: width, findImages: targets}
+	out = r.renderDocument(docNode)
+	hits = make([]ImageHit, len(r.imageLines))
+	for i, line := range r.imageLines {
+		hits[i] = ImageHit{URL: urls[i], Line: line}
+	}
+	return out, hits
+}
+
+// eligibleImageParagraphs walks doc for every *ast.Image node, in document
+// order, and reports which are eligible for inline graphics rendering: the
+// image's parent must be a top-level (direct child of doc) *ast.Paragraph or
+// *ast.TextBlock, and the image must be that paragraph's only child. Returns
+// parallel slices (target block node, its image's URL) — one entry per
+// eligible image; an ineligible image is simply skipped, not substituted.
+func eligibleImageParagraphs(doc *ast.Document) (targets []ast.Node, urls []string) {
+	ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		img, isImg := n.(*ast.Image)
+		if !isImg {
+			return ast.WalkContinue, nil
+		}
+		parent := img.Parent()
+		switch parent.(type) {
+		case *ast.Paragraph, *ast.TextBlock:
+		default:
+			return ast.WalkContinue, nil
+		}
+		if parent.Parent() != doc {
+			return ast.WalkContinue, nil
+		}
+		if parent.FirstChild() != img || parent.LastChild() != img {
+			return ast.WalkContinue, nil
+		}
+		targets = append(targets, parent)
+		urls = append(urls, string(img.Destination))
+		return ast.WalkContinue, nil
+	})
+	return targets, urls
+}
+
+// preprocessMarkdown applies Render's/RenderLocatingImage's shared
+// preprocessing (HTML-entity unescaping, control-char stripping, Unicode
+// normalization, ambiguous-rune stripping, width default) and reports
+// whether the result is empty (nothing to render).
+func preprocessMarkdown(content string, width int) (src []byte, resolvedWidth int, empty bool) {
 	content = html.UnescapeString(content)
 	content = sanitize.Strip(content)
 	content = norm.NFC.String(content)
 	content = stripAmbiguousRunes(content)
 	if strings.TrimSpace(content) == "" {
-		return ""
+		return nil, width, true
 	}
 	if width < 1 {
 		width = 80
 	}
-
-	src := []byte(content)
-	reader := text.NewReader(src)
-	doc := mdInstance.Parser().Parse(reader)
-
-	r := &renderer{source: src, width: width}
-	docNode, ok := doc.(*ast.Document)
-	if !ok {
-		return theme.Base.Width(width).Render(content)
-	}
-	return r.renderDocument(docNode)
+	return []byte(content), width, false
 }
 
 // mdInlineParser registers only a paragraph block parser (no heading, list,
@@ -234,13 +312,34 @@ type renderer struct {
 	// doc comment for why this happens here rather than as a post-render
 	// pass. Compiled once per RenderInline call, not per text node.
 	highlightRe *regexp.Regexp
+
+	// findImages and imageLines are used only by RenderLocatingImages:
+	// findImages holds the target block nodes (each eligible image's parent
+	// paragraph), in document order, set before rendering begins.
+	// renderDocument appends to imageLines as its loop reaches each one,
+	// since it's the only place that knows the accumulated line count of
+	// every preceding block (a block can itself span multiple lines) — both
+	// it and findImages visit nodes in the same document order, so a single
+	// index pointer is enough to match them up (see the loop below). nil/
+	// empty for every other caller (Render, RenderInline, FirstLine) — no
+	// effect on their output.
+	findImages []ast.Node
+	imageLines []int
 }
 
 func (r *renderer) renderDocument(doc *ast.Document) string {
 	var parts []string
+	lineOffset := 0
+	nextImage := 0
 	for child := doc.FirstChild(); child != nil; child = child.NextSibling() {
-		if rendered := r.renderBlock(child); rendered != "" {
+		if nextImage < len(r.findImages) && child == r.findImages[nextImage] {
+			r.imageLines = append(r.imageLines, lineOffset)
+			nextImage++
+		}
+		rendered := r.renderBlock(child)
+		if rendered != "" {
 			parts = append(parts, rendered)
+			lineOffset += strings.Count(rendered, "\n") + 1
 		}
 	}
 	return strings.Join(parts, "\n")

--- a/internal/ui/markdown/renderer_test.go
+++ b/internal/ui/markdown/renderer_test.go
@@ -120,6 +120,101 @@ func TestRender_ImageNoAlt(t *testing.T) {
 	}
 }
 
+// TestRenderLocatingImages_SoleParagraphImage confirms the common real-world
+// case: an image alone in its own paragraph is reported as eligible, with
+// the correct URL and line index, and out is unaffected (byte-identical to
+// plain Render).
+func TestRenderLocatingImages_SoleParagraphImage(t *testing.T) {
+	content := "hi\n\n![photo.jpg](https://example.com/photo.jpg)\n\nbye"
+	out, hits := RenderLocatingImages(content, 80)
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 eligible image, got %d: %+v", len(hits), hits)
+	}
+	hit := hits[0]
+	if hit.URL != "https://example.com/photo.jpg" {
+		t.Errorf("expected matching URL, got %q", hit.URL)
+	}
+	lines := strings.Split(out, "\n")
+	if hit.Line < 0 || hit.Line >= len(lines) {
+		t.Fatalf("hit.Line %d out of range for %d lines", hit.Line, len(lines))
+	}
+	if !strings.Contains(strip(lines[hit.Line]), "[IMG") {
+		t.Errorf("expected line %d to be the image placeholder, got %q", hit.Line, lines[hit.Line])
+	}
+	if out != Render(content, 80) {
+		t.Errorf("RenderLocatingImages's out must be byte-identical to Render's output")
+	}
+}
+
+// TestRenderLocatingImages_LineOffsetAcrossMultiLineBlock confirms the line
+// index accounts for a preceding block that itself wraps to multiple lines
+// — the one case renderDocument's running lineOffset exists to handle.
+func TestRenderLocatingImages_LineOffsetAcrossMultiLineBlock(t *testing.T) {
+	long := strings.Repeat("word ", 30) // wraps across several lines at width 40
+	content := long + "\n\n![img](https://example.com/a.png)"
+	out, hits := RenderLocatingImages(content, 40)
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 eligible image, got %d: %+v", len(hits), hits)
+	}
+	hit := hits[0]
+	lines := strings.Split(out, "\n")
+	if hit.Line == 0 {
+		t.Errorf("expected the image line to come after the wrapped paragraph's multiple lines, got Line=0")
+	}
+	if hit.Line < 0 || hit.Line >= len(lines) || !strings.Contains(strip(lines[hit.Line]), "[IMG") {
+		t.Errorf("hit.Line (%d) does not point at the image line: %q", hit.Line, lines)
+	}
+}
+
+// TestRenderLocatingImages_Ineligible covers the spike's accepted corner
+// cuts: an image mixed inline with other text, and one nested in a list —
+// neither is ever reported, regardless of what else is in the document.
+func TestRenderLocatingImages_Ineligible(t *testing.T) {
+	cases := map[string]string{
+		"mixed inline text": "look at this ![img](https://example.com/a.png) cool huh",
+		"nested in list":    "- ![img](https://example.com/a.png)\n- other item",
+		"no image at all":   "just plain text, no images here",
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, hits := RenderLocatingImages(content, 80)
+			if len(hits) != 0 {
+				t.Errorf("expected no eligible images for %q, got %+v", content, hits)
+			}
+		})
+	}
+}
+
+// TestRenderLocatingImages_MultipleImages confirms every eligible image in a
+// document is reported, in document order, with correct per-hit lines — and
+// that an ineligible image earlier in the document doesn't suppress a later
+// eligible one (the old "first image or nothing" rule no longer applies).
+func TestRenderLocatingImages_MultipleImages(t *testing.T) {
+	content := "intro ![mixed](https://example.com/mixed.png) text\n\n" +
+		"![first](https://example.com/first.png)\n\n" +
+		"middle text\n\n" +
+		"![second](https://example.com/second.png)"
+	out, hits := RenderLocatingImages(content, 80)
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 eligible images (mixed one excluded), got %d: %+v", len(hits), hits)
+	}
+	if hits[0].URL != "https://example.com/first.png" {
+		t.Errorf("expected first hit to be 'first', got %q", hits[0].URL)
+	}
+	if hits[1].URL != "https://example.com/second.png" {
+		t.Errorf("expected second hit to be 'second', got %q", hits[1].URL)
+	}
+	if hits[1].Line <= hits[0].Line {
+		t.Errorf("expected hits in ascending line order, got %d then %d", hits[0].Line, hits[1].Line)
+	}
+	lines := strings.Split(out, "\n")
+	for _, h := range hits {
+		if h.Line < 0 || h.Line >= len(lines) || !strings.Contains(strip(lines[h.Line]), "[IMG") {
+			t.Errorf("hit.Line (%d) does not point at an image line: %q", h.Line, lines)
+		}
+	}
+}
+
 func TestRender_InlineCode(t *testing.T) {
 	raw := Render("Use `fmt.Println` here", 80)
 	plain := strip(raw)

--- a/internal/ui/screens/bookmarks.go
+++ b/internal/ui/screens/bookmarks.go
@@ -362,7 +362,7 @@ func (m BookmarksModel) renderItem(b model.Bookmark, selected bool) string {
 	if author != "" {
 		authorStyled = "  " + theme.Highlight.Render("@"+author)
 	}
-	attInd := attachmentIndicator(attachments)
+	attInd := attachmentIndicator(attachments, content)
 	left1 := typeTag + authorStyled
 	if attInd != "" {
 		left1 += "  " + attInd

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -839,9 +839,31 @@ func (m FeedModel) CurrentDetailCmd() (FeedModel, tea.Cmd) {
 	return m, func() tea.Msg { return LoadFeedDetailMsg{PostID: postID} }
 }
 
+// renderDetailPost renders the selected post's card for Miller's reading
+// pane, mirroring RenderPost's border/selection styling but — unlike
+// RenderPost, whose non-Feed-list callers (Search/Guilds/Topics/the
+// fullscreen modal) always pass inlineImagesEnabled=false — opts into
+// inline-image-aware rendering via m.inlineImagesEnabled, so Miller's
+// detail pane can composite inline images the same way Feed's own list
+// view and PostDetail already do.
+func (m FeedModel) renderDetailPost(p model.Post, selected, bookmarked, watched bool, width int) (string, []postImageSlot) {
+	content, imgSlots := renderPostBody(p, bookmarked, watched, width, m.location(), m.timeDisplayFormat, 0, m.inlineImagesEnabled)
+	boxStyle := theme.Border
+	if selected {
+		boxStyle = theme.ActiveBorder
+	}
+	if width-4 > 0 {
+		boxStyle = boxStyle.Width(width - 2)
+	}
+	return boxStyle.Render(content), imgSlots
+}
+
 // renderDetailReply renders a reply in the Miller reading pane using the same tree-aware
-// card style as the post-detail screen: depth indentation, parent back-reference, active border.
-func (m FeedModel) renderDetailReply(node replyNode, selected bool, width int) string {
+// card style as the post-detail screen: depth indentation, parent back-reference, active
+// border. lineBase is 2 (border top row + the single header row) — reply cards, unlike
+// posts, never have optional badge/title rows, so this is always fixed (see
+// PostDetailModel.renderReply's identical convention).
+func (m FeedModel) renderDetailReply(node replyNode, selected bool, width int) (string, []postImageSlot) {
 	indentW := node.Depth * 3
 	cardWidth := width - 2 - indentW
 	if cardWidth < 4 {
@@ -858,7 +880,19 @@ func (m FeedModel) renderDetailReply(node replyNode, selected bool, width int) s
 	}
 	header += theme.Subtle.Render("  " + displayTime(node.Reply.CreatedAt, m.location(), m.timeDisplayFormat, false))
 
-	body := strings.TrimRight(markdown.Render(node.Reply.Content, innerWidth), "\n")
+	var body string
+	var imgSlots []postImageSlot
+	if m.inlineImagesEnabled {
+		rendered, hits := markdown.RenderLocatingImages(node.Reply.Content, innerWidth)
+		if len(hits) > 0 {
+			lines, slots := spliceInlineImageBands(strings.Split(rendered, "\n"), hits, 2)
+			rendered = strings.Join(lines, "\n")
+			imgSlots = slots
+		}
+		body = strings.TrimRight(rendered, "\n")
+	} else {
+		body = strings.TrimRight(markdown.Render(node.Reply.Content, innerWidth), "\n")
+	}
 
 	boxStyle := theme.Border
 	if selected {
@@ -869,9 +903,57 @@ func (m FeedModel) renderDetailReply(node replyNode, selected bool, width int) s
 	}
 	card := boxStyle.Render(lipgloss.JoinVertical(lipgloss.Left, header, body))
 	if indentW > 0 {
-		return lipgloss.NewStyle().MarginLeft(indentW).Render(card)
+		return lipgloss.NewStyle().MarginLeft(indentW).Render(card), imgSlots
 	}
-	return card
+	return card, imgSlots
+}
+
+// detailContent is everything Miller's reading pane needs to render, page,
+// and locate inline images for the selected post + its reply tree — computed
+// once so all three stay in exact agreement. Computing pager heights (or
+// image positions) from separately re-rendered content risks desyncing from
+// what's actually on screen, e.g. if inline images make a card taller than a
+// non-image-aware height measurement would predict.
+type detailContent struct {
+	parts       []string // card strings: post first, then one per m.detailFlatTree entry
+	startLines  []int    // startLines[i] = the line parts[i] begins at within the joined content
+	lineCount   int      // total lines across all parts joined
+	postH       int
+	postImages  []postImageSlot
+	replyImages [][]postImageSlot // parallel to m.detailFlatTree; nil while detailLoading
+}
+
+// buildDetailContent renders the selected post's card and reply tree at
+// width. postSelected/selectedReply control which card gets the active
+// border; callers that only need geometry (pageDetailNav) pass false/-1
+// since border style never changes a card's rendered height.
+func (m FeedModel) buildDetailContent(width int, postSelected bool, selectedReply int) detailContent {
+	visible := m.visiblePosts()
+	if m.selectedIndex >= len(visible) {
+		return detailContent{}
+	}
+	p := visible[m.selectedIndex]
+	_, bookmarked := m.bookmarkedPostIDs[p.ID]
+	_, watched := m.watchedPostIDs[p.ID]
+
+	card, postImgs := m.renderDetailPost(p, postSelected, bookmarked, watched, width)
+	postH := lipgloss.Height(card)
+
+	parts := []string{card}
+	startLines := []int{0}
+	lineCount := postH
+	var replyImgs [][]postImageSlot
+	if !m.detailLoading {
+		replyImgs = make([][]postImageSlot, len(m.detailFlatTree))
+		for i, node := range m.detailFlatTree {
+			rendered, imgs := m.renderDetailReply(node, i == selectedReply, width)
+			replyImgs[i] = imgs
+			startLines = append(startLines, lineCount)
+			lineCount += lipgloss.Height(rendered)
+			parts = append(parts, rendered)
+		}
+	}
+	return detailContent{parts: parts, startLines: startLines, lineCount: lineCount, postH: postH, postImages: postImgs, replyImages: replyImgs}
 }
 
 // renderCompactPost renders a single-line summary of a post for the Miller compact list pane.
@@ -985,29 +1067,18 @@ func (m FeedModel) CompactListView(width, height int) string {
 
 // pageDetailNav implements pager-style scrolling for the Miller detail pane.
 func (m FeedModel) pageDetailNav(delta, paneH, paneW int) FeedModel {
-	visible := m.visiblePosts()
-	if m.selectedIndex >= len(visible) {
+	dc := m.buildDetailContent(paneW, false, -1)
+	if len(dc.parts) == 0 {
 		return m
 	}
-	p := visible[m.selectedIndex]
-	_, bookmarked := m.bookmarkedPostIDs[p.ID]
-	_, watched := m.watchedPostIDs[p.ID]
-
-	postCard := RenderPost(p, false, bookmarked, watched, paneW, m.location(), m.timeDisplayFormat, 0)
-	postH := lipgloss.Height(postCard)
-
-	replyStarts := make([]int, len(m.detailFlatTree))
-	replyHeights := make([]int, len(m.detailFlatTree))
-	pos := postH
-	for i, node := range m.detailFlatTree {
-		replyStarts[i] = pos
-		rendered := m.renderDetailReply(node, false, paneW)
-		replyHeights[i] = lipgloss.Height(rendered)
-		pos += replyHeights[i]
+	replyStarts := dc.startLines[1:]
+	replyHeights := make([]int, len(dc.parts)-1)
+	for i := range replyHeights {
+		replyHeights[i] = lipgloss.Height(dc.parts[i+1])
 	}
 
 	m.detailReplyIndex, m.detailScrollOffset = millerPageNav(
-		delta, paneH, postH, replyStarts, replyHeights, m.detailReplyIndex, m.detailScrollOffset,
+		delta, paneH, dc.postH, replyStarts, replyHeights, m.detailReplyIndex, m.detailScrollOffset,
 	)
 	return m
 }
@@ -1026,31 +1097,96 @@ func (m FeedModel) DetailView(width, height int) string {
 	if m.selectedIndex >= len(visible) {
 		return theme.Subtle.Render("  select a post")
 	}
-	p := visible[m.selectedIndex]
-	_, bookmarked := m.bookmarkedPostIDs[p.ID]
-	_, watched := m.watchedPostIDs[p.ID]
-
-	// Render all items and track each item's start line for scroll computation.
-	postSelected := m.detailReplyIndex < 0
-	card := RenderPost(p, postSelected, bookmarked, watched, width, m.location(), m.timeDisplayFormat, 0)
-
-	var parts []string
-	startLines := []int{0} // startLines[0] = post start line (always 0)
-	lineCount := lipgloss.Height(card)
-	parts = append(parts, card)
-
+	dc := m.buildDetailContent(width, m.detailReplyIndex < 0, m.detailReplyIndex)
+	parts := dc.parts
 	if m.detailLoading {
 		parts = append(parts, theme.Subtle.Render("  loading replies…"))
-	} else {
-		for i, node := range m.detailFlatTree {
-			rendered := m.renderDetailReply(node, i == m.detailReplyIndex, width)
-			startLines = append(startLines, lineCount)
-			lineCount += lipgloss.Height(rendered)
-			parts = append(parts, rendered)
-		}
 	}
 	fullContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
-	return sliceContent(fullContent, m.detailScrollOffset, height, lineCount)
+	return sliceContent(fullContent, m.detailScrollOffset, height, dc.lineCount)
+}
+
+// effectiveScrollTop mirrors sliceContent's own offset clamping (see
+// miller_pager.go) so callers computing positions against the *actual*
+// displayed window agree with what sliceContent will show — near the
+// bottom of a pane, sliceContent clamps the raw scroll offset inward, and
+// using the raw offset instead would misplace inline images.
+func effectiveScrollTop(offset, height, lineCount int) int {
+	if lineCount <= height {
+		return 0
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset+height > lineCount {
+		offset = lineCount - height
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return offset
+}
+
+// VisibleDetailInlineImages returns the inline image slots currently fully
+// within Miller's reading pane for the selected post + reply tree. width and
+// height must match what MillerLayout passed to DetailView this frame (see
+// MillerLayout.InlineImageSlots) — this recomputes buildDetailContent rather
+// than caching, since the pane width Miller uses depends on the current
+// list/detail split and isn't known until View() runs, and Bubble Tea's
+// value-receiver View() can't persist it back onto the model for Update() to
+// see next (see FeedModel.VisibleInlineImages for the Tabs-viewport analog).
+func (m FeedModel) VisibleDetailInlineImages(width, height int) []InlineImageSlot {
+	if !m.ready || !m.inlineImagesEnabled {
+		return nil
+	}
+	visible := m.visiblePosts()
+	if m.selectedIndex >= len(visible) {
+		return nil
+	}
+	dc := m.buildDetailContent(width, m.detailReplyIndex < 0, m.detailReplyIndex)
+	if len(dc.parts) == 0 {
+		return nil
+	}
+	top := effectiveScrollTop(m.detailScrollOffset, height, dc.lineCount)
+	bottom := top + height
+
+	p := visible[m.selectedIndex]
+	var slots []InlineImageSlot
+	for j, img := range dc.postImages {
+		if img.Line < top || img.Line+inlineImageMaxRows > bottom {
+			continue
+		}
+		slots = append(slots, InlineImageSlot{
+			URL:       img.URL,
+			Row:       img.Line - top,
+			ColIndent: 2,
+			MaxCols:   width - 4,
+			MaxRows:   inlineImageEncodeMaxRows,
+			Key:       fmt.Sprintf("post:%s:%d", p.ID, j),
+		})
+	}
+	for i, node := range m.detailFlatTree {
+		if i >= len(dc.replyImages) || i+1 >= len(dc.startLines) {
+			continue
+		}
+		indentW := node.Depth * 3
+		replyStart := dc.startLines[i+1]
+		for j, img := range dc.replyImages[i] {
+			abs := replyStart + img.Line
+			if abs < top || abs+inlineImageMaxRows > bottom {
+				continue
+			}
+			slots = append(slots, InlineImageSlot{
+				URL:       img.URL,
+				Row:       abs - top,
+				ColIndent: 2 + indentW,
+				MaxCols:   width - 4 - indentW,
+				MaxRows:   inlineImageEncodeMaxRows,
+				Key:       fmt.Sprintf("reply:%s:%d", node.Reply.ID, j),
+			})
+		}
+	}
+	return slots
 }
 
 func (m FeedModel) View() string {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -95,6 +95,12 @@ type FeedModel struct {
 	loc               *time.Location // timezone for timestamp display; nil = UTC
 	timeDisplayFormat string         // API setting: "datetime", "relative", "unix", "swatch"
 
+	// inlineImagesEnabled mirrors SharedConfigMsg.InlineImagesEnabled — see
+	// PostDetailModel's field of the same name. postImages is parallel to
+	// postOffsets/visiblePosts(); only ever populated when this is true.
+	inlineImagesEnabled bool
+	postImages          [][]postImageSlot
+
 	currentUsername  string // set after login; used to guard the delete key
 	confirmingDelete bool   // true while the delete-post confirmation overlay is shown
 
@@ -362,8 +368,9 @@ func (m FeedModel) SetLocation(loc *time.Location) FeedModel {
 // refreshContent rebuilds the viewport content and updates postOffsets.
 // Call this whenever posts, selectedIndex, or width changes.
 func (m FeedModel) refreshContent() FeedModel {
-	content, offsets := m.buildContent()
+	content, offsets, postImages := m.buildContent()
 	m.postOffsets = offsets
+	m.postImages = postImages
 	m.viewport.SetContent(content)
 	return m
 }
@@ -377,7 +384,8 @@ func (m FeedModel) ensureSelectedVisible() FeedModel {
 		return m
 	}
 	postStart := m.postOffsets[m.selectedIndex]
-	postHeight := lipgloss.Height(m.renderPost(visible[m.selectedIndex], false))
+	rendered, _ := m.renderPost(visible[m.selectedIndex], false)
+	postHeight := lipgloss.Height(rendered)
 	postEnd := postStart + postHeight - 1
 
 	viewTop := m.viewport.YOffset
@@ -417,6 +425,8 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 	case SharedConfigMsg:
 		m.timeDisplayFormat = msg.Settings.TimeDisplayFormat
 		m.defaultPublicPost = msg.Settings.DefaultPublicPost
+		imagesChanged := msg.InlineImagesEnabled != m.inlineImagesEnabled
+		m.inlineImagesEnabled = msg.InlineImagesEnabled
 		m = m.SetRelaxed(msg.Relaxed)
 		m = m.SetLocation(msg.Loc)
 		if msg.Settings.FilterNSFW != m.filterNSFW {
@@ -425,6 +435,8 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 			if m.ready {
 				m = m.refreshContent()
 			}
+		} else if imagesChanged && m.ready {
+			m = m.refreshContent()
 		}
 		if msg.MaxThreadDepth != m.maxThreadDepth {
 			m.maxThreadDepth = msg.MaxThreadDepth
@@ -701,10 +713,11 @@ func (m FeedModel) triggerLoadMore() (FeedModel, tea.Cmd) {
 }
 
 // buildContent renders all posts into a single string for the viewport and
-// returns the start line of each post so ensureSelectedVisible can scroll accurately.
-func (m FeedModel) buildContent() (string, []int) {
+// returns the start line of each post so ensureSelectedVisible can scroll
+// accurately, plus each post's inline image slots (parallel to offsets).
+func (m FeedModel) buildContent() (string, []int, [][]postImageSlot) {
 	if m.fetching {
-		return theme.Subtle.Render("  loading feed…"), nil
+		return theme.Subtle.Render("  loading feed…"), nil, nil
 	}
 	var prefix string
 	startLine := 0
@@ -714,9 +727,9 @@ func (m FeedModel) buildContent() (string, []int) {
 	}
 	if len(m.posts) == 0 {
 		if m.err != nil {
-			return prefix + theme.Subtle.Render("  couldn't load feed"), nil
+			return prefix + theme.Subtle.Render("  couldn't load feed"), nil, nil
 		}
-		return prefix + theme.Subtle.Render("  no posts yet"), nil
+		return prefix + theme.Subtle.Render("  no posts yet"), nil, nil
 	}
 	sep := "\n"
 	lineInc := 0
@@ -726,12 +739,14 @@ func (m FeedModel) buildContent() (string, []int) {
 	}
 	visible := m.visiblePosts()
 	offsets := make([]int, len(visible))
+	postImages := make([][]postImageSlot, len(visible))
 	var out strings.Builder
 	out.WriteString(prefix)
 	currentLine := startLine
 	for i, p := range visible {
 		offsets[i] = currentLine
-		rendered := m.renderPost(p, i == m.selectedIndex)
+		rendered, imgSlots := m.renderPost(p, i == m.selectedIndex)
+		postImages[i] = imgSlots
 		out.WriteString(rendered)
 		out.WriteString(sep)
 		currentLine += lipgloss.Height(rendered) + lineInc
@@ -741,31 +756,34 @@ func (m FeedModel) buildContent() (string, []int) {
 	} else if m.exhausted {
 		out.WriteString(theme.Subtle.Render("  — end of feed —") + "\n")
 	}
-	return out.String(), offsets
+	return out.String(), offsets, postImages
 }
 
 // feedBodyCacheEntry is a memoized renderPostBody result plus the inputs it
-// was computed from, so a stale hit (width resize, bookmark/watch toggle, or
-// an edited post body) can be detected and recomputed instead of served.
+// was computed from, so a stale hit (width resize, bookmark/watch toggle, an
+// edited post body, or the inline-images setting changing) can be detected
+// and recomputed instead of served.
 type feedBodyCacheEntry struct {
-	body       string
-	width      int
-	bookmarked bool
-	watched    bool
-	content    string
+	body                string
+	imgSlots            []postImageSlot
+	width               int
+	bookmarked          bool
+	watched             bool
+	content             string
+	inlineImagesEnabled bool
 }
 
-func (m FeedModel) renderPost(p model.Post, selected bool) string {
+func (m FeedModel) renderPost(p model.Post, selected bool) (string, []postImageSlot) {
 	_, bookmarked := m.bookmarkedPostIDs[p.ID]
 	_, watched := m.watchedPostIDs[p.ID]
 
-	body, ok := "", false
-	if e, hit := m.bodyCache[p.ID]; hit && e.width == m.width && e.bookmarked == bookmarked && e.watched == watched && e.content == p.Content {
-		body, ok = e.body, true
+	body, imgSlots, ok := "", []postImageSlot(nil), false
+	if e, hit := m.bodyCache[p.ID]; hit && e.width == m.width && e.bookmarked == bookmarked && e.watched == watched && e.content == p.Content && e.inlineImagesEnabled == m.inlineImagesEnabled {
+		body, imgSlots, ok = e.body, e.imgSlots, true
 	}
 	if !ok {
-		body = renderPostBody(p, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat, postMaxBodyLines)
-		m.bodyCache[p.ID] = feedBodyCacheEntry{body: body, width: m.width, bookmarked: bookmarked, watched: watched, content: p.Content}
+		body, imgSlots = renderPostBody(p, bookmarked, watched, m.width, m.location(), m.timeDisplayFormat, postMaxBodyLines, m.inlineImagesEnabled)
+		m.bodyCache[p.ID] = feedBodyCacheEntry{body: body, imgSlots: imgSlots, width: m.width, bookmarked: bookmarked, watched: watched, content: p.Content, inlineImagesEnabled: m.inlineImagesEnabled}
 	}
 
 	boxStyle := theme.Border
@@ -775,7 +793,7 @@ func (m FeedModel) renderPost(p model.Post, selected bool) string {
 	if m.width-4 > 0 {
 		boxStyle = boxStyle.Width(m.width - 2)
 	}
-	return boxStyle.Render(body)
+	return boxStyle.Render(body), imgSlots
 }
 
 // currentDetailCmd clears the detail pane immediately and starts a debounce timer.
@@ -1075,4 +1093,38 @@ func (m FeedModel) GetFocusedURLs() []string {
 	}
 	p := visible[m.selectedIndex]
 	return append(extractURLs(p.Content), attachmentURLs(p.Attachments)...)
+}
+
+// VisibleInlineImages returns the inline image slots currently fully within
+// the viewport, top to bottom, across every visible post — see
+// PostDetailModel.VisibleInlineImages for the full contract (this is purely
+// a "where, if anywhere" query; App owns fetching/encoding/caching).
+func (m FeedModel) VisibleInlineImages() []InlineImageSlot {
+	if !m.ready || !m.inlineImagesEnabled {
+		return nil
+	}
+	visible := m.visiblePosts()
+	top, bottom := m.viewport.YOffset, m.viewport.YOffset+m.viewport.Height
+
+	var slots []InlineImageSlot
+	for i, p := range visible {
+		if i >= len(m.postImages) || i >= len(m.postOffsets) {
+			continue
+		}
+		for j, img := range m.postImages[i] {
+			abs := m.postOffsets[i] + img.Line
+			if abs < top || abs+inlineImageMaxRows > bottom {
+				continue
+			}
+			slots = append(slots, InlineImageSlot{
+				URL:       img.URL,
+				Row:       abs - top,
+				ColIndent: 2,
+				MaxCols:   m.width - 4,
+				MaxRows:   inlineImageEncodeMaxRows,
+				Key:       fmt.Sprintf("post:%s:%d", p.ID, j),
+			})
+		}
+	}
+	return slots
 }

--- a/internal/ui/screens/feed_test.go
+++ b/internal/ui/screens/feed_test.go
@@ -448,6 +448,92 @@ func TestFeed_VisibleInlineImages_CapsAtFirstImage(t *testing.T) {
 	}
 }
 
+// --- VisibleDetailInlineImages (Miller reading pane) ---
+
+// TestFeed_VisibleDetailInlineImages_DisabledByDefault mirrors
+// TestFeed_VisibleInlineImages_DisabledByDefault for Miller's detail pane.
+func TestFeed_VisibleDetailInlineImages_DisabledByDefault(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hi\n\n![a](https://example.com/a.png)\n\nbye"},
+	}, "")
+
+	if slots := m.VisibleDetailInlineImages(76, 40); slots != nil {
+		t.Errorf("expected no slots while disabled, got %+v", slots)
+	}
+}
+
+// TestFeed_VisibleDetailInlineImages_PostImage confirms the selected post's
+// own image is located, using renderDetailPost's inline-image-aware
+// rendering rather than RenderPost's (which always disables it for every
+// non-Feed-list caller — this is the one Feed opts into for Miller).
+func TestFeed_VisibleDetailInlineImages_PostImage(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m, _ = m.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hi\n\n![a](https://example.com/a.png)\n\nbye"},
+	}, "")
+
+	slots := m.VisibleDetailInlineImages(76, 40)
+	if len(slots) != 1 {
+		t.Fatalf("expected 1 slot for the post's own image, got %d: %+v", len(slots), slots)
+	}
+	if slots[0].Key != "post:p1:0" {
+		t.Errorf("expected key %q, got %q", "post:p1:0", slots[0].Key)
+	}
+	if slots[0].URL != "https://example.com/a.png" {
+		t.Errorf("expected the post's image URL, got %q", slots[0].URL)
+	}
+}
+
+// TestFeed_VisibleDetailInlineImages_ReplyImage confirms a reply's image is
+// located below the post, keyed by reply ID — reply image extraction has no
+// Tabs-side equivalent to mirror (Tabs' Feed view never shows replies
+// inline), so this is new logic ported from PostDetailModel's pattern.
+func TestFeed_VisibleDetailInlineImages_ReplyImage(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m, _ = m.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hello", RepliesCount: 1},
+	}, "")
+	m, _ = m.Update(screens.FeedDetailRepliesMsg{PostID: "p1", Replies: []model.Reply{
+		{ID: "r1", PostID: "p1", AuthorUsername: "bob", Content: "check this\n\n![b](https://example.com/b.png)"},
+	}})
+
+	slots := m.VisibleDetailInlineImages(76, 60)
+	if len(slots) != 1 {
+		t.Fatalf("expected 1 slot for the reply's image, got %d: %+v", len(slots), slots)
+	}
+	if slots[0].Key != "reply:r1:0" {
+		t.Errorf("expected key %q, got %q", "reply:r1:0", slots[0].Key)
+	}
+	if slots[0].Row <= 0 {
+		t.Errorf("expected the reply's image below the post card (row > 0), got %d", slots[0].Row)
+	}
+}
+
+// TestFeed_VisibleDetailInlineImages_OutOfViewHiddenBySmallHeight confirms
+// the visibility window is respected: the same reply image from the test
+// above must be excluded when height is too small to reach it.
+func TestFeed_VisibleDetailInlineImages_OutOfViewHiddenBySmallHeight(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m, _ = m.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hello", RepliesCount: 1},
+	}, "")
+	m, _ = m.Update(screens.FeedDetailRepliesMsg{PostID: "p1", Replies: []model.Reply{
+		{ID: "r1", PostID: "p1", AuthorUsername: "bob", Content: "check this\n\n![b](https://example.com/b.png)"},
+	}})
+
+	if slots := m.VisibleDetailInlineImages(76, 2); slots != nil {
+		t.Errorf("expected the reply's image to be out of view at height=2, got %+v", slots)
+	}
+}
+
 // --- ParseTopics ---
 
 func TestParseTopics_LowercasesTrimsCapsAndIgnoresEmpty(t *testing.T) {

--- a/internal/ui/screens/feed_test.go
+++ b/internal/ui/screens/feed_test.go
@@ -353,6 +353,101 @@ func TestFeed_UpAtTop_WithPendingNew_AnimatesThenMergesLocally(t *testing.T) {
 	}
 }
 
+// --- VisibleInlineImages ---
+
+// TestFeed_VisibleInlineImages_DisabledByDefault mirrors PostDetail's
+// equivalent: with InlineImagesEnabled never sent, a post with an eligible
+// image must report no slots — the feature is a strict no-op until enabled.
+func TestFeed_VisibleInlineImages_DisabledByDefault(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hi\n\n![a](https://example.com/a.png)\n\nbye"},
+	}, "")
+
+	if slots := m.VisibleInlineImages(); slots != nil {
+		t.Errorf("expected no slots while disabled, got %+v", slots)
+	}
+}
+
+// TestFeed_VisibleInlineImages_MultiplePosts confirms multiple posts on
+// screen at once each report their own image slot, with distinct per-post
+// Keys and strictly increasing Rows — the scenario phase 5 exists to
+// exercise (several images visible simultaneously, not just one post's).
+func TestFeed_VisibleInlineImages_MultiplePosts(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 80})
+	m, _ = m.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "hi\n\n![a](https://example.com/a.png)\n\nbye"},
+		{ID: "p2", AuthorUsername: "bob", Content: "yo\n\n![b](https://example.com/b.png)\n\nlater"},
+	}, "")
+
+	slots := m.VisibleInlineImages()
+	if len(slots) != 2 {
+		t.Fatalf("expected 2 slots (one per post), got %d: %+v", len(slots), slots)
+	}
+	if slots[0].Key != "post:p1:0" || slots[1].Key != "post:p2:0" {
+		t.Errorf("expected distinct per-post keys, got %q and %q", slots[0].Key, slots[1].Key)
+	}
+	if slots[1].Row <= slots[0].Row {
+		t.Errorf("expected the second post's image below the first's: rows %d, %d", slots[0].Row, slots[1].Row)
+	}
+}
+
+// TestFeed_VisibleInlineImages_TrailingImageDoesNotShrinkCard is a
+// regression test: a post whose *last* image has no text after it (very
+// common in real content — many posts end right on the image) used to have
+// its reserved image band silently deleted by a trailing-whitespace trim in
+// renderPostBody, shrinking the card's computed height below what the image
+// actually needed and letting it paint into the next post. p1's image here
+// is the very last thing in its content — the exact trigger.
+func TestFeed_VisibleInlineImages_TrailingImageDoesNotShrinkCard(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 80})
+	m, _ = m.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "look at this\n\n![a](https://example.com/a.png)"},
+		{ID: "p2", AuthorUsername: "bob", Content: "yo\n\n![b](https://example.com/b.png)\n\nlater"},
+	}, "")
+
+	slots := m.VisibleInlineImages()
+	if len(slots) != 2 {
+		t.Fatalf("expected 2 slots (one per post), got %d: %+v", len(slots), slots)
+	}
+	// p2's image must land at least a full image band below p1's — if the
+	// bug were present, p1's card would be computed shorter than its actual
+	// rendered content, and p2's row would land inside (or before) p1's own
+	// reserved band instead of safely after it.
+	const minGap = 10 // inlineImageMaxRows(8) + 2 spacer rows
+	if got := slots[1].Row - slots[0].Row; got < minGap {
+		t.Errorf("expected at least %d rows between the two posts' images (card shrunk?), got %d (rows %d, %d)", minGap, got, slots[0].Row, slots[1].Row)
+	}
+}
+
+// TestFeed_VisibleInlineImages_CapsAtFirstImage confirms Feed shows at most
+// one inline image per post even when a post has multiple eligible ones
+// (e.g. mattmanz1/yay-i-have-gear, 2 images) — PostDetail still shows all of
+// them (see postdetail_test.go); Feed's card is compact and truncates body
+// text, so capping to the first keeps its image count predictable rather
+// than 0..N depending on how much intro text precedes the images.
+func TestFeed_VisibleInlineImages_CapsAtFirstImage(t *testing.T) {
+	m := screens.NewFeedModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	m, _ = m.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "two photos\n\n![a](https://example.com/a.png)\n\n![b](https://example.com/b.png)"},
+	}, "")
+
+	slots := m.VisibleInlineImages()
+	if len(slots) != 1 {
+		t.Fatalf("expected exactly 1 slot (capped), got %d: %+v", len(slots), slots)
+	}
+	if slots[0].URL != "https://example.com/a.png" {
+		t.Errorf("expected the first image only, got %q", slots[0].URL)
+	}
+}
+
 // --- ParseTopics ---
 
 func TestParseTopics_LowercasesTrimsCapsAndIgnoresEmpty(t *testing.T) {

--- a/internal/ui/screens/inlineimage.go
+++ b/internal/ui/screens/inlineimage.go
@@ -1,0 +1,100 @@
+package screens
+
+import "github.com/ragnar/cyber-tui/internal/ui/markdown"
+
+// inlineImageMaxRows is the fixed row budget reserved for one inline image
+// within a post/reply card — a thumbnail, not a hero image, since every
+// eligible image in a post renders inline (not just the first). The image
+// is fit into this box preserving aspect ratio (never upscaled), so it may
+// occupy fewer rows than this in practice — the rest of the band just stays
+// blank. Deliberately fixed rather than computed from the image's real
+// dimensions: those aren't known until an async fetch completes, and
+// reflowing the whole card once they arrive is real complexity this spike
+// doesn't need yet (see the plan).
+const inlineImageMaxRows = 8
+
+// inlineImageBandRows is the total number of lines spliceImageBand reserves
+// per image: one blank spacer line, the image's own rows, one more blank
+// spacer line — so consecutive inline images (or an image and surrounding
+// text) never look like they're touching. The image itself is drawn
+// starting one line into the band (see renderBodyWithInlineImage).
+const inlineImageBandRows = inlineImageMaxRows + 2
+
+// inlineImageEncodeMaxRows is what InlineImageSlot.MaxRows is actually set
+// to — inlineImageMaxRows minus a small safety margin, not the full budget.
+// Kitty/iTerm2 tell the terminal "display this in exactly N rows" and it
+// scales to fit, so they're self-correcting; Sixel has no such instruction —
+// it just emits raw pixels, and how many terminal rows those actually cover
+// depends on TerminalCellPixelSize's cell-height estimate, which is only
+// ever approximate (some terminals don't report real geometry at all, and
+// the fallback is a hardcoded guess). An image that exactly fills the
+// reserved band has zero margin for that estimate to be wrong; a tall/narrow
+// image that hits the row cap is the case that actually shows it — wide
+// images naturally end up shorter than the cap and have slack regardless.
+// ponytail: a fixed fudge factor, not a measured one — tune (or replace with
+// something that reads the terminal's real font metrics) if 2 rows isn't
+// enough slack on some terminal/font combination.
+const inlineImageEncodeMaxRows = inlineImageMaxRows - 2
+
+// postImageSlot is the eligible inline image found for one post/reply card,
+// in that card's own line coordinates (0-based from the first line of the
+// string that card's render function returns, i.e. including its border).
+// URL == "" means no eligible image.
+type postImageSlot struct {
+	URL  string
+	Line int
+}
+
+// InlineImageSlot is a post/reply's inline image location in viewport
+// coordinates, as reported by a screen's VisibleInlineImages(). App uses
+// this purely as a "where, if anywhere" query each frame — it doesn't fetch,
+// encode, or track placement/cache state itself.
+type InlineImageSlot struct {
+	URL       string
+	Row       int // viewport-relative row (0 = top of the visible viewport)
+	ColIndent int // left padding (border + card indent) before the image starts
+	MaxCols   int
+	MaxRows   int
+	Key       string // stable per post/reply, for placement tracking (Kitty) and caching
+}
+
+// spliceImageBand replaces lines[at] with n blank lines, reserving room for
+// an inline image to be overlaid at that position later. Returns lines
+// unchanged if at is out of range.
+func spliceImageBand(lines []string, at, n int) []string {
+	if at < 0 || at >= len(lines) {
+		return lines
+	}
+	out := make([]string, 0, len(lines)+n-1)
+	out = append(out, lines[:at]...)
+	for i := 0; i < n; i++ {
+		out = append(out, "")
+	}
+	out = append(out, lines[at+1:]...)
+	return out
+}
+
+// spliceInlineImageBands splices a reserved, spacer-inclusive band into
+// lines for every hit, in document order, tracking the shift each earlier
+// splice introduces so later hits still land at the right spot (splicing at
+// line N shifts everything after N down by inlineImageBandRows-1). A hit
+// whose current (shift-adjusted) position falls outside lines is skipped —
+// this is what makes a hit past a truncation cutoff (e.g. Feed's
+// postMaxBodyLines) simply disappear, the same way its plain-text
+// placeholder would have been truncated away. lineBase translates each
+// hit's position into the caller's card-local coordinate space for the
+// returned slots.
+func spliceInlineImageBands(lines []string, hits []markdown.ImageHit, lineBase int) ([]string, []postImageSlot) {
+	var slots []postImageSlot
+	shift := 0
+	for _, h := range hits {
+		at := h.Line + shift
+		if at < 0 || at >= len(lines) {
+			continue
+		}
+		lines = spliceImageBand(lines, at, inlineImageBandRows)
+		slots = append(slots, postImageSlot{URL: h.URL, Line: lineBase + at + 1})
+		shift += inlineImageBandRows - 1
+	}
+	return lines, slots
+}

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -44,8 +44,16 @@ type SharedConfigMsg struct {
 	MaxThreadDepth int
 	Timezone       string
 	ImageViewer    string
-	OwnGuildSlug   string
-	LayoutName     string // "tabs" or "miller"; used by settings screen to show current value
+	// InlineImages is the user's raw preference (config.Config.InlineImages),
+	// used by the settings screen to display/edit the toggle.
+	InlineImages bool
+	// InlineImagesEnabled is the fully-gated value — InlineImages AND a
+	// graphics protocol is available AND ImageViewer != "browser" AND the
+	// session isn't ephemeral (SSH-hosted). Feed and PostDetail should check
+	// only this field; they never need to know about the individual gates.
+	InlineImagesEnabled bool
+	OwnGuildSlug        string
+	LayoutName          string // "tabs" or "miller"; used by settings screen to show current value
 }
 
 // URLProvider is implemented by screens that can expose URLs from their
@@ -97,6 +105,7 @@ type SaveSettingsMsg struct {
 	MaxThreadDepth int
 	Timezone       string
 	ImageViewer    string
+	InlineImages   bool
 	LayoutName     string // "tabs" or "miller"
 	RemoteChanged  bool   // true when API-managed fields differ from the last saved baseline
 }

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -102,19 +102,27 @@ type SubmitReplyMsg struct {
 }
 
 type PostDetailModel struct {
-	post          model.Post
-	replies       []model.Reply
-	flatTree      []replyNode // DFS-ordered tree walk; len always == len(replies)
-	replyOffsets  []int       // start line of each reply within the viewport content
-	replyHeights  []int       // rendered height of each reply (matches offsets; set by buildContent)
-	postHeight    int         // rendered height of the full post block; set by refreshContent
-	selectedReply int
-	viewport      viewport.Model
-	width         int
-	height        int
-	ready         bool
-	loading       bool
-	err           error
+	post         model.Post
+	replies      []model.Reply
+	flatTree     []replyNode // DFS-ordered tree walk; len always == len(replies)
+	replyOffsets []int       // start line of each reply within the viewport content
+	replyHeights []int       // rendered height of each reply (matches offsets; set by buildContent)
+	postHeight   int         // rendered height of the full post block; set by refreshContent
+
+	// inlineImagesEnabled mirrors SharedConfigMsg.InlineImagesEnabled — the
+	// fully-gated value (config flag AND protocol available AND imageViewer
+	// != "browser" AND not an ephemeral SSH session). postImages/replyImages
+	// are only ever populated when this is true.
+	inlineImagesEnabled bool
+	postImages          []postImageSlot   // every eligible image in the post; set by buildContent
+	replyImages         [][]postImageSlot // parallel to flatTree/replyOffsets — one slice per reply; set by buildContent
+	selectedReply       int
+	viewport            viewport.Model
+	width               int
+	height              int
+	ready               bool
+	loading             bool
+	err                 error
 
 	compose           ComposeModel
 	replyPostID       string         // postID set when compose opens
@@ -392,10 +400,12 @@ func (m PostDetailModel) viewportHeight() int {
 }
 
 func (m PostDetailModel) refreshContent() PostDetailModel {
-	content, offsets, heights, postH := m.buildContent()
+	content, offsets, heights, postH, postImgs, replyImgs := m.buildContent()
 	m.replyOffsets = offsets
 	m.replyHeights = heights
 	m.postHeight = postH
+	m.postImages = postImgs
+	m.replyImages = replyImgs
 	m.viewport.SetContent(content)
 	return m
 }
@@ -410,7 +420,8 @@ func (m PostDetailModel) ensureSelectedVisible() PostDetailModel {
 	if m.selectedReply == -1 {
 		// Post is selected — it always starts at line 0.
 		itemStart = 0
-		itemHeight = lipgloss.Height(m.renderFullPost(true))
+		fullPost, _ := m.renderFullPost(true)
+		itemHeight = lipgloss.Height(fullPost)
 	} else {
 		if len(m.replyOffsets) == 0 || m.selectedReply >= len(m.flatTree) {
 			return m
@@ -441,11 +452,15 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case SharedConfigMsg:
 		m.timeDisplayFormat = msg.Settings.TimeDisplayFormat
+		imagesChanged := msg.InlineImagesEnabled != m.inlineImagesEnabled
+		m.inlineImagesEnabled = msg.InlineImagesEnabled
 		m = m.SetRelaxed(msg.Relaxed)
 		m = m.SetLocation(msg.Loc)
 		if msg.MaxThreadDepth != m.maxThreadDepth {
 			m.maxThreadDepth = msg.MaxThreadDepth
 			m = m.applyReplies(m.replies)
+		} else if imagesChanged && m.ready {
+			m = m.refreshContent()
 		}
 		return m, nil
 
@@ -691,8 +706,8 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 // the rendered height of each reply, and the rendered height of the post block.
 // Heights are measured here once so that ensureSelectedVisible and the pager
 // always use the same values that were used to lay out the content.
-func (m PostDetailModel) buildContent() (string, []int, []int, int) {
-	postContent := m.renderFullPost(m.selectedReply == -1)
+func (m PostDetailModel) buildContent() (content string, offsets []int, heights []int, postH int, postImgs []postImageSlot, replyImgs [][]postImageSlot) {
+	postContent, postImgs := m.renderFullPost(m.selectedReply == -1)
 	var repliesHeaderText string
 	total := m.post.RepliesCount
 	loaded := len(m.replies)
@@ -721,17 +736,17 @@ func (m PostDetailModel) buildContent() (string, []int, []int, int) {
 	sb.WriteString(repliesHeader)
 	sb.WriteString(sep)
 
-	postH := lipgloss.Height(postContent)
+	postH = lipgloss.Height(postContent)
 
 	if m.loading {
 		sb.WriteString(theme.Subtle.Render("  loading replies…"))
 		sb.WriteString("\n")
-		return sb.String(), nil, nil, postH
+		return sb.String(), nil, nil, postH, postImgs, nil
 	}
 	if len(m.replies) == 0 {
 		sb.WriteString(theme.Subtle.Render("  no replies yet"))
 		sb.WriteString("\n")
-		return sb.String(), nil, nil, postH
+		return sb.String(), nil, nil, postH, postImgs, nil
 	}
 
 	// Base line where first reply starts.
@@ -743,13 +758,15 @@ func (m PostDetailModel) buildContent() (string, []int, []int, int) {
 	} else {
 		baseLines = postH + lipgloss.Height(repliesHeader)
 	}
-	offsets := make([]int, len(m.flatTree))
-	heights := make([]int, len(m.flatTree))
+	offsets = make([]int, len(m.flatTree))
+	heights = make([]int, len(m.flatTree))
+	replyImgs = make([][]postImageSlot, len(m.flatTree))
 	currentLine := baseLines
 
 	for i, node := range m.flatTree {
 		offsets[i] = currentLine
-		rendered := m.renderReply(node, i == m.selectedReply)
+		rendered, replyImgsForNode := m.renderReply(node, i == m.selectedReply)
+		replyImgs[i] = replyImgsForNode
 		h := lipgloss.Height(rendered)
 		heights[i] = h
 		sb.WriteString(rendered)
@@ -761,10 +778,10 @@ func (m PostDetailModel) buildContent() (string, []int, []int, int) {
 		}
 	}
 
-	return sb.String(), offsets, heights, postH
+	return sb.String(), offsets, heights, postH, postImgs, replyImgs
 }
 
-func (m PostDetailModel) renderFullPost(selected bool) string {
+func (m PostDetailModel) renderFullPost(selected bool) (string, []postImageSlot) {
 	innerWidth := m.width - 4
 
 	_, postBookmarked := m.bookmarkedPostIDs[m.post.ID]
@@ -774,7 +791,7 @@ func (m PostDetailModel) renderFullPost(selected bool) string {
 		theme.Subtle.Render("  "+displayTime(m.post.CreatedAt, m.location(), m.timeDisplayFormat, false)),
 	) + audioIcon(m.post.Attachments) + bookmarkIcon(postBookmarked) + watchIcon(postWatched)
 	var rightParts []string
-	if ind := attachmentIndicator(m.post.Attachments); ind != "" {
+	if ind := attachmentIndicator(m.post.Attachments, m.post.Content); ind != "" {
 		rightParts = append(rightParts, ind)
 	}
 	right := strings.Join(rightParts, " ")
@@ -803,7 +820,15 @@ func (m PostDetailModel) renderFullPost(selected bool) string {
 	}
 	badges := strings.Join(badgeParts, "  ")
 
-	body := markdown.Render(m.post.Content, innerWidth)
+	rows := []string{header}
+	if badges != "" {
+		rows = append(rows, badges)
+	}
+	if m.post.Title != "" {
+		rows = append(rows, theme.Title.Render(m.post.Title))
+	}
+
+	body, imgSlots := m.renderBodyWithInlineImage(m.post.Content, innerWidth, 1+lipgloss.Height(lipgloss.JoinVertical(lipgloss.Left, rows...)))
 	if att := renderAttachments(m.post.Attachments); att != "" {
 		body = body + "\n" + att
 	}
@@ -822,18 +847,38 @@ func (m PostDetailModel) renderFullPost(selected bool) string {
 		boxStyle = boxStyle.Width(m.width - 2)
 	}
 
-	rows := []string{header}
-	if badges != "" {
-		rows = append(rows, badges)
-	}
-	if m.post.Title != "" {
-		rows = append(rows, theme.Title.Render(m.post.Title))
-	}
 	rows = append(rows, body, fmt.Sprintf("\n%s", topics))
-	return boxStyle.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+	return boxStyle.Render(lipgloss.JoinVertical(lipgloss.Left, rows...)), imgSlots
 }
 
-func (m PostDetailModel) renderReply(node replyNode, selected bool) string {
+// renderBodyWithInlineImage renders content at innerWidth, splicing in an
+// inlineImageBandRows-tall reserved band (spacer + inlineImageMaxRows image
+// rows + spacer) in place of each eligible image's placeholder line, when
+// inline images are enabled. lineBase is the number of lines that will
+// precede body in the card this is embedded in (border top row +
+// header/badges/title), used to translate each image's body-local line into
+// a card-local one. Returns the plain-Render output, unchanged, when inline
+// images are disabled or no eligible image is found.
+//
+// Splicing shifts every line after the insertion point down by
+// (inlineImageBandRows - 1); processing hits in ascending/document order and
+// accumulating that shift as we go means each hit's original Line, plus the
+// shift accumulated from only the earlier hits already spliced in, is always
+// the correct current insertion point — no need to re-scan or recompute
+// anything after the fact.
+func (m PostDetailModel) renderBodyWithInlineImage(content string, innerWidth, lineBase int) (string, []postImageSlot) {
+	if !m.inlineImagesEnabled {
+		return markdown.Render(content, innerWidth), nil
+	}
+	rendered, hits := markdown.RenderLocatingImages(content, innerWidth)
+	if len(hits) == 0 {
+		return rendered, nil
+	}
+	lines, slots := spliceInlineImageBands(strings.Split(rendered, "\n"), hits, lineBase)
+	return strings.Join(lines, "\n"), slots
+}
+
+func (m PostDetailModel) renderReply(node replyNode, selected bool) (string, []postImageSlot) {
 	indentW := node.Depth * 3
 	cardWidth := m.width - 2 - indentW
 	innerWidth := cardWidth - 2
@@ -848,7 +893,7 @@ func (m PostDetailModel) renderReply(node replyNode, selected bool) string {
 	_, replyBookmarked := m.bookmarkedReplyIDs[node.Reply.ID]
 	left := lipgloss.JoinHorizontal(lipgloss.Top, headerParts...) + audioIcon(node.Reply.Attachments) + bookmarkIcon(replyBookmarked)
 	var replyRightParts []string
-	if ind := attachmentIndicator(node.Reply.Attachments); ind != "" {
+	if ind := attachmentIndicator(node.Reply.Attachments, node.Reply.Content); ind != "" {
 		replyRightParts = append(replyRightParts, ind)
 	}
 	replyRight := strings.Join(replyRightParts, " ")
@@ -860,7 +905,9 @@ func (m PostDetailModel) renderReply(node replyNode, selected bool) string {
 		}
 	}
 
-	body := markdown.Render(node.Reply.Content, innerWidth)
+	// lineBase: 1 border-top row + 1 header row (header is always a single
+	// JoinHorizontal line here, unlike the full post's optional badges/title).
+	body, imgSlots := m.renderBodyWithInlineImage(node.Reply.Content, innerWidth, 2)
 	if att := renderAttachments(node.Reply.Attachments); att != "" {
 		body = body + "\n" + att
 	}
@@ -874,9 +921,9 @@ func (m PostDetailModel) renderReply(node replyNode, selected bool) string {
 	}
 	card := boxStyle.Render(lipgloss.JoinVertical(lipgloss.Left, header, body))
 	if indentW > 0 {
-		return lipgloss.NewStyle().MarginLeft(indentW).Render(card)
+		return lipgloss.NewStyle().MarginLeft(indentW).Render(card), imgSlots
 	}
-	return card
+	return card, imgSlots
 }
 
 func (m PostDetailModel) View() string {
@@ -937,4 +984,53 @@ func (m PostDetailModel) GetFocusedURLs() []string {
 		return append(extractURLs(r.Content), attachmentURLs(r.Attachments)...)
 	}
 	return append(extractURLs(m.post.Content), attachmentURLs(m.post.Attachments)...)
+}
+
+// VisibleInlineImages returns the inline image slots (post + replies)
+// currently fully within the viewport, top to bottom. It's purely a "where,
+// if anywhere" query — App's rendering step owns fetching, encoding, and any
+// placement/cache state; this just reports positions for the current frame.
+// An image only counts as visible when its entire reserved row band fits in
+// [YOffset, YOffset+Height) — no partial-visibility clipping (see the plan).
+func (m PostDetailModel) VisibleInlineImages() []InlineImageSlot {
+	if !m.ready || !m.inlineImagesEnabled {
+		return nil
+	}
+	top, bottom := m.viewport.YOffset, m.viewport.YOffset+m.viewport.Height
+
+	var slots []InlineImageSlot
+	for i, img := range m.postImages {
+		if img.Line < top || img.Line+inlineImageMaxRows > bottom {
+			continue
+		}
+		slots = append(slots, InlineImageSlot{
+			URL:       img.URL,
+			Row:       img.Line - top,
+			ColIndent: 2,
+			MaxCols:   m.width - 4,
+			MaxRows:   inlineImageEncodeMaxRows,
+			Key:       fmt.Sprintf("post:%s:%d", m.post.ID, i),
+		})
+	}
+	for i, node := range m.flatTree {
+		if i >= len(m.replyImages) {
+			continue
+		}
+		indentW := node.Depth * 3
+		for j, img := range m.replyImages[i] {
+			abs := m.replyOffsets[i] + img.Line
+			if abs < top || abs+inlineImageMaxRows > bottom {
+				continue
+			}
+			slots = append(slots, InlineImageSlot{
+				URL:       img.URL,
+				Row:       abs - top,
+				ColIndent: 2 + indentW,
+				MaxCols:   m.width - 4 - indentW,
+				MaxRows:   inlineImageEncodeMaxRows,
+				Key:       fmt.Sprintf("reply:%s:%d", node.Reply.ID, j),
+			})
+		}
+	}
+	return slots
 }

--- a/internal/ui/screens/postdetail_test.go
+++ b/internal/ui/screens/postdetail_test.go
@@ -210,6 +210,86 @@ func TestPostDetail_PaginationRebuildsTree(t *testing.T) {
 	}
 }
 
+// TestPostDetail_VisibleInlineImages_DisabledByDefault confirms that with no
+// SharedConfigMsg.InlineImagesEnabled ever sent (the default), no slots are
+// reported even for a post whose content has an eligible image — the whole
+// feature must be a strict no-op until explicitly turned on.
+func TestPostDetail_VisibleInlineImages_DisabledByDefault(t *testing.T) {
+	m := initPostDetail()
+	post := pdPost("p1")
+	post.Content = "hi\n\n![a](https://example.com/a.png)\n\nbye"
+	m = m.SetPost(post)
+
+	if slots := m.VisibleInlineImages(); slots != nil {
+		t.Errorf("expected no slots while disabled, got %+v", slots)
+	}
+}
+
+// TestPostDetail_VisibleInlineImages_PostAndReply confirms that once enabled,
+// both the post's and a top-level reply's eligible image are reported, in
+// order, with the URL/Key/indent expected for each.
+func TestPostDetail_VisibleInlineImages_PostAndReply(t *testing.T) {
+	m := initPostDetail()
+	// Taller than the default 40 rows: the post's own reserved image band
+	// plus its header/border already takes a good chunk of the viewport, so
+	// a short viewport would legitimately cut the reply's image band off —
+	// this test wants both fully visible, not to exercise that cutoff.
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 60})
+	m, _ = m.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+
+	post := pdPost("p1")
+	post.Content = "hi\n\n![a](https://example.com/a.png)\n\nbye"
+	m = m.SetPost(post)
+
+	reply := pdReply("r1", "", "someone", time.Now())
+	reply.Content = "check this\n\n![b](https://example.com/b.png)"
+	m = m.SetReplies([]model.Reply{reply})
+
+	slots := m.VisibleInlineImages()
+	if len(slots) != 2 {
+		t.Fatalf("expected 2 visible slots (post + reply), got %d: %+v", len(slots), slots)
+	}
+	if slots[0].URL != "https://example.com/a.png" || slots[0].Key != "post:p1:0" || slots[0].ColIndent != 2 {
+		t.Errorf("unexpected post slot: %+v", slots[0])
+	}
+	if slots[1].URL != "https://example.com/b.png" || slots[1].Key != "reply:r1:0" || slots[1].ColIndent != 2 {
+		t.Errorf("unexpected reply slot: %+v", slots[1])
+	}
+	if slots[1].Row <= slots[0].Row {
+		t.Errorf("expected reply slot to be below the post slot: post Row=%d, reply Row=%d", slots[0].Row, slots[1].Row)
+	}
+}
+
+// TestPostDetail_VisibleInlineImages_MultipleImagesInOnePost confirms every
+// eligible image in a single post is reported (not just the first), each
+// with its own index-suffixed Key, and that the second image's Row accounts
+// for the first image's full spacer-inclusive band plus the text paragraph
+// between them — the one thing renderBodyWithInlineImage's shift-tracking
+// loop exists to get right.
+func TestPostDetail_VisibleInlineImages_MultipleImagesInOnePost(t *testing.T) {
+	m := initPostDetail()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 80})
+	m, _ = m.Update(screens.SharedConfigMsg{InlineImagesEnabled: true})
+
+	post := pdPost("p1")
+	post.Content = "one\n\n![a](https://example.com/a.png)\n\ntwo\n\n![b](https://example.com/b.png)\n\nthree"
+	m = m.SetPost(post)
+
+	slots := m.VisibleInlineImages()
+	if len(slots) != 2 {
+		t.Fatalf("expected 2 slots for 2 images in one post, got %d: %+v", len(slots), slots)
+	}
+	if slots[0].Key != "post:p1:0" || slots[1].Key != "post:p1:1" {
+		t.Errorf("expected distinct per-image keys, got %q and %q", slots[0].Key, slots[1].Key)
+	}
+	// inlineImageMaxRows(8) + 2 spacer rows is the minimum gap between two
+	// images with nothing but a one-line paragraph between them.
+	const minGap = 10
+	if got := slots[1].Row - slots[0].Row; got < minGap {
+		t.Errorf("expected at least %d rows between images, got %d (rows %d, %d)", minGap, got, slots[0].Row, slots[1].Row)
+	}
+}
+
 // TestPostDetail_DepthCap verifies that a chain deeper than 3 levels does not
 // panic and that all replies remain reachable via navigation.
 func TestPostDetail_DepthCap(t *testing.T) {

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ragnar/cyber-tui/internal/sanitize"
 	"github.com/ragnar/cyber-tui/internal/ui/markdown"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
+	"github.com/ragnar/cyber-tui/internal/ui/urlutil"
 )
 
 const postMaxBodyLines = 4
@@ -23,7 +24,7 @@ const postMaxBodyLines = 4
 // maxBodyLines caps body text at that many lines (postMaxBodyLines for list views,
 // 0 for the reading pane where the full content should be shown).
 func RenderPost(p model.Post, selected bool, bookmarked bool, watched bool, width int, loc *time.Location, timeFormat string, maxBodyLines int) string {
-	content := renderPostBody(p, bookmarked, watched, width, loc, timeFormat, maxBodyLines)
+	content, _ := renderPostBody(p, bookmarked, watched, width, loc, timeFormat, maxBodyLines, false)
 	boxStyle := theme.Border
 	if selected {
 		boxStyle = theme.ActiveBorder
@@ -40,8 +41,10 @@ func RenderPost(p model.Post, selected bool, bookmarked bool, watched bool, widt
 // so a caller re-rendering only because the selection moved (e.g. feed.go's
 // arrow-key navigation) can cache this per post ID/width and skip the
 // markdown re-parse, instead of rebuilding every loaded post on every
-// keystroke.
-func renderPostBody(p model.Post, bookmarked bool, watched bool, width int, loc *time.Location, timeFormat string, maxBodyLines int) string {
+// keystroke. inlineImagesEnabled is false for every RenderPost caller
+// (Search/Guilds/Topics/Miller panes) — only FeedModel's own list-view
+// renderer opts in, so the returned []postImageSlot is always nil elsewhere.
+func renderPostBody(p model.Post, bookmarked bool, watched bool, width int, loc *time.Location, timeFormat string, maxBodyLines int, inlineImagesEnabled bool) (string, []postImageSlot) {
 	innerWidth := width - 4
 
 	left := lipgloss.JoinHorizontal(lipgloss.Top,
@@ -49,7 +52,7 @@ func renderPostBody(p model.Post, bookmarked bool, watched bool, width int, loc 
 		theme.Subtle.Render("  "+displayTime(p.CreatedAt, loc, timeFormat, false)),
 	) + audioIcon(p.Attachments) + bookmarkIcon(bookmarked) + watchIcon(watched)
 	var rightParts []string
-	if ind := attachmentIndicator(p.Attachments); ind != "" {
+	if ind := attachmentIndicator(p.Attachments, p.Content); ind != "" {
 		rightParts = append(rightParts, ind)
 	}
 	switch p.RepliesCount {
@@ -86,16 +89,50 @@ func renderPostBody(p model.Post, bookmarked bool, watched bool, width int, loc 
 	}
 	badges := strings.Join(badgeParts, "  ")
 
+	rows := []string{header}
+	if badges != "" {
+		rows = append(rows, badges)
+	}
+	if p.Title != "" {
+		rows = append(rows, theme.Highlight.Render(p.Title))
+	}
+	// 1 = the card's own top border row, added by RenderPost/FeedModel.renderPost.
+	lineBase := 1 + lipgloss.Height(lipgloss.JoinVertical(lipgloss.Left, rows...))
+
 	var body string
+	var imgSlots []postImageSlot
 	if innerWidth > 0 {
-		rendered := markdown.Render(p.Content, innerWidth)
-		lines := strings.Split(rendered, "\n")
-		if maxBodyLines > 0 && len(lines) > maxBodyLines {
-			body = strings.Join(lines[:maxBodyLines], "\n")
-			more := len(lines) - maxBodyLines
-			body += "\n" + theme.Subtle.Render(fmt.Sprintf("  ▼ %d more lines", more))
+		if inlineImagesEnabled {
+			rendered, hits := markdown.RenderLocatingImages(p.Content, innerWidth)
+			// Feed's card is compact and truncates body text to maxBodyLines,
+			// so a post's later images can already fall past that cutoff and
+			// simply not fit — capping to the first eligible image here keeps
+			// Feed predictable rather than showing a variable 0..N of them.
+			// PostDetail (no text truncation) still shows every eligible image.
+			if len(hits) > 1 {
+				hits = hits[:1]
+			}
+			lines := strings.Split(rendered, "\n")
+			more := 0
+			if maxBodyLines > 0 && len(lines) > maxBodyLines {
+				more = len(lines) - maxBodyLines
+				lines = lines[:maxBodyLines]
+			}
+			lines, imgSlots = spliceInlineImageBands(lines, hits, lineBase)
+			body = strings.Join(lines, "\n")
+			if more > 0 {
+				body += "\n" + theme.Subtle.Render(fmt.Sprintf("  ▼ %d more lines", more))
+			}
 		} else {
-			body = rendered
+			rendered := markdown.Render(p.Content, innerWidth)
+			lines := strings.Split(rendered, "\n")
+			if maxBodyLines > 0 && len(lines) > maxBodyLines {
+				body = strings.Join(lines[:maxBodyLines], "\n")
+				more := len(lines) - maxBodyLines
+				body += "\n" + theme.Subtle.Render(fmt.Sprintf("  ▼ %d more lines", more))
+			} else {
+				body = rendered
+			}
 		}
 	} else {
 		body = markdown.Render(p.Content, 0)
@@ -111,30 +148,45 @@ func renderPostBody(p model.Post, bookmarked bool, watched bool, width int, loc 
 	}
 	topics := topicsSB.String()
 
-	body = strings.TrimRight(body, "\n")
-	rows := []string{header}
-	if badges != "" {
-		rows = append(rows, badges)
-	}
-	if p.Title != "" {
-		rows = append(rows, theme.Highlight.Render(p.Title))
+	if len(imgSlots) == 0 {
+		// Only safe when nothing was spliced in: an image band's reserved
+		// rows are blank strings, and when the last image in a post has no
+		// text after it (common — many posts end right on the image),
+		// blindly trimming trailing "\n"s deletes that whole reservation,
+		// shrinking the card below what VisibleInlineImages/App assume it
+		// occupies and letting the image paint into the next post's card.
+		body = strings.TrimRight(body, "\n")
 	}
 	rows = append(rows, body)
 	if topics != "" {
 		rows = append(rows, "\n"+topics)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, rows...)
+	return lipgloss.JoinVertical(lipgloss.Left, rows...), imgSlots
 }
 
-// attachmentIndicator returns a compact header badge for any attachments present,
-// e.g. "[img]". Returns "" when there are no attachments.
-func attachmentIndicator(attachments []model.Attachment) string {
+// attachmentIndicator returns a compact header badge for any images present
+// — counting both structured image/gif Attachments and images embedded as
+// markdown syntax in content (most real posts use the latter; see
+// urlutil.CountImages) — e.g. "[img]" for one, "[img +2]" when there are
+// more beyond the first (the count beyond what inline rendering shows, and
+// what the carousel modal has left to page through). Returns "" when there
+// are no images at all — audio attachments get their own icon (audioIcon).
+func attachmentIndicator(attachments []model.Attachment, content string) string {
+	n := 0
 	for _, a := range attachments {
-		if a.Type == "image" {
-			return theme.Subtle.Render("[img]")
+		if a.Type == "image" || a.Type == "gif" {
+			n++
 		}
 	}
-	return ""
+	n += urlutil.CountImages(content)
+	switch {
+	case n == 0:
+		return ""
+	case n == 1:
+		return theme.Subtle.Render("[img]")
+	default:
+		return theme.Subtle.Render(fmt.Sprintf("[img +%d]", n-1))
+	}
 }
 
 // audioIcon returns a ♫ icon (with leading spaces) when any attachment is audio, else "".

--- a/internal/ui/screens/render_test.go
+++ b/internal/ui/screens/render_test.go
@@ -465,6 +465,44 @@ func TestRenderAttachments_GifBadge(t *testing.T) {
 	}
 }
 
+// TestAttachmentIndicator_CountsImages confirms the badge is blank with no
+// images, flat "[img]" for exactly one, and "[img +N]" (extra beyond the one
+// inline rendering shows) for multiple — audio attachments never count, and
+// markdown-embedded images (the actual mechanism real posts use — see the
+// "markdown only" cases) count the same as structured Attachments.
+func TestAttachmentIndicator_CountsImages(t *testing.T) {
+	cases := []struct {
+		name        string
+		attachments []model.Attachment
+		content     string
+		want        string
+	}{
+		{"none", nil, "just text", ""},
+		{"audio only", []model.Attachment{{Type: "audio"}}, "", ""},
+		{"one image", []model.Attachment{{Type: "image"}}, "", "[img]"},
+		{"one gif", []model.Attachment{{Type: "gif"}}, "", "[img]"},
+		{"image plus gif", []model.Attachment{{Type: "image"}, {Type: "gif"}}, "", "[img +1]"},
+		{"three images", []model.Attachment{{Type: "image"}, {Type: "audio"}, {Type: "image"}, {Type: "image"}}, "", "[img +2]"},
+		{"markdown only, one image", nil, "hi\n\n![a](https://x/a.png)\n\n", "[img]"},
+		{"markdown only, two images", nil, "![a](https://x/a.png)\n\n![b](https://x/b.png)\n\n", "[img +1]"},
+		{"attachment plus markdown image", []model.Attachment{{Type: "audio"}}, "![a](https://x/a.png)\n\n", "[img]"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := attachmentIndicator(c.attachments, c.content)
+			if c.want == "" {
+				if out != "" {
+					t.Errorf("expected no badge, got: %q", out)
+				}
+				return
+			}
+			if !strings.Contains(out, c.want) {
+				t.Errorf("expected badge to contain %q, got: %q", c.want, out)
+			}
+		})
+	}
+}
+
 // TestRenderCircMessages_AttachmentOnlyBodySkipsDuplicateURL confirms that
 // when Body merely duplicates ImageUrl (an attachment-only message), the URL
 // is shown once via the attachment badge, not a second time as wrapped body text.
@@ -703,8 +741,8 @@ func TestFeedRenderPost_CachesBodyAcrossSelectionChange(t *testing.T) {
 	m.width = 80
 	post := model.Post{ID: "p1", AuthorUsername: "alice", Content: "hello world"}
 
-	unselected := m.renderPost(post, false)
-	selected := m.renderPost(post, true)
+	unselected, _ := m.renderPost(post, false)
+	selected, _ := m.renderPost(post, true)
 
 	if unselected == selected {
 		t.Error("expected selected vs unselected rendering to differ (border style)")
@@ -714,7 +752,7 @@ func TestFeedRenderPost_CachesBodyAcrossSelectionChange(t *testing.T) {
 	}
 
 	post.Content = "edited content"
-	edited := m.renderPost(post, false)
+	edited, _ := m.renderPost(post, false)
 	if strings.Contains(ansi.Strip(edited), "hello world") {
 		t.Error("expected cache to invalidate after post content changed, got stale body")
 	}

--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -166,6 +166,11 @@ var settingsGroups = []settingsGroup{
 					return m
 				},
 			},
+			{
+				label: "inline images (experimental)", kind: "bool",
+				getBool: func(m SettingsModel) bool { return m.inlineImages },
+				toggle:  func(m SettingsModel) SettingsModel { m.inlineImages = !m.inlineImages; return m },
+			},
 		},
 	},
 	{
@@ -192,6 +197,8 @@ type SettingsModel struct {
 	originalTimezone       string         // last saved baseline
 	imageViewer            string         // live local config value ("terminal" or "browser")
 	originalImageViewer    string         // last saved baseline
+	inlineImages           bool           // live local config value
+	originalInlineImages   bool           // last saved baseline
 	layoutName             string         // live local config value ("tabs" or "miller")
 	originalLayoutName     string         // last saved baseline
 	cursor                 int
@@ -216,7 +223,7 @@ func (m SettingsModel) SetSettings(s model.Settings) SettingsModel {
 }
 
 // SetSaved marks the current settings as saved and advances the baseline.
-func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, imageViewer, layoutName string) SettingsModel {
+func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, imageViewer string, inlineImages bool, layoutName string) SettingsModel {
 	m.saved = true
 	m.err = nil
 	m.original = m.settings
@@ -228,6 +235,8 @@ func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, i
 	m.originalTimezone = timezone
 	m.imageViewer = imageViewer
 	m.originalImageViewer = imageViewer
+	m.inlineImages = inlineImages
+	m.originalInlineImages = inlineImages
 	m.layoutName = layoutName
 	m.originalLayoutName = layoutName
 	return m
@@ -246,6 +255,7 @@ func (m SettingsModel) IsDirty() bool {
 		m.maxThreadDepth != m.originalMaxThreadDepth ||
 		m.timezone != m.originalTimezone ||
 		m.imageViewer != m.originalImageViewer ||
+		m.inlineImages != m.originalInlineImages ||
 		m.layoutName != m.originalLayoutName
 }
 
@@ -330,6 +340,8 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			}
 			m.imageViewer = iv
 			m.originalImageViewer = iv
+			m.inlineImages = msg.InlineImages
+			m.originalInlineImages = msg.InlineImages
 			m.layoutName = msg.LayoutName
 			m.originalLayoutName = msg.LayoutName
 		}
@@ -381,10 +393,11 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				td := m.maxThreadDepth
 				tz := m.timezone
 				iv := m.imageViewer
+				ii := m.inlineImages
 				ln := m.layoutName
 				remoteChanged := !settingsEqual(m.settings, m.original)
 				return m, func() tea.Msg {
-					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, LayoutName: ln, RemoteChanged: remoteChanged}
+					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, InlineImages: ii, LayoutName: ln, RemoteChanged: remoteChanged}
 				}
 			}
 			return m, nil
@@ -396,6 +409,7 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			m.maxThreadDepth = m.originalMaxThreadDepth
 			m.timezone = m.originalTimezone
 			m.imageViewer = m.originalImageViewer
+			m.inlineImages = m.originalInlineImages
 			m.layoutName = m.originalLayoutName
 			m.saved = false
 			m.err = nil

--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -183,6 +183,29 @@ var settingsGroups = []settingsGroup{
 			},
 		},
 	},
+	{
+		title: "layout",
+		items: []settingsItem{
+			{
+				label: "layout", kind: "enum",
+				options: []string{"tabs", "miller"},
+				getEnum: func(m SettingsModel) string {
+					if m.layoutName == "miller" {
+						return "miller"
+					}
+					return "tabs"
+				},
+				cycle: func(m SettingsModel, delta int) SettingsModel {
+					cur := m.layoutName
+					if cur == "" {
+						cur = "tabs"
+					}
+					m.layoutName = cycleStringEnum(cur, []string{"tabs", "miller"}, delta)
+					return m
+				},
+			},
+		},
+	},
 }
 
 // SettingsModel is the Settings screen.

--- a/internal/ui/screens/settings_test.go
+++ b/internal/ui/screens/settings_test.go
@@ -250,7 +250,7 @@ func TestSettings_Esc_ClearsError(t *testing.T) {
 func TestSettings_SetSaved_ClearsError(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m = m.SetError(testErr)
-	m = m.SetSaved(false, 3, "UTC", "terminal", "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", false, "tabs")
 	if m.err != nil {
 		t.Error("SetSaved should clear error")
 	}
@@ -262,7 +262,7 @@ func TestSettings_SetSaved_AdvancesBaseline(t *testing.T) {
 	if !m.IsDirty() {
 		t.Error("should be dirty after change")
 	}
-	m = m.SetSaved(false, 3, "UTC", "terminal", "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", false, "tabs")
 	if m.IsDirty() {
 		t.Error("after SetSaved, should not be dirty")
 	}
@@ -387,7 +387,7 @@ func TestSettings_View_DirtyFooterHint(t *testing.T) {
 
 func TestSettings_View_SavedMessage(t *testing.T) {
 	m := initSettings(defaultSettings())
-	m = m.SetSaved(false, 3, "UTC", "terminal", "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", false, "tabs")
 	view := m.View()
 	if !containsSubstring(view, "saved!") {
 		t.Error("View should show 'saved!' when saved=true")
@@ -416,7 +416,7 @@ func TestSettings_WanderGroup_Visible(t *testing.T) {
 func TestSettings_WanderToggle(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
-	m.cursor = 11 // wander mode item
+	m.cursor = 12 // wander mode item
 	m, _ = m.Update(keyMsg("enter"))
 	if m.wanderLust {
 		t.Error("toggling wander mode should flip wanderLust to false")
@@ -458,7 +458,7 @@ func TestSettings_WanderSetSaved(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
 	m.originalWanderLust = false // dirty
-	m = m.SetSaved(true, 3, "UTC", "terminal", "tabs")
+	m = m.SetSaved(true, 3, "UTC", "terminal", false, "tabs")
 	if m.originalWanderLust != true {
 		t.Error("SetSaved should update originalWanderLust to the saved value")
 	}

--- a/internal/ui/urlutil/extract.go
+++ b/internal/ui/urlutil/extract.go
@@ -52,6 +52,27 @@ func ExtractURLs(content string) []string {
 	return urls
 }
 
+// CountImages returns the number of markdown image nodes in content, in
+// document order. Used for the post/reply header badge — deliberately
+// looser than any inline-rendering eligibility rule elsewhere: this counts
+// every ![alt](url), whether or not it would qualify for inline display.
+func CountImages(content string) int {
+	if strings.TrimSpace(content) == "" {
+		return 0
+	}
+	doc := md.Parser().Parse(text.NewReader([]byte(content)))
+	n := 0
+	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if _, ok := node.(*ast.Image); ok {
+				n++
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+	return n
+}
+
 // NormalizeURL prefixes relative paths with the cyberspace.online base URL.
 // Absolute URLs are returned unchanged.
 func NormalizeURL(u string) string {


### PR DESCRIPTION
## Summary

- Render post/reply images inline in Feed and PostDetail via Kitty, Sixel, and iTerm2/WezTerm graphics protocols, behind an off-by-default "inline images (experimental)" setting
- Fix Kitty lifecycle bugs found on real hardware (Ghostty): blunt delete-all colliding with the fullscreen modal, deletes lost to Bubble Tea's throttled renderer, a sticky cleanup flag, stale cache entries, and an unsuppressed protocol ACK misread as a keystroke — plus a `ProbeSixel` goroutine leak and stale placements left on toggle-off
- Finish `MillerLayout`: fix `layoutFromName` (previously discarded its argument and always returned `TabsLayout`), add a live-switching "layout" item to Settings, centralize the overlay-compositing logic that Miller had silently drifted out of sync on, and add Feed's own inline-image support for Miller's compact detail pane (post + reply images, which didn't exist before)
- Fix a Miller-only bug where nav keys stayed trapped inside a backgrounded Circ/CMail room after moving focus to the spaces column
- Bound the inline-image cache (LRU, 16 MiB), compress the Kitty payload to PNG (was raw RGBA), and add a cooldown for repeatedly-failing image fetches
- Three review docs (architecture, independent critique, a chafa-as-replacement evaluation) plus a consolidated improvement plan tracking what's done vs. deferred

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Manual verification against a real cyberspace.online account via tmux: layout switching (Settings save, live, both directions), Feed/PostDetail navigation and rendering in both layouts, Circ room open/background/resume/typing
- [ ] Kitty/Sixel/iTerm2 pixel-level rendering — not verifiable in this sandboxed environment (no graphics-capable terminal attached); covered instead by golden-output tests asserting the correct escape sequences are composited, and by this branch's own history of prior Ghostty-hardware bug fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)