### PR TITLE
feat: send pokes to other users from their profile

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -187,12 +187,6 @@ cIRC/C-Mail messages can now carry `imageUrl`, `gifUrl` (`/gif <url>`), `audioAt
 | `/v1/posts/:id` | PATCH | Edit own post — supporter-only, within 5 minutes of publishing. `slug`/`createdAt` immutable; no re-notification; response/entry gains `editedAt`. Rate limit 5/min, 30/day. | Not yet implemented |
 | `/v1/replies/:id` | PATCH | Edit own reply — same supporter/5-minute window; `content` only. Rate limit 5/min, 30/day. | Not yet implemented |
 
-### Poke (new in v0.8.4)
-
-| Endpoint | Method | Description | Priority |
-|---|---|---|---|
-| `/v1/users/:username/poke` | POST | Send a `poke` notification to a user (mirrors the web **[P] Poke** button). No body; blocked in either direction → 403; self-poke → 400. Rate limit 1/hour, 8/day across all users. | Not yet implemented |
-
 ### TypeScript definitions (new in v0.8.4)
 
 `/types.d.ts` now publishes TypeScript types for every documented response shape. Not applicable to this Go client — noted for reference only.
@@ -288,3 +282,4 @@ Notes:
 | `POST /v1/guilds/:slug/leave` | Leave guild — `l` key in guild thread feed with confirmation prompt; success banner "✓ Left #name"; navigates back to guild list. Feature 29. | 2026-06-01 |
 | Attachments (image/audio) | Attachment URLs surfaced via `GetFocusedURLs` and opened with `o`. Best-effort handling for a TUI — no further work needed. | 2026-05-30 |
 | `POST /v1/posts`/`/v1/threads`/`/v1/notes` `topics`, and `slug` | Client-side fix, not a server bug: `topics` is documented as "must be lowercase" and `slug` as `[a-z0-9-]`, but neither field restricted input client-side — an uppercase or punctuation-laced tag round-tripped to the server and came back a `400 VALIDATION_ERROR`. Compose's slug and topics inputs, and journal's topics input, now filter keystrokes live (`filterSlugCharsKeyMsg`/`filterTopicsKeyMsg`, `internal/ui/screens/shared.go`): uppercase auto-lowercases, any character outside `[a-z0-9-]` (plus `, ` as topic delimiters) is dropped as typed. Topics' existing 3-item cap (`ParseTopics`) is now also enforced live — a comma that would open a 4th topic is blocked — instead of only silently truncating at submit. Closes #94 ("Posts with uppercase tags cause API error"). | 2026-08-07 |
+| `POST /v1/users/:username/poke` (v0.8.4) | Send a poke — `p` key on a read-only profile; brief `poked.` feedback; suppressed on own profile. 429 (1/hour, 8/day cap) and 403 (blocked either direction) get friendly banners instead of raw API error text. Feature 42. | 2026-08-12 |

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -164,6 +164,7 @@ Defines the `Client` interface — the only type the UI layer imports from this 
 | Profile | `GetOwnProfile()`, `GetProfile(username)`, `UpdateProfile(update)` |
 | User History | `GetUserPosts(username, cursor)`, `GetUserReplies(username, cursor)` |
 | Follows | `GetFollowing(cursor)`, `GetFollowers(cursor)`, `GetUserFollows(userID, followType, cursor)`, `Follow(followedID)`, `Unfollow(followID)` |
+| Poke | `Poke(username)` |
 | Settings | `GetSettings()`, `UpdateSettings(update)` |
 | Rooms | `GetRooms()`, `GetRoomMessages(roomID, limit)`, `SendRoomMessage(roomID, body)` |
 | Notifications | `GetNotifications(cursor, unreadOnly, types)`, `GetUnreadNotificationCount()`, `MarkNotificationRead(id)`, `MarkAllNotificationsRead()` |
@@ -835,6 +836,7 @@ cycle), not a global shortcut.
 | `e` | Edit profile (own profile, Info tab) |
 | `f` | Follow / unfollow (read-only profiles) |
 | `c` | Start C-Mail conversation (read-only profiles only) |
+| `p` | Poke (read-only profiles only) |
 | `esc` | Back to previous screen |
 
 ### Feed

--- a/docs/42-poke.md
+++ b/docs/42-poke.md
@@ -1,0 +1,71 @@
+# Feature 42 — Poke
+
+Implements sending a poke to another user from their profile. Receiving pokes (the `poke` notification type) was already implemented alongside general notification support.
+
+---
+
+## Scope
+
+| Capability | Status |
+|---|---|
+| Poke another user (`p` key on read-only profile) | Done |
+| `p` visible in the status bar hints and `?` help modal on a read-only profile | Done |
+| Toast confirmation after a successful poke | Done |
+| Suppressed on the logged-in user's own profile | Done |
+| Friendly toast on rate limit (429) | Done |
+| Friendly toast when blocked either direction (403) | Done |
+| Receiving a `poke` notification | **Already implemented** — see `docs/15-notifications.md` |
+
+---
+
+## API Endpoints Used
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/v1/users/:username/poke` | Send a poke notification to a user. No body. |
+
+Response body (`{ userId, username, poked }`) is not used — a non-error response is treated as success, matching the client's existing no-body-response actions (e.g. `WatchPost`).
+
+Rate limit: **1/hour, 8/day, across all users** — not per target, and tighter than any other write action in the client. A rejected poke (400/403/404) doesn't count against the limit per the API docs.
+
+---
+
+## UI
+
+### Profile screen
+
+- Viewing another user's profile (`readOnly=true`): pressing `p` sends `PokeUserMsg{Username}` to `App`.
+- On success, the global toast banner (bottom of screen — the same one used for "reported", room-joined, link-copied, etc.) shows `poked @username`.
+- The poke key is suppressed on the logged-in user's own profile (`readOnly=false`), same as follow/message.
+- No confirmation prompt — matches the web, which also pokes immediately on click.
+- `p` is visible in the status bar hints (`f · follow  c · message  p · poke  tab · cycle`) and in the `?` help modal's profile section, both only while viewing a read-only profile.
+
+### Key note: `p` is contextual
+
+`p` already means "open this post's author's profile" on Feed, Post Detail, and Notifications. That binding lives on those screens' own models and only fires while they own input; once the app navigates to the Profile screen, `ProfileModel.Update` is the only handler receiving keys, so `p` there means "poke" instead. There's no shared/global keymap in this app — every binding is scoped to whichever screen is active — so the two meanings never compete. The status-bar hint for `p` also changes screen-to-screen for the same reason (`screenHints` in `internal/ui/layout_tabs.go` switches on `a.active`).
+
+### Error handling
+
+Poke result and errors are routed through the app's global toast system (`notifyMsg`/`actionErrMsg`, handled by `handleNotify` in `internal/ui/app.go`) — the same 4-second bottom-of-screen banner used everywhere else (flagging, room join/leave, link copy, etc.), rather than the profile-local feedback text used by Follow/Unfollow.
+
+- Success: info-level toast, `poked @username`.
+- `429` (rate limit reached): error-level toast "poke limit reached — try again later" instead of the raw API error text — expected to be hit occasionally given the tight 1/hour cap.
+- `403` (blocked either direction): error-level toast "can't poke this user".
+- Anything else (e.g. an unreachable-in-practice 404 for an unknown user, or a 400 for poking yourself — both should be prevented client-side by the `readOnly` guard) falls through to the standard `actionErrMsg` toast.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `internal/api/interface.go` | Added `Poke(username string) error` to the `Client` interface |
+| `internal/api/client.go` | Implemented `Poke` — `POST /v1/users/:username/poke`, no body, ignores response |
+| `internal/api/mock.go` | Stub `Poke` implementation |
+| `internal/ui/screens/messages.go` | Added `PokeUserMsg` |
+| `internal/ui/screens/profile.go` | Added `p` key binding (read-only only), emits `PokeUserMsg` |
+| `internal/ui/app.go` | Added `pokeUserCmd` (returns `notifyMsg` on success), `pokeErrorMsg` (429/403 friendly toasts); wired `PokeUserMsg` dispatch in `handleProfile` — result/errors flow through the existing global `handleNotify` toast path |
+| `internal/ui/layout_tabs.go` | Added `p · poke` to the read-only-profile status bar hints (`screenHints`, shared by the Miller layout) and to the `?` help modal's profile section |
+| `internal/api/client_test.go` | `TestHTTPPoke_CallsCorrectEndpoint`, `TestHTTPPoke_RateLimited` |
+| `internal/ui/screens/profile_test.go` | Tests for `p` key emitting `PokeUserMsg`, suppressed on own profile |
+| `internal/ui/app_test.go` | Tests for `pokeErrorMsg` 429/403 softening and fallthrough |

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1551,6 +1551,11 @@ func (c *HTTPClient) UnwatchPost(postID string) error {
 	return err
 }
 
+func (c *HTTPClient) Poke(username string) error {
+	_, err := c.doRequest("POST", "/v1/users/"+url.PathEscape(username)+"/poke", nil)
+	return err
+}
+
 // --- Topics ---
 
 func (c *HTTPClient) GetTopics(cursor string) ([]model.Topic, string, error) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -3362,6 +3362,42 @@ func TestHTTPWatchPost_CallsCorrectEndpoint(t *testing.T) {
 	}
 }
 
+func TestHTTPPoke_CallsCorrectEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		writeOK(t, w, map[string]any{"userId": "u1", "username": "alice", "poked": true})
+	})))
+	c.Login("u@example.com", "pass")
+
+	if err := c.Poke("alice"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/users/alice/poke" {
+		t.Errorf("path = %q, want /v1/users/alice/poke", gotPath)
+	}
+}
+
+func TestHTTPPoke_RateLimited(t *testing.T) {
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeErr(w, http.StatusTooManyRequests, "RATE_LIMITED", "too many pokes")
+	})))
+	c.Login("u@example.com", "pass")
+
+	err := c.Poke("alice")
+	apiErr, ok := asAPIError(err)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.Status != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", apiErr.Status)
+	}
+}
+
 func TestHTTPUnwatchPost_CallsCorrectEndpoint(t *testing.T) {
 	var gotMethod, gotPath string
 	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -59,6 +59,9 @@ type Client interface {
 	Follow(followedID string) (string, error)
 	// Unfollow removes a follow relationship by its document ID.
 	Unfollow(followID string) error
+	// Poke sends a poke notification to a user. Rate limited to 1/hour, 8/day
+	// across all users (not per-target).
+	Poke(username string) error
 
 	// Settings
 	GetSettings() (model.Settings, error)

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -686,6 +686,10 @@ func (m *MockClient) Unfollow(followID string) error {
 	return nil
 }
 
+func (m *MockClient) Poke(username string) error {
+	return nil
+}
+
 func (m *MockClient) GetNotes(cursor string) ([]model.Note, string, error) {
 	return m.notes, "", nil
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1307,6 +1307,8 @@ func (a App) handleProfile(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, a.followUserCmd(msg.UserID), true
 	case screens.UnfollowUserMsg:
 		return a, a.unfollowUserCmd(msg.FollowID), true
+	case screens.PokeUserMsg:
+		return a, a.pokeUserCmd(msg.Username), true
 	case followResultMsg:
 		a.profile = a.profile.SetFollowState(true, msg.followID).IncrementFollowersCount(1).SetFollowFeedback("following.")
 		return a, nil, true
@@ -3996,6 +3998,33 @@ func (a *App) unfollowUserCmd(followID string) tea.Cmd {
 		}
 		return unfollowResultMsg{}
 	}
+}
+
+func (a *App) pokeUserCmd(username string) tea.Cmd {
+	return func() tea.Msg {
+		if err := a.client.Poke(username); err != nil {
+			return pokeErrorMsg(err)
+		}
+		return notifyMsg{level: notifyInfo, text: "poked @" + username}
+	}
+}
+
+// pokeErrorMsg converts a poke-action error into the message to emit. A 429
+// is expected here far more than on other actions (1/hour, 8/day cap across
+// all users) so it gets a friendly banner instead of the raw API error text;
+// a 403 (blocked either direction) also gets a friendlier message. Anything
+// else falls through to actionErrMsg's normal handling.
+func pokeErrorMsg(err error) tea.Msg {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.Status {
+		case 429:
+			return notifyMsg{level: notifyError, text: "poke limit reached — try again later"}
+		case 403:
+			return notifyMsg{level: notifyError, text: "can't poke this user"}
+		}
+	}
+	return actionErrMsg{err}
 }
 
 func (a *App) loadUserPostsCmd(username, cursor string) tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1861,6 +1861,46 @@ func TestFlagErrorMsg_OtherErrorsFallThrough(t *testing.T) {
 	}
 }
 
+// pokeErrorMsg softens the expected 429 (1/hour, 8/day cap) and the documented
+// 403 (blocked either direction) into friendly banners; anything else falls
+// through to the normal actionErrMsg handling.
+func TestPokeErrorMsg_429IsSoftened(t *testing.T) {
+	got := pokeErrorMsg(&api.APIError{Code: "RATE_LIMITED", Status: 429, Message: "too many requests"})
+	msg, ok := got.(notifyMsg)
+	if !ok {
+		t.Fatalf("pokeErrorMsg(429) = %T, want notifyMsg", got)
+	}
+	if msg.level != notifyError {
+		t.Errorf("level = %v, want notifyError", msg.level)
+	}
+	if msg.text != "poke limit reached — try again later" {
+		t.Errorf("text = %q, want friendly rate-limit message", msg.text)
+	}
+}
+
+func TestPokeErrorMsg_403IsSoftened(t *testing.T) {
+	got := pokeErrorMsg(&api.APIError{Code: "FORBIDDEN", Status: 403, Message: "blocked"})
+	msg, ok := got.(notifyMsg)
+	if !ok {
+		t.Fatalf("pokeErrorMsg(403) = %T, want notifyMsg", got)
+	}
+	if msg.text != "can't poke this user" {
+		t.Errorf("text = %q, want friendly blocked message", msg.text)
+	}
+}
+
+func TestPokeErrorMsg_OtherErrorsFallThrough(t *testing.T) {
+	err := &api.APIError{Code: "NOT_FOUND", Status: 404, Message: "unknown user"}
+	got := pokeErrorMsg(err)
+	ae, ok := got.(actionErrMsg)
+	if !ok {
+		t.Fatalf("pokeErrorMsg(404) = %T, want actionErrMsg", got)
+	}
+	if ae.err != err {
+		t.Errorf("actionErrMsg.err = %v, want the original error", ae.err)
+	}
+}
+
 // --- routeURL: ephemeral (SSH) sessions must not drive host side effects ---
 
 func TestRouteURL_EphemeralBlocksExternalOpen(t *testing.T) {

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -344,7 +344,7 @@ func (l TabsLayout) screenHints(a App) []hint {
 			return []hint{{"Ctrl+s", "save"}, {"Esc", "cancel"}, {"tab", "cycle"}}
 		}
 		if a.profile.IsReadOnly() {
-			return []hint{{"↑↓", "navigate"}, {"f", "follow"}, {"c", "message"}, {"tab", "cycle"}, more}
+			return []hint{{"↑↓", "navigate"}, {"f", "follow"}, {"c", "message"}, {"p", "poke"}, {"tab", "cycle"}, more}
 		}
 		return []hint{{"↑↓", "navigate"}, {"e", "edit"}, {"tab", "cycle"}, more}
 	case screenNotifications:
@@ -504,6 +504,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 			localSection = section("profile",
 				row("enter", "open"),
 				row("c", "message"),
+				row("p", "poke"),
 			)
 		} else {
 			localSection = section("profile (own)",

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -120,6 +120,9 @@ type FollowUserMsg struct{ UserID string }
 // UnfollowUserMsg is emitted by ProfileModel when the user presses 'f' to unfollow.
 type UnfollowUserMsg struct{ FollowID string }
 
+// PokeUserMsg is emitted by ProfileModel when the user presses 'p' to poke another user.
+type PokeUserMsg struct{ Username string }
+
 // LoadMoreJournalMsg is emitted by JournalModel when the viewport reaches the bottom
 // and a next-page cursor is available. App intercepts this and fires the API call.
 type LoadMoreJournalMsg struct{ Cursor string }

--- a/internal/ui/screens/profile.go
+++ b/internal/ui/screens/profile.go
@@ -677,6 +677,11 @@ func (m ProfileModel) Update(msg tea.Msg) (ProfileModel, tea.Cmd) {
 				username := m.user.Username
 				return m, func() tea.Msg { return StartConversationMsg{Username: username} }
 			}
+		case "p":
+			if m.readOnly {
+				username := m.user.Username
+				return m, func() tea.Msg { return PokeUserMsg{Username: username} }
+			}
 		}
 
 	// ComposeSubmitMsg arrives when Ctrl+S is pressed inside the bio compose box.

--- a/internal/ui/screens/profile_test.go
+++ b/internal/ui/screens/profile_test.go
@@ -114,6 +114,37 @@ func TestProfileUpdate_FKey_EmitsUnfollowMsg_WhenFollowing(t *testing.T) {
 	}
 }
 
+// --- 'p' key — poke ---
+
+func TestProfileUpdate_PKey_EmitsPokeMsg_WhenReadOnly(t *testing.T) {
+	m := screens.NewProfileModel().SetUser(testUser()).SetReadOnly(true)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	_ = updated
+	if cmd == nil {
+		t.Fatal("expected a cmd, got nil")
+	}
+	msg := cmd()
+	pokeMsg, ok := msg.(screens.PokeUserMsg)
+	if !ok {
+		t.Fatalf("expected PokeUserMsg, got %T", msg)
+	}
+	if pokeMsg.Username != "ragnar" {
+		t.Errorf("Username = %q, want ragnar", pokeMsg.Username)
+	}
+}
+
+func TestProfileUpdate_PKey_NoOp_OnOwnProfile(t *testing.T) {
+	m := screens.NewProfileModel().SetUser(testUser()).SetReadOnly(false)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	if cmd != nil {
+		if _, ok := cmd().(screens.PokeUserMsg); ok {
+			t.Error("did not expect PokeUserMsg on own (non-read-only) profile")
+		}
+	}
+}
+
 // --- IncrementFollowersCount ---
 
 func TestProfileIncrementFollowersCount(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the sending side of the API's poke feature (v0.8.4): pressing `p` on a read-only profile sends a poke to that user. The receiving side (poke notifications) was already implemented.

## Changes

- `Poke(username string) error` added to the API client (`interface.go`, `client.go`, `mock.go`), following the existing no-body-POST pattern used by `WatchPost`
- `p` keybinding on read-only profiles (`internal/ui/screens/profile.go`), suppressed on the logged-in user's own profile
- Result/errors route through the app's global toast banner rather than a screen-local feedback slot — success shows `poked @username`; a 429 (1/hour, 8/day cap) and a 403 (blocked either direction) get friendly text instead of the raw API error
- `p` surfaced in the status bar hints and the `?` help modal for read-only profiles
- `docs/42-poke.md` added; `docs/00-project-reference.md` and `docs/00-api-backlog.md` updated

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — all clean
- `go test ./...` — full suite passes, including new tests:
  - `TestHTTPPoke_CallsCorrectEndpoint`, `TestHTTPPoke_RateLimited`
  - `TestProfileUpdate_PKey_EmitsPokeMsg_WhenReadOnly`, `TestProfileUpdate_PKey_NoOp_OnOwnProfile`
  - `TestPokeErrorMsg_429IsSoftened`, `TestPokeErrorMsg_403IsSoftened`, `TestPokeErrorMsg_OtherErrorsFallThrough`
