### PR TITLE
feat: chunk large Kitty graphics protocol payloads

### DIFF
--- a/docs/plan-inline-images-improvements.md
+++ b/docs/plan-inline-images-improvements.md
@@ -241,3 +241,63 @@ skipping this entirely.
 **Not yet touched**: a second `tea.ClearScreen` remains on modal *close* for Sixel
 specifically (`app.go`, gated to `imgview.ProtocolSixel`, not iTerm2) — out of scope for the
 iTerm2 carousel-cycle report above; worth revisiting if Sixel close-flash is ever reported.
+
+---
+
+## 9. WezTerm on Windows: scroll bug fixed; Kitty-protocol experiment ruled out, black image still open
+
+First real-world testing on WezTerm (Windows), reported by the user as a scrolled-into-view
+image causing the status bar to balloon by several lines and the image to render partially,
+offset from its intended position.
+
+**Root cause and fix (merged, PR #103)**: WezTerm has a confirmed bug in its iTerm2-protocol
+implementation — with the default `doNotMoveCursor=0`, it scrolls its whole screen when an
+image's footprint reaches the terminal's last line
+([wezterm/wezterm#3266](https://github.com/wezterm/wezterm/issues/3266)). That unrequested
+scroll desyncs every subsequent absolute-cursor-positioned draw `injectInlineImages` issues.
+Fixed by sending `doNotMoveCursor=1` unconditionally in `EncodeITerm2` — a WezTerm extension
+to OSC 1337 that real iTerm2 tolerates as an unrecognized key, so no `TERM_PROGRAM` branching
+was needed. The app never relied on the terminal's own post-image cursor advance anyway.
+
+**Second bug found once the first was fixed**: the inline image's reserved space rendered
+solid black, and the fullscreen modal (`o`) did too, with a garbled fragment visible
+elsewhere on screen. Likely present all along, just visually masked by the scroll
+distortion. Suspected cause: the app is a native Windows console process, so WezTerm's
+local-process panes on Windows are necessarily backed by ConPTY — a documented source of
+interference with long or unrecognized escape sequences
+([microsoft/terminal#15551](https://github.com/microsoft/terminal/issues/15551),
+[#17314](https://github.com/microsoft/terminal/issues/17314)). `EncodeITerm2` sends the
+whole image as one giant unchunked OSC 1337 sequence (several KB on one physical line) —
+a shape ConPTY is known to mishandle, and OSC 1337 has no official chunking mechanism to
+work around it.
+
+**Experiment (branch `fix/wezterm-kitty-graphics`, reverted)**: `DetectProtocol` was
+temporarily switched to map `TERM_PROGRAM=WezTerm` to `ProtocolKitty` instead of
+`ProtocolITerm2` — this had never been an explicit decision in the first place (see
+`protocol.go`'s original mapping, introduced in `71ff4e1` without discussion of the
+Kitty-vs-iTerm2 tradeoff for WezTerm specifically). `EncodeKitty` also gained chunked
+transmission (`chunkKittyPayload`, splitting large base64 payloads into 4096-byte pieces
+per the protocol's official chunked-transmission mode) as part of the same experiment —
+that code is harmless and spec-compliant on its own, independent of the WezTerm mapping
+question, and may be worth keeping/re-proposing separately.
+
+**Result: ruled out for Windows.** The user tested on WezTerm/Windows — the image still
+rendered black, just without the stray garbled fragment seen on the iTerm2 path. Research
+turned up [wezterm/wezterm#5757](https://github.com/wezterm/wezterm/issues/5757): **the
+Windows build of WezTerm does not implement the Kitty graphics protocol at all** — only
+iTerm2-protocol images work there (Linux supports both). So the black render was WezTerm
+silently ignoring an entirely unrecognized escape sequence, not evidence of anything fixed.
+That same issue also undermines the original ConPTY-corruption theory for the iTerm2 path:
+it notes a third-party tool (`timg -pi`) using the same iTerm2/OSC 1337 protocol renders
+correctly on WezTerm/Windows through the same ConPTY layer — so the transport itself isn't
+the problem, which points at something specific to cyber-tui's own OSC 1337 output or how
+it's delivered through Bubble Tea's renderer instead.
+
+`DetectProtocol` has been reverted to map WezTerm back to `ProtocolITerm2` unconditionally.
+
+**Next step, not yet done**: byte-level comparison of `EncodeITerm2`'s actual emitted
+sequence (captured from a live WezTerm/Windows session) against a known-working reference
+(`wezterm imgcat` / `timg -pi` on the same source image), plus testing whether a manual
+replay of the captured bytes outside Bubble Tea's renderer displays correctly — narrows the
+black-render bug down to cyber-tui's encoding vs. how `injectInlineImages` (`layout.go`)
+delivers it, before attempting another fix.

--- a/internal/ui/imgview/encode_test.go
+++ b/internal/ui/imgview/encode_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"image"
 	"image/color"
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -149,6 +150,59 @@ func TestEncodeKitty_UsesPNGFormat(t *testing.T) {
 	}
 	if len(raw) < 8 || !bytes.HasPrefix(raw, []byte("\x89PNG\r\n\x1a\n")) {
 		t.Errorf("expected the payload to be a PNG (magic bytes), got %d bytes starting %x", len(raw), raw[:min(len(raw), 8)])
+	}
+}
+
+// noisyImage returns a deterministic pseudo-random RGBA image — PNG
+// compresses a uniform test image far below the Kitty protocol's 4096-byte
+// chunk size, so chunking tests need incompressible pixel data to actually
+// force multiple chunks.
+func noisyImage(w, h int) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	rng := rand.New(rand.NewSource(1))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: byte(rng.Intn(256)), G: byte(rng.Intn(256)),
+				B: byte(rng.Intn(256)), A: 255,
+			})
+		}
+	}
+	return img
+}
+
+// TestEncodeKitty_ChunksLargePayloads is a regression test for WezTerm on
+// Windows failing to render images sent as one giant unchunked APC sequence
+// (suspected ConPTY interference) — EncodeKitty must split a payload over
+// the protocol's 4096-byte chunk size into multiple APC sequences, each
+// wrapped in its own ESC_G...ESC\, m=1 on every chunk but the last (m=0),
+// and continuation chunks must carry no control keys besides m/q.
+func TestEncodeKitty_ChunksLargePayloads(t *testing.T) {
+	img := noisyImage(200, 200)
+	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 7)
+	if err != nil {
+		t.Fatalf("EncodeKitty: %v", err)
+	}
+	chunks := strings.Split(strings.TrimSuffix(seq, "\x1b\\"), "\x1b\\\x1b_G")
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks for a large payload, got %d (seq len %d)", len(chunks), len(seq))
+	}
+	for i, c := range chunks {
+		last := i == len(chunks)-1
+		wantM := "m=1"
+		if last {
+			wantM = "m=0"
+		}
+		if !strings.Contains(c, wantM) {
+			t.Errorf("chunk %d: expected %s, got control data %q", i, wantM, c[:min(len(c), 40)])
+		}
+		if i > 0 {
+			for _, key := range []string{"a=", "f=", "c=", "r=", "i=", "p="} {
+				if strings.Contains(c, key) {
+					t.Errorf("chunk %d: continuation chunk must not repeat control key %q, got %q", i, key, c[:min(len(c), 40)])
+				}
+			}
+		}
 	}
 }
 

--- a/internal/ui/imgview/kitty.go
+++ b/internal/ui/imgview/kitty.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"image"
 	"image/png"
+	"strings"
 )
 
 // EncodeKitty encodes img for display via the Kitty terminal graphics
@@ -51,19 +52,62 @@ func EncodeKitty(img image.Image, maxCols, maxRows, cellPxW, cellPxH, placementI
 	// the terminal reads pixel dimensions from the PNG data itself (unlike the
 	// raw-RGBA f=32 this used to send, which required them explicitly). c/r:
 	// display size in terminal columns/rows (Kitty scales to fit, preserving
-	// aspect ratio). m=0: final chunk. q=2: suppress the terminal's OK/error
-	// response — by default (q unset) the terminal writes one back over the
-	// same stream used for keyboard input, and Bubble Tea's input reader has
-	// no way to tell it apart from a real keystroke. The fullscreen modal
-	// treats any keypress while open as "close" (see app.go), so that
-	// phantom response was closing the modal the instant it opened — every
-	// single time.
+	// aspect ratio). q=2: suppress the terminal's OK/error response — by
+	// default (q unset) the terminal writes one back over the same stream
+	// used for keyboard input, and Bubble Tea's input reader has no way to
+	// tell it apart from a real keystroke. The fullscreen modal treats any
+	// keypress while open as "close" (see app.go), so that phantom response
+	// was closing the modal the instant it opened — every single time.
+	var control string
 	if placementID == 0 {
-		encoded = fmt.Sprintf("\x1b_Ga=d,d=A\x1b\\\x1b_Ga=T,f=100,c=%d,r=%d,m=0,q=2;%s\x1b\\", cols, rows, payload)
+		control = fmt.Sprintf("a=T,f=100,c=%d,r=%d,q=2", cols, rows)
 	} else {
-		encoded = fmt.Sprintf("\x1b_Ga=T,f=100,c=%d,r=%d,m=0,q=2,i=%d,p=%d;%s\x1b\\", cols, rows, placementID, placementID, payload)
+		control = fmt.Sprintf("a=T,f=100,c=%d,r=%d,q=2,i=%d,p=%d", cols, rows, placementID, placementID)
+	}
+	chunked := chunkKittyPayload(control, payload)
+	if placementID == 0 {
+		encoded = "\x1b_Ga=d,d=A\x1b\\" + chunked
+	} else {
+		encoded = chunked
 	}
 	return
+}
+
+// kittyChunkSize is the Kitty graphics protocol's maximum payload size per
+// APC sequence (all chunks but the last must be a multiple of 4). Terminals
+// reached through Windows' ConPTY layer (e.g. WezTerm's local-process panes
+// on Windows) have been observed failing to render a large image sent as one
+// giant unchunked sequence — ConPTY is a known source of interference with
+// long or unrecognized escape sequences. Chunking is also simply what the
+// protocol spec expects for large payloads, independent of that.
+const kittyChunkSize = 4096
+
+// chunkKittyPayload splits payload into kittyChunkSize-byte APC sequences per
+// the Kitty graphics protocol's chunked-transmission mode: the first chunk
+// carries control (the full a=/f=/c=/r=/q=/i=/p= control data) plus m=1 if
+// more chunks follow; every subsequent chunk carries only m (m=1, or m=0 on
+// the last) and optionally q — no other control keys repeated, per spec. If
+// payload fits in a single chunk, this degenerates to exactly the old
+// single-sequence output (m=0, full control data, one APC block).
+func chunkKittyPayload(control, payload string) string {
+	if len(payload) <= kittyChunkSize {
+		return fmt.Sprintf("\x1b_G%s,m=0;%s\x1b\\", control, payload)
+	}
+	var sb strings.Builder
+	for i := 0; i < len(payload); i += kittyChunkSize {
+		end := min(i+kittyChunkSize, len(payload))
+		last := end == len(payload)
+		m := 1
+		if last {
+			m = 0
+		}
+		if i == 0 {
+			fmt.Fprintf(&sb, "\x1b_G%s,m=%d;%s\x1b\\", control, m, payload[i:end])
+		} else {
+			fmt.Fprintf(&sb, "\x1b_Gm=%d,q=2;%s\x1b\\", m, payload[i:end])
+		}
+	}
+	return sb.String()
 }
 
 // DeleteKittyPlacement returns the escape sequence to delete exactly one

--- a/internal/ui/imgview/protocol.go
+++ b/internal/ui/imgview/protocol.go
@@ -31,6 +31,15 @@ const (
 // terminal's graphics protocol support. Returns ProtocolNone when the terminal
 // is unknown or unsupported. Sixel terminals don't reliably set an env var, so
 // they're not detected here — see ProbeSixel.
+//
+// WezTerm supports both the Kitty and iTerm2 protocols on Linux, but its
+// Windows build does not implement Kitty graphics at all
+// (wezterm/wezterm#5757) — only iTerm2-protocol images work there. Mapped to
+// ProtocolITerm2 unconditionally rather than splitting on GOOS, since that's
+// the one protocol guaranteed to work across all of WezTerm's platforms; see
+// docs/plan-inline-images-improvements.md for the Kitty-protocol experiment
+// this reverts (it hit that Windows limitation) and the still-open black-
+// image-render investigation on the iTerm2 path.
 func DetectProtocol() GraphicsProtocol {
 	if os.Getenv("KITTY_WINDOW_ID") != "" {
 		return ProtocolKitty


### PR DESCRIPTION
## Summary

Adds chunked transmission to `EncodeKitty` for the Kitty graphics protocol. Previously it always sent the whole PNG payload as one unchunked APC sequence, regardless of size.

## Why

The Kitty graphics protocol has an official chunked-transmission mode for large payloads: split into ≤4096-byte pieces, `m=1` on every chunk but the last, continuation chunks carrying only `m`/`q` (no repeated control keys). This is spec-correct behavior for any large inline image on Kitty/Ghostty, independent of any particular terminal quirk.

Small payloads (the common case for feed thumbnails) are unaffected — output is byte-identical to before; chunking only kicks in above the 4096-byte threshold.

## Context

Spun out of a WezTerm/Windows investigation (`docs/plan-inline-images-improvements.md`, section 9) that also tried mapping WezTerm to the Kitty protocol as a fix for a black-image-render bug. That part was reverted after confirming WezTerm's Windows build doesn't implement the Kitty graphics protocol at all ([wezterm/wezterm#5757](https://github.com/wezterm/wezterm/issues/5757)) — so WezTerm stays on `ProtocolITerm2` unconditionally, unchanged from `dev`. This chunking piece is kept on its own since it's a genuine, independently-useful protocol-compliance improvement for Kitty/Ghostty.

## Testing

- `go test ./...`, `go vet ./...`, `staticcheck ./...` all pass
- Added `TestEncodeKitty_ChunksLargePayloads` (asserts multi-chunk output, correct `m=` values, and that continuation chunks carry no stray control keys)
- Existing `TestEncodeKitty_*` tests pass unmodified (small-payload/single-chunk path)
- Not yet manually verified against a real Ghostty session with a large enough image to trigger chunking — worth a live smoke test before merge
