### PR TITLE
fix: send doNotMoveCursor=1 in iTerm2-protocol image sequences

### DIFF
--- a/internal/ui/imgview/encode_test.go
+++ b/internal/ui/imgview/encode_test.go
@@ -186,6 +186,23 @@ func TestEncodeITerm2_ContainsOSC(t *testing.T) {
 	}
 }
 
+// TestEncodeITerm2_SetsDoNotMoveCursor is a regression test: without
+// doNotMoveCursor=1, WezTerm scrolls its whole screen once an inline image's
+// footprint reaches the terminal's last line (wezterm/wezterm#3266), which
+// desyncs every absolute-cursor-positioned draw injectInlineImages issues
+// afterward. The app never relies on the terminal's own post-image cursor
+// advance, so this is safe to always send.
+func TestEncodeITerm2_SetsDoNotMoveCursor(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	seq, _, _, err := imgview.EncodeITerm2(img, 80, 40, 0, 0)
+	if err != nil {
+		t.Fatalf("EncodeITerm2: %v", err)
+	}
+	if !strings.Contains(seq, "doNotMoveCursor=1") {
+		t.Errorf("EncodeITerm2: expected doNotMoveCursor=1, got %q", seq)
+	}
+}
+
 // TestEncodeITerm2_UsesRealCellSize mirrors TestEncodeSixel_UsesRealCellSize:
 // a 4x larger real cell size should need fewer cols/rows than the default
 // assumed cell size, confirming cellPxW/cellPxH actually drives the sizing

--- a/internal/ui/imgview/iterm2.go
+++ b/internal/ui/imgview/iterm2.go
@@ -35,8 +35,16 @@ func EncodeITerm2(img image.Image, maxCols, maxRows, cellPxW, cellPxH int) (enco
 	payload := base64.StdEncoding.EncodeToString(buf.Bytes())
 	cols, rows = fitBox(w, h, maxCols, maxRows, cellPxW, cellPxH)
 	// width/height without suffix means terminal character cells in iTerm2.
+	// doNotMoveCursor=1 is a WezTerm extension (ignored by real iTerm2, which
+	// tolerates unknown keys): without it, WezTerm scrolls its whole screen
+	// whenever an image's footprint reaches the terminal's last line
+	// (https://github.com/wezterm/wezterm/issues/3266), which desyncs every
+	// absolute-cursor-positioned draw that follows. Safe here regardless of
+	// terminal since injectInlineImages always repositions the cursor
+	// absolutely before every draw and parks it explicitly after — nothing
+	// relies on the terminal's own post-image cursor advance.
 	encoded = fmt.Sprintf(
-		"\x1b]1337;File=inline=1;width=%d;height=%d;preserveAspectRatio=1:%s\x07",
+		"\x1b]1337;File=inline=1;width=%d;height=%d;preserveAspectRatio=1;doNotMoveCursor=1:%s\x07",
 		cols, rows, payload,
 	)
 	return


### PR DESCRIPTION
## Summary

Fixes an inline-image scroll/distortion bug reported on WezTerm/Windows: scrolling a post's image into view near the bottom of the Feed tab caused the status bar to balloon by several lines and the image to render partially, offset to the wrong position.

## Root cause

WezTerm has a confirmed bug in its iTerm2-protocol implementation ([wezterm/wezterm#3266](https://github.com/wezterm/wezterm/issues/3266)): with the default `doNotMoveCursor=0`, WezTerm scrolls its whole screen when an image's footprint reaches the terminal's last line. That unrequested scroll desyncs every subsequent absolute-cursor-positioned draw `injectInlineImages` issues, producing the observed enlarged/duplicated status bar and misplaced image.

## Fix

Send `doNotMoveCursor=1` unconditionally in `EncodeITerm2`'s OSC 1337 sequence (`internal/ui/imgview/iterm2.go`). It's a WezTerm extension that real iTerm2 tolerates as an unrecognized key, so no `TERM_PROGRAM` branching is needed. The app never relied on the terminal's own post-image cursor advance — `injectInlineImages` always repositions the cursor absolutely before every draw and parks it explicitly afterward.

## Testing

- `go test ./...`, `go vet ./...`, `staticcheck ./...` all pass
- Added `TestEncodeITerm2_SetsDoNotMoveCursor` regression test
- User confirmed on WezTerm/Windows: status bar and post layout are now visually stable

## Known follow-up

A second, previously-obscured issue remains on WezTerm/Windows: the inline image space and fullscreen modal render black instead of the image, with a garbled fragment visible elsewhere on screen — suspected ConPTY interference with the large unchunked OSC 1337 payload. That's being investigated separately on another branch (switching WezTerm to the Kitty protocol with chunked transmission) and is out of scope for this PR.
