### PR TITLE
fix: cap chatroom message buffer by estimated byte size

### DIFF
--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -37,6 +37,12 @@ const (
 // top border + 2 content rows + bottom border = 4.
 const roomCardHeight = 4
 
+// chatMessageBufferMaxBytes bounds the live message history kept for the
+// active room, evicting oldest-first once exceeded — mirrors the byte cap
+// used for inlineImageCache (app.go). Prevents unbounded growth from an
+// active room over a long-running session.
+const chatMessageBufferMaxBytes = 2 << 20 // 2 MiB
+
 // roomSubscription holds the live RTDB channel and its cancellation function.
 type roomSubscription struct {
 	RoomID string
@@ -751,10 +757,56 @@ func (m ChatroomsModel) enterRoomDetail(idx int, room model.Room) (ChatroomsMode
 // AppendMessage adds a live incoming message to the currently open room.
 func (m ChatroomsModel) AppendMessage(msg model.Message) ChatroomsModel {
 	m.messages = append(m.messages, msg)
+	m = m.trimMessageBuffer()
 	m.err = nil
 	if m.ready {
 		m = m.refreshMessages()
 		m.viewport.GotoBottom()
+	}
+	return m
+}
+
+// estimatedMessageSize approximates a model.Message's memory footprint for
+// chatMessageBufferMaxBytes accounting. Doesn't need to be exact, just
+// proportional to actual size — messages carrying ASCII art (already
+// base64-decoded into Body) or attachments can be far larger than a typical
+// chat line, which a fixed message-count cap wouldn't account for.
+func estimatedMessageSize(msg model.Message) int {
+	const overhead = 128
+	n := overhead + len(msg.ID) + len(msg.From.Username) + len(msg.Body) +
+		len(msg.ImageUrl) + len(msg.GifUrl)
+	for _, s := range msg.Style {
+		n += len(s)
+	}
+	if msg.AudioAttachment != nil {
+		n += 128
+	}
+	return n
+}
+
+// trimMessageBuffer evicts oldest messages from m.messages while the
+// estimated total size exceeds chatMessageBufferMaxBytes, always keeping at
+// least the most recent message. Clears m.selectedMsgID if the evicted range
+// contained the current selection, and resets m.historyExhausted so a later
+// scroll-to-top re-fetches the evicted range from the server instead of
+// treating it as permanently gone — the pagination cursor is m.messages[0]
+// (see maybeLoadOlderMessages), so this is always safe to re-trigger.
+func (m ChatroomsModel) trimMessageBuffer() ChatroomsModel {
+	total := 0
+	for _, msg := range m.messages {
+		total += estimatedMessageSize(msg)
+	}
+	i := 0
+	for total > chatMessageBufferMaxBytes && i < len(m.messages)-1 {
+		if m.messages[i].ID != "" && m.messages[i].ID == m.selectedMsgID {
+			m.selectedMsgID = ""
+		}
+		total -= estimatedMessageSize(m.messages[i])
+		i++
+	}
+	if i > 0 {
+		m.messages = m.messages[i:]
+		m.historyExhausted = false
 	}
 	return m
 }

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -1409,3 +1409,91 @@ func TestBrowsing_Enter_TogglesL33tReveal(t *testing.T) {
 		t.Error("expected l33t-substituted text again after toggling off")
 	}
 }
+
+// --- message buffer byte cap (trimMessageBuffer) ---
+
+// bigMessage returns a message whose estimated size is roughly n bytes, via
+// its Body, so tests can push the buffer over chatMessageBufferMaxBytes
+// without needing thousands of individual AppendMessage calls.
+func bigMessage(id string, n int) model.Message {
+	return model.Message{
+		ID:        id,
+		From:      model.User{Username: "molly"},
+		Body:      strings.Repeat("x", n),
+		CreatedAt: time.Now(),
+	}
+}
+
+func TestAppendMessage_TrimsOldestWhenOverByteCap(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	big := chatMessageBufferMaxBytes / 3
+	m = m.SetMessages("zion", []model.Message{
+		bigMessage("old1", big),
+		bigMessage("old2", big),
+	})
+
+	m = m.AppendMessage(bigMessage("new1", big))
+	m = m.AppendMessage(bigMessage("new2", big))
+
+	if len(m.messages) == 0 {
+		t.Fatal("expected at least one message to remain")
+	}
+	if m.messages[len(m.messages)-1].ID != "new2" {
+		t.Errorf("expected newest message to survive, got last ID %q", m.messages[len(m.messages)-1].ID)
+	}
+	for _, msg := range m.messages {
+		if msg.ID == "old1" {
+			t.Error("expected oldest message to be evicted, found old1 still present")
+		}
+	}
+	total := 0
+	for _, msg := range m.messages {
+		total += estimatedMessageSize(msg)
+	}
+	if total > chatMessageBufferMaxBytes {
+		t.Errorf("total estimated size = %d, want <= %d", total, chatMessageBufferMaxBytes)
+	}
+}
+
+func TestAppendMessage_ClearsSelectionOnEviction(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	big := chatMessageBufferMaxBytes / 2
+	m = m.SetMessages("zion", []model.Message{bigMessage("old1", big)})
+	m.selectedMsgID = "old1"
+
+	m = m.AppendMessage(bigMessage("new1", big))
+	m = m.AppendMessage(bigMessage("new2", big))
+
+	if m.selectedMsgID != "" {
+		t.Errorf("expected selectedMsgID cleared after its message was evicted, got %q", m.selectedMsgID)
+	}
+}
+
+func TestPrependMessages_NotSubjectToByteCap(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	big := chatMessageBufferMaxBytes
+	m = m.SetMessages("zion", []model.Message{bigMessage("recent", 10)})
+
+	m = m.PrependMessages("zion", []model.Message{bigMessage("history", big)})
+
+	if len(m.messages) != 2 {
+		t.Fatalf("expected prepend to keep both messages regardless of byte cap, got %d messages", len(m.messages))
+	}
+	if m.messages[0].ID != "history" {
+		t.Errorf("expected prepended message first, got %q", m.messages[0].ID)
+	}
+}
+
+func TestAppendMessage_EvictionResetsHistoryExhausted(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	big := chatMessageBufferMaxBytes / 2
+	m = m.SetMessages("zion", []model.Message{bigMessage("old1", big)})
+	m.historyExhausted = true
+
+	m = m.AppendMessage(bigMessage("new1", big))
+	m = m.AppendMessage(bigMessage("new2", big))
+
+	if m.historyExhausted {
+		t.Error("expected historyExhausted reset to false after eviction, so scrolling up can re-fetch the evicted history")
+	}
+}


### PR DESCRIPTION
## What

Caps the chatroom message buffer (`ChatroomsModel.messages`) by estimated total byte size instead of letting it grow unbounded for the life of an open room.

## Why

`AppendMessage` appended every live incoming message with no limit. Sessions are SSH-hosted (Wish) and can run for hours or days, so idling in a busy room accumulated memory indefinitely. Messages can carry ASCII art (`/art`, already base64-decoded), image/gif URLs, and audio attachments, so a fixed message-count cap wouldn't reliably bound memory the way a byte-size cap does — mirrors the existing byte-capped `inlineImageCache` pattern already used elsewhere in the app.

## How

- `trimMessageBuffer()` evicts oldest-first once the estimated total exceeds `chatMessageBufferMaxBytes` (2 MiB), called from `AppendMessage`.
- `PrependMessages` (history pagination) is untouched — never subject to the cap, so a history load is never truncated mid-page.
- Eviction resets `historyExhausted` so previously-exhausted history stays reachable again via scroll-up (pagination cursor is `m.messages[0]`) instead of becoming a permanent, unrecoverable gap.
- Eviction clears `selectedMsgID` if the evicted range held the current selection.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — all clean
- `go test ./...` — all packages pass
- New tests in `chatrooms_test.go`: eviction trims oldest and keeps size under cap, selection clears on eviction, prepend is exempt from the cap, eviction resets `historyExhausted` (regression test for the permanent-gap scenario).
