### PR TITLE
feat: replace [img] text badge with left-aligned image glyph

### DIFF
--- a/internal/ui/screens/bookmarks.go
+++ b/internal/ui/screens/bookmarks.go
@@ -359,16 +359,12 @@ func (m BookmarksModel) renderItem(b model.Bookmark, selected bool) string {
 		createdAt = b.CreatedAt
 	}
 
-	// Line 1 left: [type]  @author  [img][yt]
+	// Line 1 left: [type]  @author  🖼
 	var authorStyled string
 	if author != "" {
 		authorStyled = "  " + theme.Highlight.Render("@"+author)
 	}
-	attInd := attachmentIndicator(attachments, content)
-	left1 := typeTag + authorStyled
-	if attInd != "" {
-		left1 += "  " + attInd
-	}
+	left1 := typeTag + authorStyled + imageIcon(attachments, content)
 
 	// Line 1 right: "posted Xh ago · saved Yd ago"
 	postedStr := formatRelativeTime(createdAt, now, loc)

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -928,23 +928,8 @@ func (m PostDetailModel) renderFullPost(selected bool) (string, []postImageSlot)
 	left := lipgloss.JoinHorizontal(lipgloss.Top,
 		theme.Highlight.Render("@"+m.post.AuthorUsername),
 		theme.Subtle.Render("  "+displayTime(m.post.CreatedAt, m.location(), m.timeDisplayFormat, false)+editedSuffix(m.post.EditedAt)),
-	) + audioIcon(m.post.Attachments) + bookmarkIcon(postBookmarked) + watchIcon(postWatched)
-	var rightParts []string
-	if ind := attachmentIndicator(m.post.Attachments, m.post.Content); ind != "" {
-		rightParts = append(rightParts, ind)
-	}
-	right := strings.Join(rightParts, " ")
-	var header string
-	if right != "" && innerWidth > 0 {
-		gap := innerWidth - lipgloss.Width(left) - lipgloss.Width(right)
-		if gap > 0 {
-			header = left + strings.Repeat(" ", gap) + right
-		} else {
-			header = left
-		}
-	} else {
-		header = left
-	}
+	) + imageIcon(m.post.Attachments, m.post.Content) + audioIcon(m.post.Attachments) + bookmarkIcon(postBookmarked) + watchIcon(postWatched)
+	header := left
 
 	// Badges line: guild indicator, nsfw, public — omitted when none apply.
 	var badgeParts []string
@@ -1030,19 +1015,8 @@ func (m PostDetailModel) renderReply(node replyNode, selected bool) (string, []p
 		theme.Subtle.Render("  "+displayTime(node.Reply.CreatedAt, m.location(), m.timeDisplayFormat, false)+editedSuffix(node.Reply.EditedAt)),
 	)
 	_, replyBookmarked := m.bookmarkedReplyIDs[node.Reply.ID]
-	left := lipgloss.JoinHorizontal(lipgloss.Top, headerParts...) + audioIcon(node.Reply.Attachments) + bookmarkIcon(replyBookmarked)
-	var replyRightParts []string
-	if ind := attachmentIndicator(node.Reply.Attachments, node.Reply.Content); ind != "" {
-		replyRightParts = append(replyRightParts, ind)
-	}
-	replyRight := strings.Join(replyRightParts, " ")
+	left := lipgloss.JoinHorizontal(lipgloss.Top, headerParts...) + imageIcon(node.Reply.Attachments, node.Reply.Content) + audioIcon(node.Reply.Attachments) + bookmarkIcon(replyBookmarked)
 	header := left
-	if replyRight != "" && innerWidth > 0 {
-		gap := innerWidth - lipgloss.Width(left) - lipgloss.Width(replyRight)
-		if gap > 0 {
-			header = left + strings.Repeat(" ", gap) + replyRight
-		}
-	}
 
 	// lineBase: 1 border-top row + 1 header row (header is always a single
 	// JoinHorizontal line here, unlike the full post's optional badges/title).

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -50,11 +50,8 @@ func renderPostBody(p model.Post, bookmarked bool, watched bool, width int, loc 
 	left := lipgloss.JoinHorizontal(lipgloss.Top,
 		theme.Highlight.Render("@"+p.AuthorUsername),
 		theme.Subtle.Render("  "+displayTime(p.CreatedAt, loc, timeFormat, false)+editedSuffix(p.EditedAt)),
-	) + audioIcon(p.Attachments) + bookmarkIcon(bookmarked) + watchIcon(watched)
+	) + imageIcon(p.Attachments, p.Content) + audioIcon(p.Attachments) + bookmarkIcon(bookmarked) + watchIcon(watched)
 	var rightParts []string
-	if ind := attachmentIndicator(p.Attachments, p.Content); ind != "" {
-		rightParts = append(rightParts, ind)
-	}
 	switch p.RepliesCount {
 	case 1:
 		rightParts = append(rightParts, theme.Subtle.Render("1 reply"))
@@ -164,29 +161,20 @@ func renderPostBody(p model.Post, bookmarked bool, watched bool, width int, loc 
 	return lipgloss.JoinVertical(lipgloss.Left, rows...), imgSlots
 }
 
-// attachmentIndicator returns a compact header badge for any images present
+// imageIcon returns a 🖼 icon (with leading spaces) when any image is present
 // — counting both structured image/gif Attachments and images embedded as
 // markdown syntax in content (most real posts use the latter; see
-// urlutil.CountImages) — e.g. "[img]" for one, "[img +2]" when there are
-// more beyond the first (the count beyond what inline rendering shows, and
-// what the carousel modal has left to page through). Returns "" when there
-// are no images at all — audio attachments get their own icon (audioIcon).
-func attachmentIndicator(attachments []model.Attachment, content string) string {
-	n := 0
+// urlutil.CountImages) — else "". Audio attachments get their own icon (audioIcon).
+func imageIcon(attachments []model.Attachment, content string) string {
 	for _, a := range attachments {
 		if a.Type == "image" || a.Type == "gif" {
-			n++
+			return "  " + theme.Highlight.Render("🖼")
 		}
 	}
-	n += urlutil.CountImages(content)
-	switch {
-	case n == 0:
-		return ""
-	case n == 1:
-		return theme.Subtle.Render("[img]")
-	default:
-		return theme.Subtle.Render(fmt.Sprintf("[img +%d]", n-1))
+	if urlutil.CountImages(content) > 0 {
+		return "  " + theme.Highlight.Render("🖼")
 	}
+	return ""
 }
 
 // audioIcon returns a ♫ icon (with leading spaces) when any attachment is audio, else "".

--- a/internal/ui/screens/render_test.go
+++ b/internal/ui/screens/render_test.go
@@ -465,39 +465,38 @@ func TestRenderAttachments_GifBadge(t *testing.T) {
 	}
 }
 
-// TestAttachmentIndicator_CountsImages confirms the badge is blank with no
-// images, flat "[img]" for exactly one, and "[img +N]" (extra beyond the one
-// inline rendering shows) for multiple — audio attachments never count, and
-// markdown-embedded images (the actual mechanism real posts use — see the
-// "markdown only" cases) count the same as structured Attachments.
-func TestAttachmentIndicator_CountsImages(t *testing.T) {
+// TestImageIcon_DetectsImages confirms the glyph is blank with no images and
+// present (regardless of count) otherwise — audio attachments never trigger
+// it, and markdown-embedded images (the actual mechanism real posts use —
+// see the "markdown only" cases) count the same as structured Attachments.
+func TestImageIcon_DetectsImages(t *testing.T) {
 	cases := []struct {
 		name        string
 		attachments []model.Attachment
 		content     string
-		want        string
+		want        bool
 	}{
-		{"none", nil, "just text", ""},
-		{"audio only", []model.Attachment{{Type: "audio"}}, "", ""},
-		{"one image", []model.Attachment{{Type: "image"}}, "", "[img]"},
-		{"one gif", []model.Attachment{{Type: "gif"}}, "", "[img]"},
-		{"image plus gif", []model.Attachment{{Type: "image"}, {Type: "gif"}}, "", "[img +1]"},
-		{"three images", []model.Attachment{{Type: "image"}, {Type: "audio"}, {Type: "image"}, {Type: "image"}}, "", "[img +2]"},
-		{"markdown only, one image", nil, "hi\n\n![a](https://x/a.png)\n\n", "[img]"},
-		{"markdown only, two images", nil, "![a](https://x/a.png)\n\n![b](https://x/b.png)\n\n", "[img +1]"},
-		{"attachment plus markdown image", []model.Attachment{{Type: "audio"}}, "![a](https://x/a.png)\n\n", "[img]"},
+		{"none", nil, "just text", false},
+		{"audio only", []model.Attachment{{Type: "audio"}}, "", false},
+		{"one image", []model.Attachment{{Type: "image"}}, "", true},
+		{"one gif", []model.Attachment{{Type: "gif"}}, "", true},
+		{"image plus gif", []model.Attachment{{Type: "image"}, {Type: "gif"}}, "", true},
+		{"three images", []model.Attachment{{Type: "image"}, {Type: "audio"}, {Type: "image"}, {Type: "image"}}, "", true},
+		{"markdown only, one image", nil, "hi\n\n![a](https://x/a.png)\n\n", true},
+		{"markdown only, two images", nil, "![a](https://x/a.png)\n\n![b](https://x/b.png)\n\n", true},
+		{"attachment plus markdown image", []model.Attachment{{Type: "audio"}}, "![a](https://x/a.png)\n\n", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			out := attachmentIndicator(c.attachments, c.content)
-			if c.want == "" {
+			out := imageIcon(c.attachments, c.content)
+			if !c.want {
 				if out != "" {
-					t.Errorf("expected no badge, got: %q", out)
+					t.Errorf("expected no icon, got: %q", out)
 				}
 				return
 			}
-			if !strings.Contains(out, c.want) {
-				t.Errorf("expected badge to contain %q, got: %q", c.want, out)
+			if !strings.Contains(out, "🖼") {
+				t.Errorf("expected icon to contain 🖼, got: %q", out)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Replace the right-aligned `[img]`/`[img +N]` text badge with a left-aligned 🖼 glyph, chained after the author/timestamp alongside the existing ♫ (audio) and ◉ (watched) icons.
- Drop the image count — the glyph indicates presence only, matching how the other icons behave.
- Applied consistently across all header call sites: feed/post cards, post-detail full post, post-detail replies, and the bookmarks list row.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated `TestAttachmentIndicator_CountsImages` → `TestImageIcon_DetectsImages` for presence-only behavior