### PR TITLE
feat: strikethrough for single-tilde text (~text~)

### DIFF
--- a/internal/ui/markdown/renderer.go
+++ b/internal/ui/markdown/renderer.go
@@ -195,13 +195,19 @@ func preprocessMarkdown(content string, width int) (src []byte, resolvedWidth in
 // block syntax — it stays literal chat text. Inline parsing still runs the
 // normal CommonMark set (parser.DefaultInlineParsers: code span, link,
 // autolink, raw HTML, emphasis/strong) plus bare-URL detection
-// (extension.NewLinkifyParser, the same one extension.GFM's Linkify wraps).
+// (extension.NewLinkifyParser, the same one extension.GFM's Linkify wraps)
+// and strikethrough (extension.NewStrikethroughParser, same priority as
+// extension.GFM uses for mdInstance — accepts both ~single~ and ~~double~~
+// tilde runs; see goldmark's strikethroughParser.Parse).
 // No @mention node here — CIRC has its own bespoke mention system layered on
 // top by the caller.
 var mdInlineParser = parser.NewParser(
 	parser.WithBlockParsers(util.Prioritized(parser.NewParagraphParser(), 1000)),
 	parser.WithInlineParsers(
-		append(parser.DefaultInlineParsers(), util.Prioritized(extension.NewLinkifyParser(), 999))...,
+		append(parser.DefaultInlineParsers(),
+			util.Prioritized(extension.NewLinkifyParser(), 999),
+			util.Prioritized(extension.NewStrikethroughParser(), 500),
+		)...,
 	),
 )
 

--- a/internal/ui/markdown/renderer_test.go
+++ b/internal/ui/markdown/renderer_test.go
@@ -370,6 +370,35 @@ func TestRender_Strikethrough(t *testing.T) {
 	}
 }
 
+// TestRender_SingleTildeStrikethrough confirms GFM's strikethrough extension
+// treats a single-tilde run (~text~) the same as double-tilde (~~text~~).
+func TestRender_SingleTildeStrikethrough(t *testing.T) {
+	raw := Render("~deleted text~", 80)
+	plain := strip(raw)
+	if !strings.Contains(plain, "deleted text") {
+		t.Errorf("strikethrough text not in output: %q", plain)
+	}
+	if strings.Contains(plain, "~deleted text~") {
+		t.Errorf("raw strikethrough markers remain: %q", plain)
+	}
+}
+
+// TestRenderInline_Strikethrough confirms chat/DM one-liners (RenderInline,
+// which uses a separate minimal parser from Render) also strike through both
+// ~single~ and ~~double~~ tilde runs.
+func TestRenderInline_Strikethrough(t *testing.T) {
+	for _, content := range []string{"~deleted~", "~~deleted~~"} {
+		raw := RenderInline(content, "")
+		plain := strip(raw)
+		if !strings.Contains(plain, "deleted") {
+			t.Errorf("%q: strikethrough text not in output: %q", content, plain)
+		}
+		if strings.Contains(plain, "~") {
+			t.Errorf("%q: raw strikethrough markers remain: %q", content, plain)
+		}
+	}
+}
+
 func TestRender_AmbiguousRunesStripped(t *testing.T) {
 	// U+00B0 DEGREE SIGN (°) is ambiguous-width per go-runewidth.
 	raw := Render("Hello \u00B0 world", 80)


### PR DESCRIPTION
## Summary
- Single-tilde strikethrough (`~text~`) already worked everywhere `markdown.Render`/`FirstLine` is used (posts, replies, journal, bookmarks, profile previews) — GFM's strikethrough extension treats `~text~` the same as `~~text~~`. No change needed there.
- The one gap was chat/DM one-liners (`RenderInline`), which parse with a separate minimal parser (`mdInlineParser`) that didn't register the strikethrough inline parser — added it so tildes strike through consistently across the whole app.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Added `TestRender_SingleTildeStrikethrough` and `TestRenderInline_Strikethrough` covering both `~single~` and `~~double~~` tilde forms