### PR TITLE
feat: /wave animation sweeps a 10-wide comb back and forth

### DIFF
--- a/internal/ui/screens/chatstyle.go
+++ b/internal/ui/screens/chatstyle.go
@@ -172,23 +172,38 @@ func glitchHash(msgID string, index, frame int) uint32 {
 	return h.Sum32()
 }
 
-// applyWave flips the case of a single rune position that sweeps
-// left-to-right across body, advancing one position per animation frame —
-// the same case-toggle mechanism as applyGlitch, but restricted to one
-// moving position instead of jittering ~1/3 of all letters at once. Sweeping
-// onto a non-letter (space, punctuation) is a no-op that frame, same as the
-// wave passing invisibly through whitespace.
+// waveSpacing is the gap, in runes, between simultaneously-highlighted
+// positions in applyWave's comb pattern.
+const waveSpacing = 10
+
+// applyWave flips the case of a comb of rune positions, spaced waveSpacing
+// apart and anchored at index 0, that bounces back and forth: the comb
+// shifts right one position per animation frame until it reaches the far
+// end of a waveSpacing-wide cycle, then reverses and shifts left, ping-pong
+// style, rather than snapping back to the start. Sweeping onto a non-letter
+// (space, punctuation) is a no-op that frame, same as the wave passing
+// invisibly through whitespace.
 func applyWave(body string, frame int) string {
 	runes := []rune(body)
-	if len(runes) == 0 {
+	n := len(runes)
+	if n == 0 {
 		return body
 	}
-	pos := frame % len(runes)
-	r := runes[pos]
-	if unicode.IsUpper(r) {
-		runes[pos] = unicode.ToLower(r)
-	} else if unicode.IsLower(r) {
-		runes[pos] = unicode.ToUpper(r)
+	const bouncePeriod = 2 * (waveSpacing - 1)
+	t := frame % bouncePeriod
+	phase := t
+	if t > waveSpacing-1 {
+		phase = bouncePeriod - t
+	}
+	for i, r := range runes {
+		if i%waveSpacing != phase {
+			continue
+		}
+		if unicode.IsUpper(r) {
+			runes[i] = unicode.ToLower(r)
+		} else if unicode.IsLower(r) {
+			runes[i] = unicode.ToUpper(r)
+		}
 	}
 	return string(runes)
 }

--- a/internal/ui/screens/chatstyle_test.go
+++ b/internal/ui/screens/chatstyle_test.go
@@ -81,18 +81,27 @@ func TestSubstituteChars_Slow_SameAcrossFrames(t *testing.T) {
 	}
 }
 
-func TestSubstituteChars_Wave_TogglesOneMovingPosition(t *testing.T) {
-	got0 := substituteChars("abc", "m1", []string{styleWave}, 0)
-	if got0 != "Abc" {
-		t.Errorf("substituteChars wave frame=0 = %q, want Abc", got0)
+func TestSubstituteChars_Wave_CombBouncesBackAndForth(t *testing.T) {
+	// 12 runes, waveSpacing 10: comb starts at index 0 and shifts right each
+	// frame through frame 9 (the far end of the 10-wide cycle), then
+	// reverses and shifts left back through frame 17, mirroring frames 1-8.
+	body := "abcdefghijkl"
+	cases := []struct {
+		frame int
+		want  string
+	}{
+		{0, "AbcdefghijKl"},  // comb at {0,10}: start, anchored left
+		{1, "aBcdefghijkL"},  // comb at {1,11}: shifted right
+		{9, "abcdefghiJkl"},  // comb at {9}: far end of the cycle
+		{10, "abcdefghIjkl"}, // comb at {8}: reversed, shifting left
+		{17, "aBcdefghijkL"}, // comb at {1,11}: mirrors frame 1
+		{18, "AbcdefghijKl"}, // comb at {0,10}: mirrors frame 0, cycle repeats
 	}
-	got1 := substituteChars("abc", "m1", []string{styleWave}, 1)
-	if got1 != "aBc" {
-		t.Errorf("substituteChars wave frame=1 = %q, want aBc", got1)
-	}
-	got3 := substituteChars("abc", "m1", []string{styleWave}, 3) // wraps: 3%3 == 0
-	if got3 != "Abc" {
-		t.Errorf("substituteChars wave frame=3 = %q, want Abc (wraps to position 0)", got3)
+	for _, c := range cases {
+		got := substituteChars(body, "m1", []string{styleWave}, c.frame)
+		if got != c.want {
+			t.Errorf("substituteChars wave frame=%d = %q, want %q", c.frame, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `/wave` now flips the case of a comb of positions spaced 10 runes apart, anchored at the left edge, and ping-pongs back and forth instead of a single character wrapping around
- Replaces the earlier two-sided sweep (tested live, looked too glitch-like on short messages) with a calmer single-origin bounce

## Test plan
- [x] `go test ./internal/ui/screens/... -run Wave -v`
- [x] `go test ./...`
- [x] `go build ./...` / `go vet ./...`
- [x] Manually verified in a live cIRC room with `/wave`