### PR TITLE
fix: anchor +/- image scale step to rendered box

### DIFF
--- a/docs/46-image-modal-scale.md
+++ b/docs/46-image-modal-scale.md
@@ -135,6 +135,31 @@ at exactly this margin, that's a signal the true trigger is closer to "any
 non-trivial image size" than "close to full screen," and would need the
 compositing mechanism itself addressed rather than a bigger margin.
 
+## `-` doing nothing right after `+` hits the screen margin
+
+Follow-up report: at max size, `+` correctly does nothing (already at the
+`modalScreenMarginFrac`/`ModalMaxWidth` ceiling) — but the very next `-`
+also did nothing, even though it should always shrink. Reproduced only at
+the max end, never at the min end.
+
+Cause: `adjustImageScale` computed its "current" position by recomputing
+`nativeCols * a.imageScale` — a value with no awareness of the screen-margin
+ceiling. Once the rendered box hit that ceiling, further `+` presses kept
+inflating `a.imageScale` with no visible effect (correctly clamped by
+`openImageInTerminal`), but the *stored* scale value kept climbing past
+what was actually achievable. The next `-` then only walked that invisible
+excess back down by one step — not enough to drop below the ceiling yet, so
+it also produced no visible change. This didn't happen at the min end
+because nothing pushes the box *smaller* than `config.MinImageScale`
+already produces — there's no equivalent invisible slack to build up on
+that side.
+
+Fix: `adjustImageScale` now anchors its step to `a.imageModalCols` — the
+box that's actually rendered right now — instead of recomputing an ideal,
+unclamped value from `a.imageScale`. Since that's always the true on-screen
+size, a.imageScale can never drift past what's achievable, and `-` always
+shrinks immediately on the very next press.
+
 ## Non-fix
 
 This does not change the underlying protocol behavior (iTerm2 still

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3319,20 +3319,36 @@ const modalScreenMarginFrac = 0.8
 // this). No-op if the modal's image isn't cached yet, which shouldn't happen
 // while it's open (the cache is populated the moment it opens) but avoids a
 // lookup panic.
+//
+// The step is based on a.imageModalCols — the box actually on screen right
+// now — not on a value recomputed from a.imageScale. Those two can diverge:
+// openImageInTerminal additionally clamps the rendered box to
+// modalScreenMarginFrac/Layout.ModalMaxWidth, which is a tighter ceiling
+// than config.MaxImageScale in a small terminal. Stepping from the
+// unclamped scale let repeated "+" presses at that ceiling keep inflating
+// a.imageScale with no visible effect (correctly, since the box was already
+// maxed), but then the first "-" press only walked the invisible excess
+// back down one step, so it visibly did nothing either — reported live as
+// "+ does nothing at max size, but then - does nothing too, the first
+// time." Anchoring to the real rendered box instead means the very next
+// "-" press always immediately shrinks it.
 func (a App) adjustImageScale(delta float64) (App, tea.Cmd) {
 	cached, hit := a.imageCache[a.imageModalURL]
 	if !hit || len(cached.frames) == 0 {
 		return a, nil
 	}
-	scale := a.imageScale
-	if scale <= 0 {
-		scale = 1.0
-	}
 	cellW, cellH, _ := imgview.TerminalCellPixelSize(int(os.Stdout.Fd()))
 	b := cached.frames[0].Bounds()
 	nativeCols, _ := imgview.NativeCellBox(b.Dx(), b.Dy(), cellW, cellH)
 
-	currentCols := int(float64(nativeCols)*scale + 0.5)
+	currentCols := a.imageModalCols
+	if currentCols < 1 {
+		scale := a.imageScale
+		if scale <= 0 {
+			scale = 1.0
+		}
+		currentCols = int(float64(nativeCols)*scale + 0.5)
+	}
 	step := int(float64(nativeCols)*imageScaleStep + 0.5)
 	if step < 1 {
 		step = 1

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2920,6 +2920,58 @@ func TestAdjustImageScale_TinyImage_AlwaysMovesAtLeastOneCell(t *testing.T) {
 	}
 }
 
+// TestAdjustImageScale_MinusImmediatelyShrinksAfterHittingScreenMargin is a
+// regression test: openImageInTerminal's screen-margin clamp
+// (modalScreenMarginFrac/Layout.ModalMaxWidth) can cap the rendered box well
+// below what config.MaxImageScale alone would allow for a large native
+// image on a small terminal. adjustImageScale used to step from a value
+// recomputed off a.imageScale, which kept climbing on repeated "+" presses
+// even after the box stopped growing (correctly clamped) — so the first "-"
+// press afterward only walked that invisible excess back down one step,
+// visibly doing nothing either. Reported live as "+ does nothing at max
+// size, then - does nothing the first time too." Fixed by anchoring the
+// step to a.imageModalCols (the box actually on screen), so "-" always
+// shrinks immediately.
+func TestAdjustImageScale_MinusImmediatelyShrinksAfterHittingScreenMargin(t *testing.T) {
+	// 500x500, not something more extreme: large enough that scale=2.0
+	// still hits the screen-margin ceiling (reproducing the bug), but small
+	// enough that scale=0.2 does NOT also collapse onto the same ceiling —
+	// an image so much bigger than the terminal that every scale in
+	// [0.2, 2.0] renders identically would trivially "pass" without
+	// exercising the fix at all.
+	bigImg := image.NewRGBA(image.Rect(0, 0, 500, 500))
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.width, a.height = 100, 40
+	a.imageModalURL = "https://x.com/a.jpg"
+	a.imageCache = map[string]cachedImage{"https://x.com/a.jpg": {frames: []image.Image{bigImg}}}
+	a.imageScale = config.MaxImageScale // simulate having already pressed + repeatedly
+
+	// Render once to populate a.imageModalCols with the true,
+	// screen-margin-clamped box — mirrors what handleImageViewer does for a
+	// real imageFetchedMsg.
+	_, cmd := a.openImageInTerminal(a.imageModalURL)
+	msg := cmd().(imageFetchedMsg)
+	a.imageModalCols = msg.cols
+	a.imageModalRows = msg.rows
+
+	// Setup check: a further "+" is a no-op visually — already at the
+	// screen-margin ceiling, not the (much larger) native-size-relative max.
+	a2, cmd2 := a.adjustImageScale(imageScaleStep)
+	msg2 := cmd2().(imageFetchedMsg)
+	if msg2.cols != msg.cols {
+		t.Fatalf("setup: expected + to have no visible effect at the screen-margin ceiling, got cols %d -> %d", msg.cols, msg2.cols)
+	}
+	a2.imageModalCols = msg2.cols
+
+	// The regression: the very next "-" must immediately shrink the box.
+	_, cmd3 := a2.adjustImageScale(-imageScaleStep)
+	msg3 := cmd3().(imageFetchedMsg)
+	if msg3.cols >= msg2.cols {
+		t.Errorf("expected the first - press after hitting the ceiling to immediately shrink the box, got cols %d -> %d", msg2.cols, msg3.cols)
+	}
+}
+
 // TestOpenImageInTerminal_Scale_ChangesComputedBox confirms imageScale
 // actually reaches the encoder: a larger scale should never produce a
 // smaller cols/rows box than a smaller scale, for a source image large


### PR DESCRIPTION
## Summary

Small follow-up to #119 (image modal scale).

## Bug

At max scale, `+` correctly does nothing (already at the screen-margin/sidebar ceiling). But the very next `-` also did nothing, even though it should always shrink. Never reproduced at the min end.

## Cause

`adjustImageScale` computed its "current" position by recomputing `nativeCols * a.imageScale`, unaware that `openImageInTerminal` separately clamps the actual rendered box (`modalScreenMarginFrac`/`Layout.ModalMaxWidth`). Once the box hit that ceiling, repeated `+` presses kept inflating the stored `a.imageScale` invisibly, so the next `-` only walked that invisible excess back down by one step — not enough to drop below the ceiling yet.

## Fix

Anchor the step to `a.imageModalCols` (the box actually rendered) instead of recomputing from `a.imageScale`. Can no longer drift past what's achievable, so `-` always shrinks on the very next press.

## Testing

`go build/test/vet`, `staticcheck` all clean. New regression test (`TestAdjustImageScale_MinusImmediatelyShrinksAfterHittingScreenMargin`) reproduces the exact reported sequence — deliberately uses a moderately (not extremely) oversized image relative to the terminal to avoid a degenerate case where the whole scale range collapses onto the same box regardless of scale, which would pass trivially without exercising the fix.

Not yet live-tested by the reporter — verified via the regression test and manual trace of the exact fitBox/screen-margin math involved.
