### PR TITLE
feat: settings screen image-option cleanup and graphics protocol override

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -708,7 +708,7 @@ Permissions: `0600` (owner read/write only)
 | `allowRemoteSsh` | bool | `false` | Permit `sshListenAddr` to bind a non-loopback address. SSH server mode is unauthenticated, so this is off by default |
 | `wanderLust` | bool | `false` | Wander mode toggle; `true` = on, `false` = off |
 | `lastWandered` | string | `""` (= never) | ISO timestamp of last wander mode update |
-| `graphicsProtocol` | string | `""` (autodetect) | `"kitty"`, `"iterm2"`, `"sixel"`, or `"none"` — bypasses autodetection when it's unreliable (e.g. mintty/Git Bash). See `docs/41-graphics-protocol-override.md` |
+| `graphicsProtocol` | string | `""` (autodetect) | `"kitty"`, `"iterm2"`, `"sixel"`, or `"none"` — bypasses autodetection when it's unreliable (e.g. mintty/Git Bash). Also editable live from the Settings screen (nested under "image viewer", terminal-only) as `"auto"`/`"kitty"`/`"iterm2"`/`"sixel"` — `"none"` stays config-file-only. See `docs/41-graphics-protocol-override.md` |
 | `imageScale` | number | `0` (= `1.0`) | Multiplier on the fullscreen image modal's display size, relative to the image's own native (1:1 pixel) size — not the terminal window. Clamped to `[0.2, 2.0]`; upscaling past native resolution is allowed (only for the modal). Also live-adjustable with `+`/`-` while the modal is open (session-only, guaranteed at least a 1-cell step per press). See `docs/46-image-modal-scale.md` |
 
 ---

--- a/docs/41-graphics-protocol-override.md
+++ b/docs/41-graphics-protocol-override.md
@@ -41,6 +41,15 @@ Set `"graphicsProtocol"` in `~/.cyber-tui.json`:
 `cmd/cyber-tui/main.go` checks the override first; if `ProtocolFromName` recognizes
 the value, detection and the DA1 probe are skipped entirely.
 
+The same override is also editable live from the Settings screen (nested
+under "image viewer", shown only when that's set to `terminal`), as an
+`auto`/`kitty`/`iterm2`/`sixel` enum — `"none"` isn't offered there since it
+disables the feature rather than picking a protocol, and stays config-file-only.
+Choosing `auto` mid-session re-resolves via `imgview.DetectProtocol()` (env
+vars) only; it does not re-run the Sixel DA1 probe, since that requires raw
+terminal access before Bubble Tea takes over stdin (see `ProbeSixel`'s doc
+comment) — a full restart is needed to re-probe Sixel.
+
 ## Diagnosing further protocol issues
 
 `cfg.Debug: true` (already-existing `debug` config key) redirects the standard

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -446,6 +446,14 @@ type App struct {
 	// image URLs always open in the OS browser even if a protocol is detected.
 	imageViewer string
 
+	// graphicsProtocolName is the user's raw override preference from
+	// config.GraphicsProtocol ("" autodetects; "kitty"/"iterm2"/"sixel" forces a
+	// choice). Kept alongside the already-resolved graphicsProtocol so the
+	// settings screen can display/edit it; saving re-resolves graphicsProtocol
+	// (see settingsSavedMsg handling) without re-running the Sixel DA1 probe,
+	// which requires raw terminal access before Bubble Tea takes over stdin.
+	graphicsProtocolName string
+
 	// inlineImages is the user's raw preference from config.InlineImages.
 	// See canInlineImages for the fully-gated value broadcast to screens.
 	inlineImages bool
@@ -577,6 +585,7 @@ func (a App) WithSavedSession(s config.Config) App {
 	a.wanderLust = s.WanderLust
 	a.maxThreadDepth = s.GetMaxThreadDepth()
 	a.imageViewer = s.ImageViewer
+	a.graphicsProtocolName = s.GraphicsProtocol
 	a.inlineImages = s.InlineImages
 	a.imageScale = s.GetImageScale()
 	a.layoutName = s.Layout
@@ -804,7 +813,7 @@ func (a App) updateAll(msg tea.Msg) App {
 // Call this whenever loc, relaxed, or dimensions change outside of a
 // WindowSizeMsg (e.g. after login, timezone change, or density toggle).
 func (a *App) broadcastConfig() {
-	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
+	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
 	*a = a.updateAll(msg)
 }
 
@@ -1446,6 +1455,7 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		td := msg.MaxThreadDepth
 		tz := msg.Timezone
 		iv := msg.ImageViewer
+		gp := msg.GraphicsProtocol
 		ii := msg.InlineImages
 		ln := msg.LayoutName
 		return a, func() tea.Msg {
@@ -1459,10 +1469,11 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 				cfg.MaxThreadDepth = td
 				cfg.Timezone = tz
 				cfg.ImageViewer = iv
+				cfg.GraphicsProtocol = gp
 				cfg.InlineImages = ii
 				cfg.Layout = ln
 			})
-			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, inlineImages: ii, layoutName: ln}
+			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, graphicsProtocol: gp, inlineImages: ii, layoutName: ln}
 		}, true
 
 	case settingsSavedMsg:
@@ -1471,16 +1482,28 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.maxThreadDepth = msg.maxThreadDepth
 		a.timezone = msg.timezone
 		a.imageViewer = msg.imageViewer
+		a.graphicsProtocolName = msg.graphicsProtocol
+		if proto, ok := imgview.ProtocolFromName(msg.graphicsProtocol); ok {
+			a.graphicsProtocol = proto
+		} else {
+			// "" (auto): re-resolve via env-var detection only. The Sixel DA1
+			// probe (imgview.ProbeSixel) needs raw terminal access before Bubble
+			// Tea takes over stdin, so it can't safely re-run mid-session — see
+			// its doc comment. Best-effort here; a full restart re-probes Sixel.
+			a.graphicsProtocol = imgview.DetectProtocol()
+		}
 		a.inlineImages = msg.inlineImages
 		a.layoutName = msg.layoutName
 		a.layout = layoutFromName(msg.layoutName)
 		a.focus = focusMenu
 		a.loc = config.ParseTimezoneLabel(msg.timezone)
-		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.inlineImages, msg.layoutName)
+		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.graphicsProtocol, msg.inlineImages, msg.layoutName)
 		a.broadcastConfig()
 		a.refreshViewports()
+		var notifyCmd tea.Cmd
+		a, notifyCmd = a.notify(notifyInfo, "settings saved")
 		if min := a.layout.NeedsCompactAutoFill(a.height); min > 0 {
-			var cmds []tea.Cmd
+			cmds := []tea.Cmd{notifyCmd}
 			if cursor := a.feed.NextCursor(); cursor != "" && a.feed.PostCount() < min {
 				cmds = append(cmds, a.loadFeedPageCmd(cursor))
 			}
@@ -1494,11 +1517,9 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 					cmds = append(cmds, a.loadTopicPostsPageCmd(a.topics.ActiveTopicName(), cursor))
 				}
 			}
-			if len(cmds) > 0 {
-				return a, tea.Batch(cmds...), true
-			}
+			return a, tea.Batch(cmds...), true
 		}
-		return a, nil, true
+		return a, notifyCmd, true
 
 	case wanderTickMsg:
 		if msg.gen != a.sessionGen {
@@ -3857,13 +3878,14 @@ type replyEditedMsg struct {
 }
 type settingsLoadedMsg struct{ settings model.Settings }
 type settingsSavedMsg struct {
-	settings       model.Settings
-	wanderLust     bool
-	maxThreadDepth int
-	timezone       string
-	imageViewer    string
-	inlineImages   bool
-	layoutName     string
+	settings         model.Settings
+	wanderLust       bool
+	maxThreadDepth   int
+	timezone         string
+	imageViewer      string
+	graphicsProtocol string
+	inlineImages     bool
+	layoutName       string
 }
 type wanderTickMsg struct{ gen int }
 type wanderDoneMsg struct{ at time.Time } // zero At means no update was made

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -44,6 +44,10 @@ type SharedConfigMsg struct {
 	MaxThreadDepth int
 	Timezone       string
 	ImageViewer    string
+	// GraphicsProtocol is the user's raw override preference
+	// (config.Config.GraphicsProtocol): "" autodetects, or "kitty"/"iterm2"/"sixel"
+	// forces a choice. Used by the settings screen to display/edit the enum.
+	GraphicsProtocol string
 	// InlineImages is the user's raw preference (config.Config.InlineImages),
 	// used by the settings screen to display/edit the toggle.
 	InlineImages bool
@@ -100,14 +104,15 @@ type LeaveChatroomsMsg struct{}
 // with unsaved changes. App.handleSettings calls UpdateSettings and returns
 // settingsSavedMsg or errMsg.
 type SaveSettingsMsg struct {
-	Settings       model.Settings
-	WanderLust     bool
-	MaxThreadDepth int
-	Timezone       string
-	ImageViewer    string
-	InlineImages   bool
-	LayoutName     string // "tabs" or "miller"
-	RemoteChanged  bool   // true when API-managed fields differ from the last saved baseline
+	Settings         model.Settings
+	WanderLust       bool
+	MaxThreadDepth   int
+	Timezone         string
+	ImageViewer      string
+	GraphicsProtocol string
+	InlineImages     bool
+	LayoutName       string // "tabs" or "miller"
+	RemoteChanged    bool   // true when API-managed fields differ from the last saved baseline
 }
 
 // BookmarkedMsg is sent back to the bookmarks screen after a successful CreateBookmark

--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -24,6 +24,8 @@ type settingsItem struct {
 	// Enum items: getEnum reads, cycle advances by delta (wraps).
 	getEnum func(m SettingsModel) string
 	cycle   func(m SettingsModel, delta int) SettingsModel
+	// showIf, when set, hides the item from the flat list unless it returns true.
+	showIf func(m SettingsModel) bool
 }
 
 // settingsGroup is a named section of related rows.
@@ -167,9 +169,37 @@ var settingsGroups = []settingsGroup{
 				},
 			},
 			{
-				label: "inline images (experimental)", kind: "bool",
+				label: "  graphics protocol", kind: "enum",
+				options: []string{"auto", "kitty", "iterm2", "sixel"},
+				getEnum: func(m SettingsModel) string {
+					if m.graphicsProtocol == "" {
+						return "auto"
+					}
+					return m.graphicsProtocol
+				},
+				cycle: func(m SettingsModel, delta int) SettingsModel {
+					cur := m.graphicsProtocol
+					if cur == "" {
+						cur = "auto"
+					}
+					next := cycleStringEnum(cur, []string{"auto", "kitty", "iterm2", "sixel"}, delta)
+					if next == "auto" {
+						next = ""
+					}
+					m.graphicsProtocol = next
+					return m
+				},
+				showIf: func(m SettingsModel) bool {
+					return m.imageViewer != "browser"
+				},
+			},
+			{
+				label: "  inline images (experimental)", kind: "bool",
 				getBool: func(m SettingsModel) bool { return m.inlineImages },
 				toggle:  func(m SettingsModel) SettingsModel { m.inlineImages = !m.inlineImages; return m },
+				showIf: func(m SettingsModel) bool {
+					return m.imageViewer != "browser"
+				},
 			},
 		},
 	},
@@ -183,52 +213,30 @@ var settingsGroups = []settingsGroup{
 			},
 		},
 	},
-	{
-		title: "layout",
-		items: []settingsItem{
-			{
-				label: "layout", kind: "enum",
-				options: []string{"tabs", "miller"},
-				getEnum: func(m SettingsModel) string {
-					if m.layoutName == "miller" {
-						return "miller"
-					}
-					return "tabs"
-				},
-				cycle: func(m SettingsModel, delta int) SettingsModel {
-					cur := m.layoutName
-					if cur == "" {
-						cur = "tabs"
-					}
-					m.layoutName = cycleStringEnum(cur, []string{"tabs", "miller"}, delta)
-					return m
-				},
-			},
-		},
-	},
 }
 
 // SettingsModel is the Settings screen.
 type SettingsModel struct {
-	settings               model.Settings // live/edited values
-	original               model.Settings // last saved baseline
-	wanderLust             bool           // live local config value
-	originalWanderLust     bool           // last saved baseline for wanderLust
-	maxThreadDepth         int            // live local config value (1–5)
-	originalMaxThreadDepth int            // last saved baseline
-	timezone               string         // live local config value (UTC offset label)
-	originalTimezone       string         // last saved baseline
-	imageViewer            string         // live local config value ("terminal" or "browser")
-	originalImageViewer    string         // last saved baseline
-	inlineImages           bool           // live local config value
-	originalInlineImages   bool           // last saved baseline
-	layoutName             string         // live local config value ("tabs" or "miller")
-	originalLayoutName     string         // last saved baseline
-	cursor                 int
-	width                  int
-	height                 int
-	saved                  bool
-	err                    error
+	settings                 model.Settings // live/edited values
+	original                 model.Settings // last saved baseline
+	wanderLust               bool           // live local config value
+	originalWanderLust       bool           // last saved baseline for wanderLust
+	maxThreadDepth           int            // live local config value (1–5)
+	originalMaxThreadDepth   int            // last saved baseline
+	timezone                 string         // live local config value (UTC offset label)
+	originalTimezone         string         // last saved baseline
+	imageViewer              string         // live local config value ("terminal" or "browser")
+	originalImageViewer      string         // last saved baseline
+	graphicsProtocol         string         // live local config value ("" auto, or "kitty"/"iterm2"/"sixel")
+	originalGraphicsProtocol string         // last saved baseline
+	inlineImages             bool           // live local config value
+	originalInlineImages     bool           // last saved baseline
+	layoutName               string         // live local config value ("tabs" or "miller")
+	originalLayoutName       string         // last saved baseline
+	cursor                   int
+	width                    int
+	height                   int
+	err                      error
 }
 
 // NewSettingsModel creates a new SettingsModel.
@@ -240,14 +248,12 @@ func NewSettingsModel() SettingsModel {
 func (m SettingsModel) SetSettings(s model.Settings) SettingsModel {
 	m.settings = s
 	m.original = s
-	m.saved = false
 	m.err = nil
 	return m
 }
 
 // SetSaved marks the current settings as saved and advances the baseline.
-func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, imageViewer string, inlineImages bool, layoutName string) SettingsModel {
-	m.saved = true
+func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, imageViewer, graphicsProtocol string, inlineImages bool, layoutName string) SettingsModel {
 	m.err = nil
 	m.original = m.settings
 	m.wanderLust = wanderLust
@@ -258,6 +264,8 @@ func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, i
 	m.originalTimezone = timezone
 	m.imageViewer = imageViewer
 	m.originalImageViewer = imageViewer
+	m.graphicsProtocol = graphicsProtocol
+	m.originalGraphicsProtocol = graphicsProtocol
 	m.inlineImages = inlineImages
 	m.originalInlineImages = inlineImages
 	m.layoutName = layoutName
@@ -278,6 +286,7 @@ func (m SettingsModel) IsDirty() bool {
 		m.maxThreadDepth != m.originalMaxThreadDepth ||
 		m.timezone != m.originalTimezone ||
 		m.imageViewer != m.originalImageViewer ||
+		m.graphicsProtocol != m.originalGraphicsProtocol ||
 		m.inlineImages != m.originalInlineImages ||
 		m.layoutName != m.originalLayoutName
 }
@@ -292,11 +301,17 @@ func settingsEqual(a, b model.Settings) bool {
 		a.TimeDisplayFormat == b.TimeDisplayFormat
 }
 
-// flatItems returns the flat ordered list of all items across all groups.
-func flatItems() []settingsItem {
+// flatItems returns the flat ordered list of all items across all groups,
+// skipping any item whose showIf returns false for m.
+func flatItems(m SettingsModel) []settingsItem {
 	var out []settingsItem
 	for _, g := range settingsGroups {
-		out = append(out, g.items...)
+		for _, item := range g.items {
+			if item.showIf != nil && !item.showIf(m) {
+				continue
+			}
+			out = append(out, item)
+		}
 	}
 	return out
 }
@@ -363,6 +378,8 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			}
 			m.imageViewer = iv
 			m.originalImageViewer = iv
+			m.graphicsProtocol = msg.GraphicsProtocol
+			m.originalGraphicsProtocol = msg.GraphicsProtocol
 			m.inlineImages = msg.InlineImages
 			m.originalInlineImages = msg.InlineImages
 			m.layoutName = msg.LayoutName
@@ -376,7 +393,7 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		items := flatItems()
+		items := flatItems(m)
 		total := len(items)
 
 		switch msg.String() {
@@ -391,21 +408,20 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 		case " ", "enter": // space (bubbletea KeySpace.String() == " ") or enter
 			if m.cursor < total && items[m.cursor].kind == "bool" {
 				m = items[m.cursor].toggle(m)
-				m.saved = false
 			}
 			return m, nil
 
 		case "tab":
 			if m.cursor < total && items[m.cursor].kind == "enum" {
 				m = items[m.cursor].cycle(m, +1)
-				m.saved = false
+				m.cursor = min(m.cursor, len(flatItems(m))-1)
 			}
 			return m, nil
 
 		case "shift+tab":
 			if m.cursor < total && items[m.cursor].kind == "enum" {
 				m = items[m.cursor].cycle(m, -1)
-				m.saved = false
+				m.cursor = min(m.cursor, len(flatItems(m))-1)
 			}
 			return m, nil
 
@@ -416,11 +432,12 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				td := m.maxThreadDepth
 				tz := m.timezone
 				iv := m.imageViewer
+				gp := m.graphicsProtocol
 				ii := m.inlineImages
 				ln := m.layoutName
 				remoteChanged := !settingsEqual(m.settings, m.original)
 				return m, func() tea.Msg {
-					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, InlineImages: ii, LayoutName: ln, RemoteChanged: remoteChanged}
+					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, GraphicsProtocol: gp, InlineImages: ii, LayoutName: ln, RemoteChanged: remoteChanged}
 				}
 			}
 			return m, nil
@@ -432,9 +449,9 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			m.maxThreadDepth = m.originalMaxThreadDepth
 			m.timezone = m.originalTimezone
 			m.imageViewer = m.originalImageViewer
+			m.graphicsProtocol = m.originalGraphicsProtocol
 			m.inlineImages = m.originalInlineImages
 			m.layoutName = m.originalLayoutName
-			m.saved = false
 			m.err = nil
 			return m, nil
 		}
@@ -456,6 +473,9 @@ func (m SettingsModel) View() string {
 		rows = append(rows, theme.Title.Render(g.title))
 
 		for _, item := range g.items {
+			if item.showIf != nil && !item.showIf(m) {
+				continue
+			}
 			selected := m.cursor == flatIdx
 			if selected {
 				cursorRow = len(rows) // track which row the cursor is on
@@ -532,8 +552,6 @@ func (m SettingsModel) View() string {
 	var footer string
 	if m.err != nil {
 		footer = theme.Error.Render("error: " + m.err.Error())
-	} else if m.saved {
-		footer = theme.Highlight.Render("saved!")
 	} else if m.IsDirty() {
 		footer = theme.Subtle.Render("ctrl+s · save   esc · revert")
 	} else {

--- a/internal/ui/screens/settings_test.go
+++ b/internal/ui/screens/settings_test.go
@@ -45,7 +45,7 @@ func keyMsg(key string) tea.KeyMsg {
 	case "right":
 		msg = tea.KeyMsg{Type: tea.KeyRight}
 	case "ctrl+s":
-		// Bubble Tea represents ctrl+s differently — just send the raw rune with ctrl modifier
+		// Bubble Tea represents ctrl+s differently â€” just send the raw rune with ctrl modifier
 		msg = tea.KeyMsg{Type: tea.KeyCtrlS, Runes: []rune{'s'}}
 	default:
 		msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
@@ -64,14 +64,14 @@ func TestSettings_CursorDown_Increments(t *testing.T) {
 func TestSettings_CursorUp_WrapsToBottom(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m, _ = m.Update(keyMsg("k"))
-	if m.cursor != len(flatItems())-1 {
-		t.Errorf("expected cursor=%d (wrapped), got %d", len(flatItems())-1, m.cursor)
+	if m.cursor != len(flatItems(m))-1 {
+		t.Errorf("expected cursor=%d (wrapped), got %d", len(flatItems(m))-1, m.cursor)
 	}
 }
 
 func TestSettings_CursorDown_WrapsToTop(t *testing.T) {
 	m := initSettings(defaultSettings())
-	m.cursor = len(flatItems()) - 1
+	m.cursor = len(flatItems(m)) - 1
 	m, _ = m.Update(keyMsg("j"))
 	if m.cursor != 0 {
 		t.Errorf("expected cursor=0 (wrapped), got %d", m.cursor)
@@ -250,7 +250,7 @@ func TestSettings_Esc_ClearsError(t *testing.T) {
 func TestSettings_SetSaved_ClearsError(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m = m.SetError(testErr)
-	m = m.SetSaved(false, 3, "UTC", "terminal", false, "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, "tabs")
 	if m.err != nil {
 		t.Error("SetSaved should clear error")
 	}
@@ -262,7 +262,7 @@ func TestSettings_SetSaved_AdvancesBaseline(t *testing.T) {
 	if !m.IsDirty() {
 		t.Error("should be dirty after change")
 	}
-	m = m.SetSaved(false, 3, "UTC", "terminal", false, "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, "tabs")
 	if m.IsDirty() {
 		t.Error("after SetSaved, should not be dirty")
 	}
@@ -387,7 +387,7 @@ func TestSettings_View_DirtyFooterHint(t *testing.T) {
 
 func TestSettings_View_SavedMessage(t *testing.T) {
 	m := initSettings(defaultSettings())
-	m = m.SetSaved(false, 3, "UTC", "terminal", false, "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, "tabs")
 	view := m.View()
 	if !containsSubstring(view, "saved!") {
 		t.Error("View should show 'saved!' when saved=true")
@@ -416,7 +416,7 @@ func TestSettings_WanderGroup_Visible(t *testing.T) {
 func TestSettings_WanderToggle(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
-	m.cursor = 12 // wander mode item
+	m.cursor = 13 // wander mode item
 	m, _ = m.Update(keyMsg("enter"))
 	if m.wanderLust {
 		t.Error("toggling wander mode should flip wanderLust to false")
@@ -458,7 +458,7 @@ func TestSettings_WanderSetSaved(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
 	m.originalWanderLust = false // dirty
-	m = m.SetSaved(true, 3, "UTC", "terminal", false, "tabs")
+	m = m.SetSaved(true, 3, "UTC", "terminal", "", false, "tabs")
 	if m.originalWanderLust != true {
 		t.Error("SetSaved should update originalWanderLust to the saved value")
 	}
@@ -493,7 +493,7 @@ func TestSettings_Timezone_CyclesBackward(t *testing.T) {
 
 func TestSettings_Timezone_Wraps(t *testing.T) {
 	m := initSettings(defaultSettings())
-	items := flatItems()
+	items := flatItems(m)
 	last := items[9].options[len(items[9].options)-1]
 	m.timezone = last
 	m.originalTimezone = last


### PR DESCRIPTION
## Summary
- Removed the miller layout option from the settings screen picker. MillerLayout itself is untouched (still selectable via the `layout` config key); the settings-screen enum just no longer offers a dead single-option (`tabs`-only) cycle.
- Nested "inline images (experimental)" under "image viewer", shown only when set to `terminal` (it's meaningless when browser-opened).
- Moved the settings-saved indicator from the screen's own footer to the existing global notification bar (`a.notify(notifyInfo, ...)`), consistent with other transient confirmations.
- Added a "graphics protocol" enum (`auto`/`kitty`/`iterm2`/`sixel`) nested under "image viewer", editable live and persisted to the existing `graphicsProtocol` config key. `auto` re-resolves via env-var detection only mid-session (the Sixel DA1 probe can't safely re-run after Bubble Tea owns stdin — full restart re-probes Sixel).

## Testing
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./internal/ui/...`

## Docs
- `docs/00-project-reference.md` and `docs/41-graphics-protocol-override.md` updated to note the new in-app editing path for `graphicsProtocol`.
