### PR TITLE
feat: view sender profile from a highlighted cIRC/C-Mail message

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1242,6 +1242,12 @@ func (a App) handleChatrooms(msg tea.Msg) (App, tea.Cmd, bool) {
 	case roomCommandReplyMsg:
 		a.chatrooms = a.chatrooms.AppendSystemMessage(msg.roomID, sanitize.Strip(msg.reply))
 		return a, a.loadSettingsCmd(), true
+	case screens.ShowUserProfileMsg:
+		if a.active != screenChatrooms {
+			return a, nil, false
+		}
+		a.profileReturn = screenChatrooms
+		return a, a.loadUserProfileCmd(msg.Username), true
 	case screens.LeaveChatroomsMsg:
 		a.active = a.chatroomsReturn
 		return a, nil, true
@@ -1293,6 +1299,12 @@ func (a App) handleCMail(msg tea.Msg) (App, tea.Cmd, bool) {
 	case cmailCommandReplyMsg:
 		a.cmail = a.cmail.AppendSystemMessage(msg.convID, sanitize.Strip(msg.reply))
 		return a, nil, true
+	case screens.ShowUserProfileMsg:
+		if a.active != screenCMail {
+			return a, nil, false
+		}
+		a.profileReturn = screenCMail
+		return a, a.loadUserProfileCmd(msg.Username), true
 	case screens.LeaveCMailMsg:
 		a.active = a.cmailReturn
 		return a, nil, true

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -1788,11 +1788,11 @@ func (m ChatroomsModel) maybeLoadOlderMessages() (ChatroomsModel, tea.Cmd) {
 
 // updateBrowsingKey handles keys while a message is selected
 // (m.selectedMsgID != ""): up/down move the selection, esc returns to
-// typing, '!' reports the selected message, enter toggles a spoiler- or
-// l33t-styled message's reveal state. Everything else is swallowed
-// rather than typed, since the input is blurred for the duration of
-// browsing — see the 'up' case in the typing-mode switch, the only place
-// browsing is entered.
+// typing, '!' reports the selected message, 'p' views the sender's
+// profile, enter toggles a spoiler- or l33t-styled message's reveal
+// state. Everything else is swallowed rather than typed, since the
+// input is blurred for the duration of browsing — see the 'up' case in
+// the typing-mode switch, the only place browsing is entered.
 func (m ChatroomsModel) updateBrowsingKey(msg tea.KeyMsg) (ChatroomsModel, tea.Cmd) {
 	if m.confirmingDeleteMsg {
 		switch msg.String() {
@@ -1885,6 +1885,13 @@ func (m ChatroomsModel) updateBrowsingKey(msg tea.KeyMsg) (ChatroomsModel, tea.C
 		m.confirmingDeleteMsg = true
 		m.viewport.Height = m.viewportHeight()
 		return m, nil
+	case "p":
+		targetMsg, ok := findMessageByID(m.messages, m.selectedMsgID)
+		if !ok {
+			return m, nil
+		}
+		username := targetMsg.From.Username
+		return m, func() tea.Msg { return ShowUserProfileMsg{Username: username} }
 	}
 	return m, nil
 }

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -1439,6 +1439,41 @@ func TestBrowsing_Enter_TogglesL33tReveal(t *testing.T) {
 	}
 }
 
+// --- view profile (see updateBrowsingKey's "p" case) ---
+
+func TestBrowsing_P_EmitsShowUserProfileMsg(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "hi", CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	sp, ok := cmd().(ShowUserProfileMsg)
+	if !ok {
+		t.Fatalf("expected ShowUserProfileMsg, got %T", cmd())
+	}
+	if sp.Username != "molly" {
+		t.Errorf("Username = %q, want molly", sp.Username)
+	}
+}
+
+func TestBrowsing_P_NoSelectedMessage_IsNoop(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", nil)
+
+	_, cmd := m.updateBrowsingKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	if cmd != nil {
+		t.Error("expected no-op when nothing is selected")
+	}
+}
+
 // --- message buffer byte cap (trimMessageBuffer) ---
 
 // bigMessage returns a message whose estimated size is roughly n bytes, via

--- a/internal/ui/screens/cmail.go
+++ b/internal/ui/screens/cmail.go
@@ -1215,12 +1215,12 @@ func (m CMailModel) updateInner(msg tea.Msg) (CMailModel, tea.Cmd) {
 
 // updateCMailBrowsingKey handles keys while a message is selected
 // (m.selectedMsgID != ""): up/down move the selection, esc returns to
-// typing. Everything else is swallowed rather than typed, since the input
-// is blurred for the duration of browsing — mirrors
-// ChatroomsModel.updateBrowsingKey, trimmed to what CMail supports: no
-// flag/delete (the API has no CMail message flag/delete endpoint) and no
-// spoiler/l33t reveal (CMail's render pipeline doesn't support those
-// styles).
+// typing, 'p' views the sender's profile. Everything else is swallowed
+// rather than typed, since the input is blurred for the duration of
+// browsing — mirrors ChatroomsModel.updateBrowsingKey, trimmed to what
+// CMail supports: no flag/delete (the API has no CMail message
+// flag/delete endpoint) and no spoiler/l33t reveal (CMail's render
+// pipeline doesn't support those styles).
 func (m CMailModel) updateCMailBrowsingKey(msg tea.KeyMsg) (CMailModel, tea.Cmd) {
 	if m.activeConv == nil {
 		m.selectedMsgID = ""
@@ -1270,6 +1270,13 @@ func (m CMailModel) updateCMailBrowsingKey(msg tea.KeyMsg) (CMailModel, tea.Cmd)
 		m.selectedMsgID = m.activeConv.Messages[sel[newPos]].ID
 		m.viewport.SetYOffset(newOffset)
 		return m.refreshMessages(), nil
+	case "p":
+		targetMsg, ok := findMessageByID(m.activeConv.Messages, m.selectedMsgID)
+		if !ok {
+			return m, nil
+		}
+		username := targetMsg.From.Username
+		return m, func() tea.Msg { return ShowUserProfileMsg{Username: username} }
 	}
 	return m, nil
 }

--- a/internal/ui/screens/cmail_test.go
+++ b/internal/ui/screens/cmail_test.go
@@ -1003,3 +1003,38 @@ func TestCMail_VisibleInlineImages_LastMessageImage_AfterRealRowsKnown(t *testin
 		t.Fatalf("expected the last message's image to stay visible after its band shrank, got %d slots: %+v", len(slots), slots)
 	}
 }
+
+// --- view profile (see updateCMailBrowsingKey's "p" case) ---
+
+func TestCMailBrowsing_P_EmitsShowUserProfileMsg(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	m = m.SetConversationMessages("c1", []model.Message{
+		{ID: "m1", From: model.User{Username: "trinity"}, Body: "hi", CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	sp, ok := cmd().(ShowUserProfileMsg)
+	if !ok {
+		t.Fatalf("expected ShowUserProfileMsg, got %T", cmd())
+	}
+	if sp.Username != "trinity" {
+		t.Errorf("Username = %q, want trinity", sp.Username)
+	}
+}
+
+func TestCMailBrowsing_P_NoSelectedMessage_IsNoop(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	m = m.SetConversationMessages("c1", nil)
+
+	_, cmd := m.updateCMailBrowsingKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	if cmd != nil {
+		t.Error("expected no-op when nothing is selected")
+	}
+}

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -66,8 +66,9 @@ type URLProvider interface {
 	GetFocusedURLs() []string
 }
 
-// ShowUserProfileMsg is emitted by Feed, PostDetail, and Notifications when
-// the user presses 'p' on the highlighted item.
+// ShowUserProfileMsg is emitted by Feed, PostDetail, Notifications,
+// Guilds, Search, Chatrooms, and CMail when the user presses 'p' on the
+// highlighted item.
 type ShowUserProfileMsg struct{ Username string }
 
 // StartConversationMsg is emitted by any screen when the user presses 'c' on a


### PR DESCRIPTION
## Summary
- Adds a `p` key in message-browsing mode (cIRC rooms and C-Mail conversations) that opens the highlighted message's sender profile, matching the existing convention in Feed/PostDetail/Notifications/Guilds/Search
- Reuses the existing `ShowUserProfileMsg` type and `loadUserProfileCmd`/`profileReturn` routing; no new abstractions
- No guard needed against system messages: `selectableMessageIndices` already filters those out of what can be highlighted

## Test plan
- [x] `go test ./internal/ui/screens/... -run 'Browsing_P|CMailBrowsing_P' -v`
- [x] `go test ./...`
- [x] `go build ./...` / `go vet ./...`
- [x] Manually verified live in tmux: highlighted a cIRC message, pressed `p`, opened the sender's read-only profile, `esc` returned to the room; same in C-Mail for both the other participant's message and my own