### PR TITLE
Attach images/GIFs, circ message shortcuts, presence sort

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -362,12 +362,13 @@ type flagResponseData struct {
 }
 
 type createPostRequest struct {
-	Content  string   `json:"content"`
-	Title    string   `json:"title,omitempty"`
-	Topics   []string `json:"topics"`
-	IsPublic bool     `json:"isPublic"`
-	IsNSFW   bool     `json:"isNSFW"`
-	Slug     string   `json:"slug,omitempty"`
+	Content     string           `json:"content"`
+	Title       string           `json:"title,omitempty"`
+	Topics      []string         `json:"topics"`
+	IsPublic    bool             `json:"isPublic"`
+	IsNSFW      bool             `json:"isNSFW"`
+	Slug        string           `json:"slug,omitempty"`
+	Attachments []wireAttachment `json:"attachments,omitempty"`
 }
 
 type createPostResponseData struct {
@@ -378,12 +379,17 @@ type createPostResponseData struct {
 
 // editPostRequest deliberately omits omitempty on Title: the API accepts ""
 // to clear an existing title, and omitempty would silently drop that intent.
+// Attachments is a pointer for the same reason omitempty doesn't work for
+// Title: nil means "don't touch existing attachments" (omitted from the
+// JSON), while a non-nil pointer — even to an empty slice — is sent as-is,
+// replacing them (per the API: "Send [] to remove them").
 type editPostRequest struct {
-	Content  string   `json:"content"`
-	Title    string   `json:"title"`
-	Topics   []string `json:"topics"`
-	IsPublic bool     `json:"isPublic"`
-	IsNSFW   bool     `json:"isNSFW"`
+	Content     string            `json:"content"`
+	Title       string            `json:"title"`
+	Topics      []string          `json:"topics"`
+	IsPublic    bool              `json:"isPublic"`
+	IsNSFW      bool              `json:"isNSFW"`
+	Attachments *[]wireAttachment `json:"attachments,omitempty"`
 }
 
 type editReplyRequest struct {
@@ -920,6 +926,21 @@ func wireAttachmentsToModel(ws []wireAttachment) []model.Attachment {
 	return out
 }
 
+// wireAttachmentFromModel converts a model.Attachment to its wire shape, for
+// requests that set attachments (CreatePost, EditPost).
+func wireAttachmentFromModel(a model.Attachment) wireAttachment {
+	return wireAttachment{
+		Type:   a.Type,
+		Src:    a.Src,
+		Width:  a.Width,
+		Height: a.Height,
+		Origin: a.Origin,
+		Artist: a.Artist,
+		Title:  a.Title,
+		Genre:  a.Genre,
+	}
+}
+
 // wireAudioAttachmentToModel converts a message's optional audioAttachment
 // object to the model type. Returns nil when w is nil.
 func wireAudioAttachmentToModel(w *wireAttachment) *model.Attachment {
@@ -1310,14 +1331,19 @@ func (c *HTTPClient) GetPostReplies(postID string) ([]model.Reply, error) {
 	return all, nil
 }
 
-func (c *HTTPClient) CreatePost(content, title, slug string, topics []string, isPublic, isNSFW bool) (model.Post, error) {
+func (c *HTTPClient) CreatePost(content, title, slug string, topics []string, isPublic, isNSFW bool, attachment *model.Attachment) (model.Post, error) {
+	var attachments []wireAttachment
+	if attachment != nil {
+		attachments = []wireAttachment{wireAttachmentFromModel(*attachment)}
+	}
 	env, err := c.doJSON("POST", "/v1/posts", createPostRequest{
-		Content:  content,
-		Title:    title,
-		Topics:   topics,
-		IsPublic: isPublic,
-		IsNSFW:   isNSFW,
-		Slug:     slug,
+		Content:     content,
+		Title:       title,
+		Topics:      topics,
+		IsPublic:    isPublic,
+		IsNSFW:      isNSFW,
+		Slug:        slug,
+		Attachments: attachments,
 	})
 	if err != nil {
 		return model.Post{}, err
@@ -1338,13 +1364,22 @@ func (c *HTTPClient) CreatePost(content, title, slug string, topics []string, is
 	}, nil
 }
 
-func (c *HTTPClient) EditPost(postID, content, title string, topics []string, isPublic, isNSFW bool) error {
+func (c *HTTPClient) EditPost(postID, content, title string, topics []string, isPublic, isNSFW bool, attachments []model.Attachment, attachmentTouched bool) error {
+	var wireAttachments *[]wireAttachment
+	if attachmentTouched {
+		list := make([]wireAttachment, len(attachments))
+		for i, a := range attachments {
+			list[i] = wireAttachmentFromModel(a)
+		}
+		wireAttachments = &list
+	}
 	_, err := c.doJSON("PATCH", "/v1/posts/"+url.PathEscape(postID), editPostRequest{
-		Content:  content,
-		Title:    title,
-		Topics:   topics,
-		IsPublic: isPublic,
-		IsNSFW:   isNSFW,
+		Content:     content,
+		Title:       title,
+		Topics:      topics,
+		IsPublic:    isPublic,
+		IsNSFW:      isNSFW,
+		Attachments: wireAttachments,
 	})
 	return err
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -251,7 +251,7 @@ func TestHTTPCreatePost_SendsAllFields(t *testing.T) {
 	})))
 	c.Login("u@example.com", "pass") //nolint:errcheck
 
-	post, err := c.CreatePost("body text", "My Title", "", []string{"cyber"}, true, true)
+	post, err := c.CreatePost("body text", "My Title", "", []string{"cyber"}, true, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3451,7 +3451,7 @@ func TestHTTPEditPost_CallsCorrectEndpoint(t *testing.T) {
 	})))
 	c.Login("u@example.com", "pass")
 
-	err := c.EditPost("p1", "corrected content", "New Title", []string{"go", "cli"}, true, false)
+	err := c.EditPost("p1", "corrected content", "New Title", []string{"go", "cli"}, true, false, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3484,7 +3484,7 @@ func TestHTTPEditPost_SendsEmptyTitleToClear(t *testing.T) {
 	})))
 	c.Login("u@example.com", "pass")
 
-	if err := c.EditPost("p1", "content", "", nil, false, false); err != nil {
+	if err := c.EditPost("p1", "content", "", nil, false, false, nil, false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !sawTitleKey {
@@ -3495,13 +3495,106 @@ func TestHTTPEditPost_SendsEmptyTitleToClear(t *testing.T) {
 	}
 }
 
+func TestHTTPCreatePost_SendsAttachment(t *testing.T) {
+	var gotBody map[string]any
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		writeOK(t, w, map[string]any{"postId": "p1"})
+	})))
+	c.Login("u@example.com", "pass")
+
+	attachment := &model.Attachment{Type: "gif", Src: "https://example.com/pic.gif", Width: 100, Height: 80}
+	if _, err := c.CreatePost("content", "", "", nil, false, false, attachment); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	attachments, ok := gotBody["attachments"].([]any)
+	if !ok || len(attachments) != 1 {
+		t.Fatalf("attachments = %v, want a single-element array", gotBody["attachments"])
+	}
+	att, _ := attachments[0].(map[string]any)
+	if att["type"] != "gif" || att["src"] != "https://example.com/pic.gif" || att["width"] != float64(100) || att["height"] != float64(80) {
+		t.Errorf("attachment = %v, want type=gif src=https://example.com/pic.gif width=100 height=80", att)
+	}
+}
+
+func TestHTTPCreatePost_NoAttachmentURL_OmitsAttachments(t *testing.T) {
+	var gotBody map[string]any
+	sawAttachmentsKey := false
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		sawAttachmentsKey = strings.Contains(string(raw), `"attachments"`)
+		json.Unmarshal(raw, &gotBody)
+		writeOK(t, w, map[string]any{"postId": "p1"})
+	})))
+	c.Login("u@example.com", "pass")
+
+	if _, err := c.CreatePost("content", "", "", nil, false, false, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawAttachmentsKey {
+		t.Fatal(`request body has "attachments" key with no attachment to send`)
+	}
+}
+
+// TestHTTPEditPost_AttachmentTouched covers the states EditPost's
+// attachmentTouched/attachments pair can produce on the wire: untouched
+// (field omitted, existing attachments left alone), touched+empty (field
+// sent as [], clearing them), touched+one (field sent as a one-element
+// array, replacing them), and touched+multiple (the shape a caller sends to
+// preserve an unrelated attachment — e.g. audio — alongside a new one,
+// since the API replaces the whole array).
+func TestHTTPEditPost_AttachmentTouched(t *testing.T) {
+	cases := []struct {
+		name              string
+		attachments       []model.Attachment
+		attachmentTouched bool
+		wantKeyPresent    bool
+		wantLen           int
+	}{
+		{"untouched omits the field", nil, false, false, 0},
+		{"touched+empty clears", nil, true, true, 0},
+		{"touched+one sets", []model.Attachment{{Type: "image", Src: "https://example.com/pic.png", Width: 100, Height: 100}}, true, true, 1},
+		{"touched+multiple preserves both", []model.Attachment{
+			{Type: "audio", Src: "https://youtu.be/x", Origin: "youtube", Artist: "a", Title: "t"},
+			{Type: "image", Src: "https://example.com/pic.png", Width: 100, Height: 100},
+		}, true, true, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			sawKey := false
+			c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw, _ := io.ReadAll(r.Body)
+				sawKey = strings.Contains(string(raw), `"attachments"`)
+				json.Unmarshal(raw, &gotBody)
+				writeOK(t, w, map[string]any{"postId": "p1"})
+			})))
+			c.Login("u@example.com", "pass")
+
+			if err := c.EditPost("p1", "content", "title", nil, false, false, tc.attachments, tc.attachmentTouched); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sawKey != tc.wantKeyPresent {
+				t.Fatalf(`"attachments" key present = %v, want %v`, sawKey, tc.wantKeyPresent)
+			}
+			if !tc.wantKeyPresent {
+				return
+			}
+			attachments, _ := gotBody["attachments"].([]any)
+			if len(attachments) != tc.wantLen {
+				t.Errorf("attachments = %v, want len %d", gotBody["attachments"], tc.wantLen)
+			}
+		})
+	}
+}
+
 func TestHTTPEditPost_Forbidden(t *testing.T) {
 	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusForbidden, "FORBIDDEN", "outside edit window")
 	})))
 	c.Login("u@example.com", "pass")
 
-	err := c.EditPost("p1", "content", "title", nil, false, false)
+	err := c.EditPost("p1", "content", "title", nil, false, false, nil, false)
 	apiErr, ok := asAPIError(err)
 	if !ok {
 		t.Fatalf("expected *APIError, got %T: %v", err, err)

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -27,7 +27,10 @@ type Client interface {
 	// Feed — pass empty cursor for first page; use returned cursor for next page.
 	// Returns empty next-cursor when there are no more pages.
 	GetFeed(cursor string) ([]model.Post, string, error)
-	CreatePost(content, title, slug string, topics []string, isPublic, isNSFW bool) (model.Post, error)
+	// attachment, if non-nil, attaches an image/gif by URL — the caller must
+	// resolve Type/Width/Height itself (the API requires width/height on the
+	// request and does not compute them server-side).
+	CreatePost(content, title, slug string, topics []string, isPublic, isNSFW bool, attachment *model.Attachment) (model.Post, error)
 	// GetPost fetches a single post by ID (used when jumping from a notification).
 	GetPost(postID string) (model.Post, error)
 	// GetPostBySlug fetches a single post by its author's username and per-author
@@ -186,7 +189,11 @@ type Client interface {
 	// only, within 5 minutes of publishing; returns an *APIError with Status 403
 	// otherwise. The response carries no fields worth returning — the caller
 	// already has the full edited state and merges it locally.
-	EditPost(postID, content, title string, topics []string, isPublic, isNSFW bool) error
+	// attachmentTouched controls whether the attachments field is sent at all:
+	// false leaves any existing attachments untouched; true replaces them
+	// wholesale with attachments (the caller is responsible for including
+	// anything it wants kept, e.g. an unrelated audio attachment).
+	EditPost(postID, content, title string, topics []string, isPublic, isNSFW bool, attachments []model.Attachment, attachmentTouched bool) error
 
 	// Replies — deletion.
 	// DeleteReply soft-deletes a reply owned by the authenticated user.

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -235,7 +235,11 @@ func (m *MockClient) GetPostReplies(postID string) ([]model.Reply, error) {
 	}, nil
 }
 
-func (m *MockClient) CreatePost(content, title, slug string, topics []string, isPublic, isNSFW bool) (model.Post, error) {
+func (m *MockClient) CreatePost(content, title, slug string, topics []string, isPublic, isNSFW bool, attachment *model.Attachment) (model.Post, error) {
+	var attachments []model.Attachment
+	if attachment != nil {
+		attachments = []model.Attachment{*attachment}
+	}
 	return model.Post{
 		ID:             "new-1",
 		AuthorID:       mockUsers[0].ID,
@@ -246,6 +250,7 @@ func (m *MockClient) CreatePost(content, title, slug string, topics []string, is
 		Topics:         topics,
 		IsPublic:       isPublic,
 		IsNSFW:         isNSFW,
+		Attachments:    attachments,
 	}, nil
 }
 
@@ -253,7 +258,7 @@ func (m *MockClient) DeletePost(postID string) error {
 	return nil // no-op: in-memory feed is rebuilt on each GetFeed call
 }
 
-func (m *MockClient) EditPost(postID, content, title string, topics []string, isPublic, isNSFW bool) error {
+func (m *MockClient) EditPost(postID, content, title string, topics []string, isPublic, isNSFW bool, attachments []model.Attachment, attachmentTouched bool) error {
 	return nil
 }
 

--- a/internal/api/mock_test.go
+++ b/internal/api/mock_test.go
@@ -152,7 +152,7 @@ func TestMockGetFeed_ReturnsEmptyCursor(t *testing.T) {
 
 func TestMockCreatePost_ReturnsPost(t *testing.T) {
 	m := newMock()
-	post, err := m.CreatePost("hello matrix", "", "", []string{"test"}, false, false)
+	post, err := m.CreatePost("hello matrix", "", "", []string{"test"}, false, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestMockCreatePost_ReturnsPost(t *testing.T) {
 
 func TestMockCreatePost_TitleAndFlags(t *testing.T) {
 	m := newMock()
-	post, err := m.CreatePost("body text", "My Title", "", []string{"test"}, true, true)
+	post, err := m.CreatePost("body text", "My Title", "", []string{"test"}, true, true, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -178,6 +178,13 @@ type App struct {
 	iconPickerOpen bool
 	iconPicker     screens.IconPickerModel
 
+	// attachURLPrompt state — open with ctrl+g from any focused compose
+	// field. Submit either sets a native post attachment (Feed's new-post
+	// panel or PostDetail's edit panel) or inserts markdown image syntax
+	// wherever InsertIconMsg would land — see applyAttachURL.
+	attachURLPromptOpen bool
+	attachURLPrompt     screens.PathPromptModel
+
 	// imageCarousel state — populated when an image is opened from a picker
 	// containing more than one image, letting left/right cycle between them
 	// without closing the image modal. Nil imageCarouselItems means a plain
@@ -552,6 +559,7 @@ func NewApp(client api.Client) App {
 		search:             screens.NewSearchModel(),
 		pathPrompt:         screens.NewPathPromptModel(),
 		iconPicker:         screens.NewIconPickerModel(),
+		attachURLPrompt:    screens.NewPathPromptModel(),
 		bookmarkedPostIDs:  make(map[string]struct{}),
 		bookmarkedReplyIDs: make(map[string]struct{}),
 		postBookmarkIDs:    make(map[string]string),
@@ -891,6 +899,10 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 		model, cmd := a.handleIconPickerKey(m)
 		return model.(App), cmd, true
 	}
+	if a.attachURLPromptOpen {
+		model, cmd := a.handleAttachURLPromptKey(m)
+		return model.(App), cmd, true
+	}
 	// When a screen has a focused text input, let it consume all keys.
 	// ctrl+c is kept as a hard escape hatch; a handful of other global
 	// shortcuts get a ctrl-prefixed twin that reaches through too, since
@@ -923,7 +935,7 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 				(a.active == screenCMail && a.cmail.ComposeEmpty()))
 		switch {
 		case m.String() == "ctrl+o", m.String() == "ctrl+q", m.String() == "ctrl+t",
-			m.String() == "ctrl+]", m.String() == "ctrl+left", m.String() == "ctrl+right", bareArrowEscapesEmptyCompose:
+			m.String() == "ctrl+]", m.String() == "ctrl+g", m.String() == "ctrl+left", m.String() == "ctrl+right", bareArrowEscapesEmptyCompose:
 			// fall through to the global switch below
 		default:
 			return a, nil, false // fall through to delegateUpdate
@@ -976,6 +988,13 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 			var cmd tea.Cmd
 			a.iconPicker, cmd = a.iconPicker.Open()
 			a.iconPicker = a.iconPicker.SetSize(width, height)
+			return a, cmd, true
+		}
+	case "ctrl+g":
+		if a.activeScreenHasFocusedInput() {
+			a.attachURLPromptOpen = true
+			var cmd tea.Cmd
+			a.attachURLPrompt, cmd = a.attachURLPrompt.Open("attach image/gif url", "")
 			return a, cmd, true
 		}
 	case "v":
@@ -1152,22 +1171,22 @@ func (a App) handlePostDetail(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		return a, nil, true
 	case screens.SubmitNewPostMsg:
-		return a, a.createPostCmd(msg.Content, msg.Title, msg.Slug, msg.Topics, msg.IsPublic, msg.IsNSFW), true
+		return a, a.createPostCmd(msg.Content, msg.Title, msg.Slug, msg.Topics, msg.IsPublic, msg.IsNSFW, msg.AttachmentURL), true
 	case postCreatedMsg:
 		return a, a.loadFeedCmd(), true
 	case postConvertedToNoteMsg:
 		a, notifyCmd := a.notify(notifyWarn, "posted too soon after your last entry — saved to your Journal instead")
 		return a, tea.Batch(notifyCmd, a.loadFeedCmd()), true
 	case screens.SubmitPostEditMsg:
-		return a, a.editPostCmd(msg.PostID, msg.Content, msg.Title, msg.Topics, msg.IsPublic, msg.IsNSFW), true
+		return a, a.editPostCmd(msg.PostID, msg.Content, msg.Title, msg.Topics, msg.IsPublic, msg.IsNSFW, msg.AttachmentURL, msg.AttachmentTouched, msg.OtherAttachments), true
 	case postEditedMsg:
 		// Both Feed and PostDetail may hold their own local copy of this post;
 		// PostDetail's ApplyPostEdit has no postID param, so guard it here —
 		// otherwise editing from Feed while PostDetail has an unrelated post
 		// open would overwrite that unrelated post's content.
-		a.feed = a.feed.ApplyPostEdit(msg.postID, msg.content, msg.title, msg.topics, msg.isPublic, msg.isNSFW, msg.editedAt)
+		a.feed = a.feed.ApplyPostEdit(msg.postID, msg.content, msg.title, msg.topics, msg.isPublic, msg.isNSFW, msg.editedAt, msg.attachments, msg.attachmentsTouched)
 		if a.postDetail.PostID() == msg.postID {
-			a.postDetail = a.postDetail.ApplyPostEdit(msg.content, msg.title, msg.topics, msg.isPublic, msg.isNSFW, msg.editedAt)
+			a.postDetail = a.postDetail.ApplyPostEdit(msg.content, msg.title, msg.topics, msg.isPublic, msg.isNSFW, msg.editedAt, msg.attachments, msg.attachmentsTouched)
 		}
 		return a, nil, true
 	case screens.SubmitReplyMsg:
@@ -3746,6 +3765,66 @@ func (a App) handleIconPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return a, cmd
 }
 
+// handleAttachURLPromptKey processes keyboard input while the attach-image-URL
+// prompt is open. Enter/esc are handled directly here (mirrors
+// handleIconPickerKey) rather than routed through
+// PathPromptSubmitMsg/PathPromptCancelMsg — those are already claimed by the
+// theme export/import prompt's handlePathPrompt, which switches purely on
+// message type, so reusing them here would misroute into the export/import
+// logic. Every other key (typing, cursor movement) is forwarded to
+// PathPromptModel.Update.
+func (a App) handleAttachURLPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		a.attachURLPromptOpen = false
+		return a, nil
+	case "enter":
+		url := strings.TrimSpace(a.attachURLPrompt.Value())
+		if url != "" && !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+			a.attachURLPrompt = a.attachURLPrompt.SetWarning("must be an http(s) URL")
+			return a, nil
+		}
+		a.attachURLPromptOpen = false
+		return a.applyAttachURL(url)
+	}
+	var cmd tea.Cmd
+	a.attachURLPrompt, cmd = a.attachURLPrompt.Update(msg)
+	return a, cmd
+}
+
+// applyAttachURL dispatches a submitted attach-URL prompt result, per what
+// was confirmed live this session: posts get a native attachment (routed
+// through the create/edit request); circ/C-Mail can only embed an animated
+// GIF, via the server's own /gif command — visually confirmed on the
+// website, whereas markdown in a message's content does not render there;
+// and replies have no attachment mechanism at all (no attachments field in
+// the reply API). Where nothing can actually render, this warns instead of
+// silently inserting text that looks like it worked but won't show up
+// anywhere but cyber-tui's own inline-image view.
+func (a App) applyAttachURL(url string) (App, tea.Cmd) {
+	switch {
+	case a.active == screenFeed && a.feed.PanelActive():
+		a.feed = a.feed.SetPanelAttachment(url)
+		return a, nil
+	case a.active == screenPostDetail && a.postDetail.EditPanelActive():
+		a.postDetail = a.postDetail.SetEditPanelAttachment(url)
+		return a, nil
+	}
+	if url == "" {
+		return a, nil
+	}
+	switch {
+	case a.active == screenChatrooms, a.active == screenCMail:
+		if !urlutil.IsGIFURL(url) {
+			return a.notify(notifyWarn, "cyberspace.online can only embed a GIF in chat (via /gif) — a static image needs a file upload the API doesn't support")
+		}
+		return a, func() tea.Msg { return screens.SetComposeValueMsg{Value: "/gif " + url} }
+	case a.active == screenPostDetail && a.postDetail.ReplyComposeActive():
+		return a.notify(notifyWarn, "replies don't support image attachments — there's no attachments field in the reply API")
+	}
+	return a, func() tea.Msg { return screens.InsertIconMsg{Icon: "![](" + url + ")"} }
+}
+
 // --- commands ---
 
 // loginSuccessMsg carries the authenticated session back to the update loop so
@@ -3944,6 +4023,12 @@ type postEditedMsg struct {
 	topics           []string
 	isPublic, isNSFW bool
 	editedAt         time.Time
+	// attachments/attachmentsTouched mirror EditPost's own pair: Feed/
+	// PostDetail's local copy only overwrites its cached Attachments when
+	// attachmentsTouched — otherwise the edit didn't touch them server-side
+	// either, so the stale local copy is already correct.
+	attachments        []model.Attachment
+	attachmentsTouched bool
 }
 
 type replyEditedMsg struct {
@@ -4548,9 +4633,56 @@ func (a *App) createReplyCmd(postID, content, parentReplyID string) tea.Cmd {
 	}
 }
 
-func (a *App) createPostCmd(content, title, slug string, topics []string, isPublic, isNSFW bool) tea.Cmd {
+// maxAttachmentDim is the width/height cap cyberspace.online enforces on a
+// post's native image/gif attachment — confirmed live (POST /v1/posts 400s
+// above it: "Image width must be an integer between 1 and 640px"). The API
+// requires the client to supply both dimensions and does not compute or
+// resize the image itself.
+const maxAttachmentDim = 640
+
+// attachmentTypeForURL infers a wireAttachment's "type" from the URL's path
+// extension (via urlutil.IsGIFURL, already used the same way for graphics-
+// protocol detection in openImageInTerminal — ignores query string/fragment,
+// unlike a raw suffix check, so a signed CDN link like ".gif?token=..."
+// still resolves correctly).
+func attachmentTypeForURL(rawURL string) string {
+	if urlutil.IsGIFURL(rawURL) {
+		return "gif"
+	}
+	return "image"
+}
+
+// resolveAttachment fetches attachmentURL's declared dimensions and builds
+// the model.Attachment CreatePost/EditPost send. Returns nil, nil for an
+// empty URL (no attachment). Returns an error — surfaced to the user like any
+// other actionErrMsg/editErrorMsg — when the image can't be fetched or
+// exceeds maxAttachmentDim; this app has no way to resize it (no upload
+// endpoint to host the result), so the accurate move is to fail clearly here
+// rather than let the server reject a request the user already spent an
+// interaction composing.
+func resolveAttachment(attachmentURL string) (*model.Attachment, error) {
+	if attachmentURL == "" {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	width, height, err := imgview.Dimensions(ctx, attachmentURL)
+	if err != nil {
+		return nil, fmt.Errorf("attach image: %w", err)
+	}
+	if width > maxAttachmentDim || height > maxAttachmentDim {
+		return nil, fmt.Errorf("attach image: %dx%d exceeds the site's %dx%d limit for post attachments — try a smaller image, or paste the link in the body text instead", width, height, maxAttachmentDim, maxAttachmentDim)
+	}
+	return &model.Attachment{Type: attachmentTypeForURL(attachmentURL), Src: attachmentURL, Width: width, Height: height}, nil
+}
+
+func (a *App) createPostCmd(content, title, slug string, topics []string, isPublic, isNSFW bool, attachmentURL string) tea.Cmd {
 	return func() tea.Msg {
-		post, err := a.client.CreatePost(content, title, slug, topics, isPublic, isNSFW)
+		attachment, err := resolveAttachment(attachmentURL)
+		if err != nil {
+			return actionErrMsg{err}
+		}
+		post, err := a.client.CreatePost(content, title, slug, topics, isPublic, isNSFW, attachment)
 		if err != nil {
 			return actionErrMsg{err}
 		}
@@ -5178,14 +5310,30 @@ func (a *App) deletePostCmd(postID string, fromFeed bool) tea.Cmd {
 	}
 }
 
-func (a *App) editPostCmd(postID, content, title string, topics []string, isPublic, isNSFW bool) tea.Cmd {
+// editPostCmd sends a post edit. otherAttachments are attachments the edit
+// panel found on the post but doesn't manage (e.g. an audio one) — when
+// attachmentTouched, they're resent alongside the resolved attachmentURL
+// since EditPost replaces the whole attachments array wholesale.
+func (a *App) editPostCmd(postID, content, title string, topics []string, isPublic, isNSFW bool, attachmentURL string, attachmentTouched bool, otherAttachments []model.Attachment) tea.Cmd {
 	return func() tea.Msg {
-		if err := a.client.EditPost(postID, content, title, topics, isPublic, isNSFW); err != nil {
+		var attachments []model.Attachment
+		if attachmentTouched {
+			attachment, err := resolveAttachment(attachmentURL)
+			if err != nil {
+				return editErrorMsg(err)
+			}
+			attachments = append(attachments, otherAttachments...)
+			if attachment != nil {
+				attachments = append(attachments, *attachment)
+			}
+		}
+		if err := a.client.EditPost(postID, content, title, topics, isPublic, isNSFW, attachments, attachmentTouched); err != nil {
 			return editErrorMsg(err)
 		}
 		return postEditedMsg{
 			postID: postID, content: content, title: title, topics: topics,
 			isPublic: isPublic, isNSFW: isNSFW, editedAt: time.Now(),
+			attachments: attachments, attachmentsTouched: attachmentTouched,
 		}
 	}
 }
@@ -5288,7 +5436,7 @@ func (a *App) deleteRoomMessageCmd(roomID, messageID string) tea.Cmd {
 // Published notes have no title, are private, and not marked NSFW.
 func (a *App) publishNoteCmd(content string, topics []string) tea.Cmd {
 	return func() tea.Msg {
-		_, err := a.client.CreatePost(content, "", "", topics, false, false)
+		_, err := a.client.CreatePost(content, "", "", topics, false, false, nil)
 		if err != nil {
 			return actionErrMsg{err}
 		}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1270,6 +1270,17 @@ func (a App) handleChatrooms(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, tea.Batch(markReadCmd, activateCmd), true
 	case screens.SendRoomMessageMsg:
 		return a, a.sendRoomMessageCmd(msg.RoomID, msg.Body), true
+	case screens.MuteUserMsg:
+		return a, a.muteUserCmd(msg.RoomID, msg.Username), true
+	case userMutedMsg:
+		// Muting is enforced client-side off Settings.MutedUsersByRoom (see
+		// ChatroomsModel's SharedConfigMsg handler), which /mute updates
+		// server-side but never pushes to us — same reload roomCommandReplyMsg
+		// already does after a command completes. Without it the room keeps
+		// showing the just-muted user's messages until something else happens
+		// to reload settings.
+		a, notifyCmd := a.notify(notifyInfo, "muted "+msg.username)
+		return a, tea.Batch(notifyCmd, a.loadSettingsCmd()), true
 	case screens.FlagMessageMsg:
 		return a, a.flagRoomMessageCmd(msg.RoomID, msg.MessageID, msg.Reason), true
 	case screens.DeleteRoomMessageMsg:
@@ -1736,6 +1747,19 @@ func (a App) handleBookmarks(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		termenv.Copy(urlutil.PostPermalink(msg.Post.AuthorUsername, msg.Post.Slug))
 		a, cmd := a.notify(notifyInfo, "Copied link to clipboard")
+		return a, cmd, true
+	case screens.CopyMessageTextMsg:
+		// Same SSH gate as CopyLinkMsg — see its comment.
+		if a.ephemeral {
+			a, cmd := a.notify(notifyInfo, "Copying is disabled in SSH sessions")
+			return a, cmd, true
+		}
+		if msg.Text == "" {
+			a, cmd := a.notify(notifyInfo, "nothing to copy")
+			return a, cmd, true
+		}
+		termenv.Copy(msg.Text)
+		a, cmd := a.notify(notifyInfo, "Copied message to clipboard")
 		return a, cmd, true
 	case screens.BookmarkPostMsg:
 		if msg.ReplyID != "" {
@@ -3980,6 +4004,11 @@ type roomCommandReplyMsg struct {
 	reply  string
 }
 type roomMessageDeletedMsg struct{ messageID string }
+
+// userMutedMsg confirms a successful /mute send — needed because, per the
+// server ("/mute ... posts nothing"), a successful mute has no visible
+// effect in the room to tell the user it worked; see muteUserCmd.
+type userMutedMsg struct{ username string }
 type cmailCommandReplyMsg struct {
 	convID string
 	reply  string
@@ -4543,6 +4572,20 @@ func (a *App) sendRoomMessageCmd(roomID, body string) tea.Cmd {
 			return roomCommandReplyMsg{roomID: roomID, reply: reply}
 		}
 		return nil
+	}
+}
+
+// muteUserCmd sends "/mute <username>" as a normal room message — the only
+// way to mute is server-side, via the same slash command a user would type
+// by hand (see docs/00-latest-api-reference.md's Commands section). Unlike
+// sendRoomMessageCmd, success always reports back (userMutedMsg) since the
+// command posts nothing to the room for the user to see otherwise.
+func (a *App) muteUserCmd(roomID, username string) tea.Cmd {
+	return func() tea.Msg {
+		if _, err := a.client.SendRoomMessage(roomID, "/mute "+username); err != nil {
+			return actionErrMsg{err}
+		}
+		return userMutedMsg{username: username}
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2029,6 +2029,131 @@ func TestEditPostCmd_MergesOtherAttachmentsWithResolvedAttachment(t *testing.T) 
 	}
 }
 
+// --- muteUserCmd / MuteUserMsg / userMutedMsg ---
+
+// sendRoomMessageRecordingClient captures the arguments SendRoomMessage was
+// called with, so a test can inspect exactly what got sent without a real API.
+type sendRoomMessageRecordingClient struct {
+	*api.MockClient
+	gotRoomID, gotBody string
+}
+
+func (c *sendRoomMessageRecordingClient) SendRoomMessage(roomID, body string) (string, error) {
+	c.gotRoomID, c.gotBody = roomID, body
+	return "", nil
+}
+
+// TestMuteUserCmd_SendsMuteSlashCommand guards the only way to mute:
+// sending "/mute <username>" as an ordinary room message, exactly as if the
+// user had typed it — there's no dedicated mute endpoint.
+func TestMuteUserCmd_SendsMuteSlashCommand(t *testing.T) {
+	client := &sendRoomMessageRecordingClient{MockClient: api.NewMockClient()}
+	a := NewApp(client)
+
+	msg := a.muteUserCmd("zion", "molly")()
+	if client.gotRoomID != "zion" || client.gotBody != "/mute molly" {
+		t.Errorf("SendRoomMessage(%q, %q), want (\"zion\", \"/mute molly\")", client.gotRoomID, client.gotBody)
+	}
+	um, ok := msg.(userMutedMsg)
+	if !ok {
+		t.Fatalf("muteUserCmd() = %T, want userMutedMsg", msg)
+	}
+	if um.username != "molly" {
+		t.Errorf("username = %q, want molly", um.username)
+	}
+}
+
+// mutedFailClient simulates the send itself failing (e.g. rate limit).
+type mutedFailClient struct{ *api.MockClient }
+
+func (c *mutedFailClient) SendRoomMessage(roomID, body string) (string, error) {
+	return "", &api.APIError{Code: "RATE_LIMITED", Status: 429, Message: "too many requests"}
+}
+
+func TestMuteUserCmd_SendFails_ReturnsActionErrMsg(t *testing.T) {
+	a := NewApp(&mutedFailClient{MockClient: api.NewMockClient()})
+
+	msg := a.muteUserCmd("zion", "molly")()
+	if _, ok := msg.(actionErrMsg); !ok {
+		t.Fatalf("muteUserCmd() = %T, want actionErrMsg", msg)
+	}
+}
+
+// TestApp_UserMutedMsg_ShowsNotification covers the reason userMutedMsg
+// exists at all: "/mute" posts nothing to the room, so without this the
+// user pressing 'm' would have no way to tell it worked.
+func TestApp_UserMutedMsg_ShowsNotification(t *testing.T) {
+	a := loggedInApp()
+
+	m, _ := a.Update(userMutedMsg{username: "molly"})
+	a = m.(App)
+
+	if a.notifyLevel != notifyInfo || a.notifyText != "muted molly" {
+		t.Errorf("notify = level=%v text=%q, want level=%v text=%q", a.notifyLevel, a.notifyText, notifyInfo, "muted molly")
+	}
+}
+
+// TestApp_UserMutedMsg_ReloadsSettings guards the fix for a real reported
+// bug: muting a user sent the /mute command fine but the room never
+// filtered their messages out, because ChatroomsModel's mute list only
+// updates from Settings.MutedUsersByRoom via SharedConfigMsg (see its
+// SharedConfigMsg handler), and /mute changes that server-side without ever
+// pushing the new value to us. batch[0] is the notify tick — not invoked
+// here since tea.Tick blocks for notifyTTL; only the settings-reload
+// command (batch[1], by construction — see the userMutedMsg case) is safe
+// to run synchronously.
+func TestApp_UserMutedMsg_ReloadsSettings(t *testing.T) {
+	a := loggedInApp()
+
+	_, cmd := a.Update(userMutedMsg{username: "molly"})
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok || len(batch) != 2 {
+		t.Fatalf("cmd() = %T (len %d), want a 2-command tea.BatchMsg (notify + settings reload)", cmd(), len(batch))
+	}
+	if _, ok := batch[1]().(settingsLoadedMsg); !ok {
+		t.Errorf("batch[1]() = %T, want settingsLoadedMsg — the mute list refresh", batch[1]())
+	}
+}
+
+// --- CopyMessageTextMsg ---
+
+func TestApp_CopyMessageTextMsg_ShowsNotification(t *testing.T) {
+	a := loggedInApp()
+
+	m, _ := a.Update(screens.CopyMessageTextMsg{Text: "hi there"})
+	a = m.(App)
+
+	if a.notifyLevel != notifyInfo || a.notifyText != "Copied message to clipboard" {
+		t.Errorf("notify = level=%v text=%q, want level=%v text=%q", a.notifyLevel, a.notifyText, notifyInfo, "Copied message to clipboard")
+	}
+}
+
+func TestApp_CopyMessageTextMsg_EmptyText_NotifiesNothingToCopy(t *testing.T) {
+	a := loggedInApp()
+
+	m, _ := a.Update(screens.CopyMessageTextMsg{Text: ""})
+	a = m.(App)
+
+	if a.notifyLevel != notifyInfo || a.notifyText != "nothing to copy" {
+		t.Errorf("notify = level=%v text=%q, want level=%v text=%q", a.notifyLevel, a.notifyText, notifyInfo, "nothing to copy")
+	}
+}
+
+func TestApp_CopyMessageTextMsg_Ephemeral_DisabledInSSH(t *testing.T) {
+	a := loggedInApp()
+	a.ephemeral = true
+
+	m, _ := a.Update(screens.CopyMessageTextMsg{Text: "hi there"})
+	a = m.(App)
+
+	if a.notifyText != "Copying is disabled in SSH sessions" {
+		t.Errorf("notifyText = %q, want the SSH-disabled banner", a.notifyText)
+	}
+}
+
 // flagErrorMsg softens the documented self-report 403 into a friendly banner;
 // anything else falls through to the normal actionErrMsg handling.
 func TestFlagErrorMsg_403IsSoftened(t *testing.T) {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1,9 +1,13 @@
 package ui
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"image"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -1907,7 +1911,7 @@ func (c *tooSoonPostClient) GetPost(postID string) (model.Post, error) {
 func TestCreatePostCmd_TooSoonConversion_ReturnsPostConvertedToNoteMsg(t *testing.T) {
 	a := NewApp(&tooSoonPostClient{MockClient: api.NewMockClient()})
 
-	msg := a.createPostCmd("hello", "", "", nil, true, false)()
+	msg := a.createPostCmd("hello", "", "", nil, true, false, "")()
 	if _, ok := msg.(postConvertedToNoteMsg); !ok {
 		t.Fatalf("createPostCmd() = %T, want postConvertedToNoteMsg", msg)
 	}
@@ -1916,9 +1920,112 @@ func TestCreatePostCmd_TooSoonConversion_ReturnsPostConvertedToNoteMsg(t *testin
 func TestCreatePostCmd_NormalSuccess_ReturnsPostCreatedMsg(t *testing.T) {
 	a := NewApp(api.NewMockClient())
 
-	msg := a.createPostCmd("hello", "", "", nil, true, false)()
+	msg := a.createPostCmd("hello", "", "", nil, true, false, "")()
 	if _, ok := msg.(postCreatedMsg); !ok {
 		t.Fatalf("createPostCmd() = %T, want postCreatedMsg", msg)
+	}
+}
+
+// --- resolveAttachment: dimension fetch + the API's 640px cap ---
+
+func testPNGServer(t *testing.T, w, h int) *httptest.Server {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write(buf.Bytes())
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestResolveAttachment_EmptyURL_ReturnsNil(t *testing.T) {
+	attachment, err := resolveAttachment("")
+	if err != nil || attachment != nil {
+		t.Errorf("resolveAttachment(\"\") = %v, %v, want nil, nil", attachment, err)
+	}
+}
+
+func TestResolveAttachment_WithinLimit_SetsTypeAndDimensions(t *testing.T) {
+	srv := testPNGServer(t, 100, 50)
+	attachment, err := resolveAttachment(srv.URL + "/pic.png")
+	if err != nil {
+		t.Fatalf("resolveAttachment: %v", err)
+	}
+	if attachment.Type != "image" || attachment.Width != 100 || attachment.Height != 50 {
+		t.Errorf("attachment = %+v, want type=image width=100 height=50", attachment)
+	}
+}
+
+// TestResolveAttachment_GIFExtension_SetsGIFType guards attachmentTypeForURL's
+// extension-based inference, which the caller (createPostCmd/editPostCmd)
+// relies on since the API distinguishes "image" from "gif" attachments.
+func TestResolveAttachment_GIFExtension_SetsGIFType(t *testing.T) {
+	srv := testPNGServer(t, 10, 10) // content doesn't need to actually be a gif — only the URL suffix is inspected
+	attachment, err := resolveAttachment(srv.URL + "/pic.gif")
+	if err != nil {
+		t.Fatalf("resolveAttachment: %v", err)
+	}
+	if attachment.Type != "gif" {
+		t.Errorf("attachment.Type = %q, want gif", attachment.Type)
+	}
+}
+
+// TestResolveAttachment_ExceedsLimit_ReturnsClearError guards the one thing
+// this app has no way to fix automatically: there's no upload endpoint to
+// host a resized copy, so an oversized image must fail here with a message
+// that explains why, rather than as a raw 400 from the API (confirmed live:
+// POST /v1/posts rejects width/height above 640px).
+func TestResolveAttachment_ExceedsLimit_ReturnsClearError(t *testing.T) {
+	srv := testPNGServer(t, 1200, 480)
+	attachment, err := resolveAttachment(srv.URL + "/pic.png")
+	if attachment != nil {
+		t.Errorf("attachment = %+v, want nil on an oversized image", attachment)
+	}
+	if err == nil || !strings.Contains(err.Error(), "640") {
+		t.Errorf("err = %v, want a message mentioning the 640px limit", err)
+	}
+}
+
+// editPostRecordingClient captures the arguments EditPost was called with,
+// so a test can inspect exactly what editPostCmd sent without a real API.
+type editPostRecordingClient struct {
+	*api.MockClient
+	gotAttachments []model.Attachment
+	gotTouched     bool
+}
+
+func (c *editPostRecordingClient) EditPost(postID, content, title string, topics []string, isPublic, isNSFW bool, attachments []model.Attachment, attachmentTouched bool) error {
+	c.gotAttachments = attachments
+	c.gotTouched = attachmentTouched
+	return nil
+}
+
+// TestEditPostCmd_MergesOtherAttachmentsWithResolvedAttachment guards the
+// merge editPostCmd is responsible for: the attachments array it sends must
+// combine otherAttachments (e.g. an audio one the edit panel doesn't manage)
+// with the newly resolved image, in that order — dropping otherAttachments
+// here would silently delete them server-side, since EditPost replaces the
+// whole array.
+func TestEditPostCmd_MergesOtherAttachmentsWithResolvedAttachment(t *testing.T) {
+	srv := testPNGServer(t, 10, 10)
+	client := &editPostRecordingClient{MockClient: api.NewMockClient()}
+	a := NewApp(client)
+	audio := model.Attachment{Type: "audio", Src: "https://youtu.be/old"}
+
+	msg := a.editPostCmd("p1", "content", "title", nil, false, false, srv.URL+"/pic.png", true, []model.Attachment{audio})()
+	if _, ok := msg.(postEditedMsg); !ok {
+		t.Fatalf("editPostCmd() = %T, want postEditedMsg", msg)
+	}
+	if !client.gotTouched {
+		t.Fatal("expected EditPost to be called with attachmentTouched = true")
+	}
+	want := []model.Attachment{audio, {Type: "image", Src: srv.URL + "/pic.png", Width: 10, Height: 10}}
+	if !slices.Equal(client.gotAttachments, want) {
+		t.Errorf("EditPost attachments = %+v, want %+v (other attachment first, then the resolved one)", client.gotAttachments, want)
 	}
 }
 
@@ -2050,6 +2157,277 @@ func TestApp_PostEditPanel_VisibleInFullRender(t *testing.T) {
 	}
 	if !strings.Contains(after, "distinctive body text") {
 		t.Errorf("expected the full App render to contain the pre-filled body content, got:\n%s", after)
+	}
+}
+
+// --- postEditedMsg: local cache must reflect an attachment change ---
+
+func TestPostEditedMsg_AttachmentsTouched_UpdatesFeedCache(t *testing.T) {
+	a := loggedInApp()
+	a.feed = a.feed.SetPosts([]model.Post{
+		{ID: "p1", Content: "body", Attachments: []model.Attachment{{Type: "audio", Src: "https://youtu.be/old"}}},
+	}, "")
+
+	newAttachments := []model.Attachment{
+		{Type: "audio", Src: "https://youtu.be/old"},
+		{Type: "image", Src: "https://example.com/new.png"},
+	}
+	m, _ := a.Update(postEditedMsg{
+		postID: "p1", content: "body", editedAt: time.Now(),
+		attachments: newAttachments, attachmentsTouched: true,
+	})
+	a = m.(App)
+
+	got := a.feed.GetFocusedURLs()
+	if !slices.Contains(got, "https://example.com/new.png") {
+		t.Errorf("GetFocusedURLs() = %v, want it to contain the newly attached image", got)
+	}
+}
+
+func TestPostEditedMsg_AttachmentsNotTouched_LeavesFeedCacheAlone(t *testing.T) {
+	a := loggedInApp()
+	a.feed = a.feed.SetPosts([]model.Post{
+		{ID: "p1", Content: "body", Attachments: []model.Attachment{{Type: "audio", Src: "https://youtu.be/old"}}},
+	}, "")
+
+	m, _ := a.Update(postEditedMsg{
+		postID: "p1", content: "edited body", editedAt: time.Now(),
+		attachmentsTouched: false,
+	})
+	a = m.(App)
+
+	got := a.feed.GetFocusedURLs()
+	if !slices.Contains(got, "https://youtu.be/old") {
+		t.Errorf("GetFocusedURLs() = %v, want the pre-existing attachment preserved when attachmentsTouched is false", got)
+	}
+}
+
+func TestPostEditedMsg_AttachmentsTouched_UpdatesPostDetailCache(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenPostDetail
+	a.postDetail = a.postDetail.SetPost(model.Post{ID: "p1", Content: "body"})
+
+	m, _ := a.Update(postEditedMsg{
+		postID: "p1", content: "body", editedAt: time.Now(),
+		attachments:        []model.Attachment{{Type: "image", Src: "https://example.com/new.png"}},
+		attachmentsTouched: true,
+	})
+	a = m.(App)
+
+	got := a.postDetail.GetFocusedURLs()
+	if !slices.Contains(got, "https://example.com/new.png") {
+		t.Errorf("GetFocusedURLs() = %v, want it to contain the newly attached image", got)
+	}
+}
+
+// --- applyAttachURL: ctrl+g dispatch (native post attachment vs markdown insert) ---
+
+// TestApplyAttachURL_FeedPanelActive_SetsNativeAttachment covers the branch
+// that must win when the Feed new-post panel is open: a native attachment on
+// the panel, not markdown text inserted into whatever's focused.
+func TestApplyAttachURL_FeedPanelActive_SetsNativeAttachment(t *testing.T) {
+	a := loggedInApp()
+	m, _ := a.feed.Update(keyMsg("n"))
+	a.feed = m
+	if !a.feed.PanelActive() {
+		t.Fatal("setup: expected Feed's new-post panel open after 'n'")
+	}
+
+	a, cmd := a.applyAttachURL("https://example.com/pic.png")
+	if cmd != nil {
+		t.Error("expected no cmd for the native-attachment branch")
+	}
+	if got := a.feed.ComposeView(80); !strings.Contains(got, "https://example.com/pic.png") {
+		t.Errorf("ComposeView() = %q, want it to contain the attached URL", got)
+	}
+}
+
+// TestApplyAttachURL_PostDetailEditPanelActive_SetsNativeAttachment mirrors
+// the Feed case for PostDetail's edit panel (opened via 'e', separate from
+// the Feed instance).
+func TestApplyAttachURL_PostDetailEditPanelActive_SetsNativeAttachment(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "op", IsSupporter: true}
+	a.active = screenPostDetail
+	a.postDetail = a.postDetail.
+		SetCurrentUsername("op").
+		SetCurrentUserIsSupporter(true).
+		SetPost(model.Post{ID: "p1", AuthorUsername: "op", Content: "body", CreatedAt: time.Now()})
+	m, _ := a.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	a = m.(App)
+	m, _ = a.Update(keyMsg("e"))
+	a = m.(App)
+	if !a.postDetail.EditPanelActive() {
+		t.Fatal("setup: expected PostDetail's edit panel open after 'e'")
+	}
+
+	a, cmd := a.applyAttachURL("https://example.com/pic.png")
+	if cmd != nil {
+		t.Error("expected no cmd for the native-attachment branch")
+	}
+	if got := a.View(); !strings.Contains(got, "https://example.com/pic.png") {
+		t.Errorf("full render doesn't contain the attached URL")
+	}
+}
+
+// TestApplyAttachURL_DefaultBranch_ReturnsInsertIconMsg covers the leftover
+// incidental surfaces (guild threads, journal, bio editing — anything not
+// explicitly special-cased): the URL still goes in as markdown image syntax
+// via the same InsertIconMsg dispatch the icon picker uses, since these were
+// never confirmed to render on the site either way and aren't part of the
+// four surfaces this feature targets.
+func TestApplyAttachURL_DefaultBranch_ReturnsInsertIconMsg(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenGuilds
+
+	_, cmd := a.applyAttachURL("https://example.com/pic.gif")
+	if cmd == nil {
+		t.Fatal("expected a cmd for the markdown-insert branch")
+	}
+	msg, ok := cmd().(screens.InsertIconMsg)
+	if !ok {
+		t.Fatalf("cmd() = %T, want screens.InsertIconMsg", msg)
+	}
+	if want := "![](https://example.com/pic.gif)"; msg.Icon != want {
+		t.Errorf("InsertIconMsg.Icon = %q, want %q", msg.Icon, want)
+	}
+}
+
+// TestApplyAttachURL_DefaultBranch_EmptyURL_NoCmd: an empty submission from
+// the prompt (e.g. esc'd out with nothing typed) must not insert an empty
+// markdown link.
+func TestApplyAttachURL_DefaultBranch_EmptyURL_NoCmd(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenGuilds
+
+	_, cmd := a.applyAttachURL("")
+	if cmd != nil {
+		t.Error("expected no cmd for an empty URL in the markdown-insert branch")
+	}
+}
+
+// --- applyAttachURL: circ/C-Mail only support GIF via /gif (confirmed live
+// this session — markdown-in-content doesn't render on the website, but
+// /gif's dedicated gifUrl field does) ---
+
+func TestApplyAttachURL_ChatroomsGIF_SetsGifCommand(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenChatrooms
+
+	_, cmd := a.applyAttachURL("https://example.com/pic.gif")
+	if cmd == nil {
+		t.Fatal("expected a cmd for the /gif branch")
+	}
+	msg, ok := cmd().(screens.SetComposeValueMsg)
+	if !ok {
+		t.Fatalf("cmd() = %T, want screens.SetComposeValueMsg", msg)
+	}
+	if want := "/gif https://example.com/pic.gif"; msg.Value != want {
+		t.Errorf("SetComposeValueMsg.Value = %q, want %q", msg.Value, want)
+	}
+}
+
+func TestApplyAttachURL_ChatroomsNonGIF_WarnsInsteadOfInserting(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenChatrooms
+
+	a2, _ := a.applyAttachURL("https://example.com/pic.png")
+	if a2.notifyLevel != notifyWarn || a2.notifyText == "" {
+		t.Errorf("expected a warning notification for a non-GIF URL in chat, got level=%v text=%q", a2.notifyLevel, a2.notifyText)
+	}
+}
+
+func TestApplyAttachURL_CMailGIF_SetsGifCommand(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenCMail
+
+	_, cmd := a.applyAttachURL("https://example.com/pic.gif")
+	if cmd == nil {
+		t.Fatal("expected a cmd for the /gif branch")
+	}
+	if _, ok := cmd().(screens.SetComposeValueMsg); !ok {
+		t.Fatalf("cmd() = %T, want screens.SetComposeValueMsg", cmd())
+	}
+}
+
+func TestApplyAttachURL_CMailNonGIF_WarnsInsteadOfInserting(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenCMail
+
+	a2, _ := a.applyAttachURL("https://example.com/pic.png")
+	if a2.notifyLevel != notifyWarn || a2.notifyText == "" {
+		t.Errorf("expected a warning notification for a non-GIF URL in C-Mail, got level=%v text=%q", a2.notifyLevel, a2.notifyText)
+	}
+}
+
+// TestApplyAttachURL_ReplyCompose_WarnsInsteadOfInserting: the reply API has
+// no attachments field at all, so ctrl+g must not silently insert markdown
+// that (per the same live evidence as the chat case) won't render anywhere.
+func TestApplyAttachURL_ReplyCompose_WarnsInsteadOfInserting(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenPostDetail
+	a.postDetail = a.postDetail.SetPost(model.Post{ID: "p1", Content: "body"})
+	m, _ := a.postDetail.OpenCompose()
+	a.postDetail = m
+	if !a.postDetail.ReplyComposeActive() {
+		t.Fatal("setup: expected the reply compose box open")
+	}
+
+	a2, _ := a.applyAttachURL("https://example.com/pic.png")
+	if a2.notifyLevel != notifyWarn || a2.notifyText == "" {
+		t.Errorf("expected a warning notification for a reply attachment, got level=%v text=%q", a2.notifyLevel, a2.notifyText)
+	}
+}
+
+// --- ctrl+g / attach-URL prompt ---
+
+func TestHandleKeys_CtrlG_OpensAttachURLPrompt_WhenInputFocused(t *testing.T) {
+	a := setupChatroomsDetailWithURL(loggedInApp())
+	if !a.chatrooms.InputFocused() {
+		t.Fatal("setup: expected chatrooms input focused in detail mode")
+	}
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyCtrlG})
+	if !consumed {
+		t.Fatal("expected ctrl+g to be consumed while a compose field is focused")
+	}
+	if !a2.attachURLPromptOpen {
+		t.Error("expected attachURLPromptOpen = true after ctrl+g")
+	}
+}
+
+// TestHandleAttachURLPromptKey_RejectsNonHTTPURL_KeepsPromptOpen guards the
+// minimal client-side validation: a bare string with no scheme (most likely
+// a typo, not a URL) must not be accepted as an attachment/markdown target.
+func TestHandleAttachURLPromptKey_RejectsNonHTTPURL_KeepsPromptOpen(t *testing.T) {
+	a := loggedInApp()
+	a.attachURLPromptOpen = true
+	a.attachURLPrompt, _ = a.attachURLPrompt.Open("attach image/gif url", "")
+	for _, r := range "not-a-url" {
+		m, _ := a.handleAttachURLPromptKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		a = m.(App)
+	}
+
+	m, _ := a.handleAttachURLPromptKey(tea.KeyMsg{Type: tea.KeyEnter})
+	a = m.(App)
+	if !a.attachURLPromptOpen {
+		t.Error("expected the prompt to stay open after submitting a non-http(s) string")
+	}
+}
+
+func TestHandleAttachURLPromptKey_AcceptsHTTPURL_ClosesPrompt(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenChatrooms
+	a.attachURLPromptOpen = true
+	a.attachURLPrompt, _ = a.attachURLPrompt.Open("attach image/gif url", "")
+	for _, r := range "https://example.com/a.png" {
+		m, _ := a.handleAttachURLPromptKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		a = m.(App)
+	}
+
+	m, _ := a.handleAttachURLPromptKey(tea.KeyMsg{Type: tea.KeyEnter})
+	a = m.(App)
+	if a.attachURLPromptOpen {
+		t.Error("expected the prompt to close after submitting a valid http(s) URL")
 	}
 }
 

--- a/internal/ui/imgview/fetch.go
+++ b/internal/ui/imgview/fetch.go
@@ -37,8 +37,9 @@ const maxGIFTotalPixels = 64 << 20
 // global mutations to http.DefaultClient.
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-// fetchBody downloads rawURL, capping the read at maxImageBytes.
-func fetchBody(ctx context.Context, rawURL string) ([]byte, error) {
+// openImageResponse issues the GET request shared by fetchBody and
+// Dimensions. The caller must close the returned response's body.
+func openImageResponse(ctx context.Context, rawURL string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("imgview: %w", err)
@@ -48,10 +49,20 @@ func fetchBody(ctx context.Context, rawURL string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("imgview: %w", err)
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
 		return nil, fmt.Errorf("imgview: server returned %s", resp.Status)
 	}
+	return resp, nil
+}
+
+// fetchBody downloads rawURL, capping the read at maxImageBytes.
+func fetchBody(ctx context.Context, rawURL string) ([]byte, error) {
+	resp, err := openImageResponse(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("imgview: read body: %w", err)
@@ -81,6 +92,25 @@ func Fetch(ctx context.Context, rawURL string) (image.Image, error) {
 		return nil, fmt.Errorf("imgview: decode: %w", err)
 	}
 	return img, nil
+}
+
+// Dimensions fetches rawURL and returns its declared width/height. Unlike
+// Fetch, it reads only as far as image.DecodeConfig needs (the format
+// header, typically well under 1KiB) rather than downloading the whole
+// body — used where a caller needs an image's size but not its content
+// (e.g. cyberspace.online's post-attachments API, which requires
+// width/height on the request and does not compute them itself).
+func Dimensions(ctx context.Context, rawURL string) (width, height int, err error) {
+	resp, err := openImageResponse(ctx, rawURL)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer resp.Body.Close()
+	cfg, _, err := image.DecodeConfig(io.LimitReader(resp.Body, maxImageBytes))
+	if err != nil {
+		return 0, 0, fmt.Errorf("imgview: decode: %w", err)
+	}
+	return cfg.Width, cfg.Height, nil
 }
 
 // FetchGIF downloads the GIF at rawURL and decodes all of its frames.

--- a/internal/ui/imgview/fetch.go
+++ b/internal/ui/imgview/fetch.go
@@ -13,7 +13,15 @@ import (
 	"time"
 
 	_ "golang.org/x/image/webp"
+
+	"github.com/ragnar/cyber-tui/internal/version"
 )
+
+// userAgent identifies cyber-tui to image hosts. Some (Wikimedia's edge,
+// confirmed live) return 403 for Go's default "Go-http-client/1.1" — an
+// identifiable UA with a contact URL is what their bot policy actually asks
+// for, and fixes the block.
+var userAgent = "cyber-tui/" + version.Version + " (+https://github.com/ArmadilloBrillo/cyber-tui)"
 
 // maxImageBytes caps how much of an image response body is read into memory,
 // matching the 10 MiB response cap used by the API and RTDB clients.
@@ -45,6 +53,7 @@ func openImageResponse(ctx context.Context, rawURL string) (*http.Response, erro
 		return nil, fmt.Errorf("imgview: %w", err)
 	}
 	req.Header.Set("Accept", "image/webp,image/png,image/jpeg,image/gif,image/*,*/*;q=0.8")
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("imgview: %w", err)

--- a/internal/ui/imgview/fetch_test.go
+++ b/internal/ui/imgview/fetch_test.go
@@ -74,6 +74,25 @@ func TestFetch_RejectsNon200(t *testing.T) {
 	}
 }
 
+func TestDimensions_ReturnsDeclaredSize(t *testing.T) {
+	srv := serve(t, http.StatusOK, pngBytes(t, 7, 5))
+	w, h, err := imgview.Dimensions(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Dimensions: %v", err)
+	}
+	if w != 7 || h != 5 {
+		t.Errorf("Dimensions() = %dx%d, want 7x5", w, h)
+	}
+}
+
+func TestDimensions_RejectsNon200(t *testing.T) {
+	srv := serve(t, http.StatusNotFound, nil)
+	_, _, err := imgview.Dimensions(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Errorf("err = %v, want 404 error", err)
+	}
+}
+
 // gifBytes encodes an n-frame, wxh GIF, each frame a solid color from
 // palette[i % len(palette)] so frames are visually distinguishable.
 func gifBytes(t *testing.T, w, h, n int) []byte {

--- a/internal/ui/imgview/fetch_test.go
+++ b/internal/ui/imgview/fetch_test.go
@@ -74,6 +74,27 @@ func TestFetch_RejectsNon200(t *testing.T) {
 	}
 }
 
+// TestFetch_SendsUserAgent guards against a regression to Go's default
+// "Go-http-client/1.1", which Wikimedia's edge (and presumably other image
+// hosts with a similar bot policy) rejects outright with 403 — confirmed
+// live: the exact same request against a real Wikimedia-hosted GIF failed
+// without this header and succeeded with it.
+func TestFetch_SendsUserAgent(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Write(pngBytes(t, 1, 1))
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := imgview.Fetch(context.Background(), srv.URL); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if gotUA == "" || strings.HasPrefix(gotUA, "Go-http-client") {
+		t.Errorf("User-Agent = %q, want a non-empty, non-default value", gotUA)
+	}
+}
+
 func TestDimensions_ReturnsDeclaredSize(t *testing.T) {
 	srv := serve(t, http.StatusOK, pngBytes(t, 7, 5))
 	w, h, err := imgview.Dimensions(context.Background(), srv.URL)

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -66,6 +66,7 @@ type modalRenderer interface {
 	renderHelpModal(a App) string
 	renderURLPicker(a App) string
 	renderIconPicker(a App) string
+	renderAttachURLPrompt(a App) string
 	renderImageModal(a App) string
 	// InlineImageSlots returns the active screen's visible inline-image
 	// slots plus this layout's screen origin (rowOrigin, colOrigin) for
@@ -95,6 +96,8 @@ func compositeOverlays(l modalRenderer, a App, base string) string {
 		return overlayCenter(base, l.renderURLPicker(a), a.width, a.height)
 	case a.iconPickerOpen:
 		return overlayCenter(base, l.renderIconPicker(a), a.width, a.height)
+	case a.attachURLPromptOpen:
+		return overlayCenter(base, l.renderAttachURLPrompt(a), a.width, a.height)
 	}
 	slots, rowOrigin, colOrigin, _ := l.InlineImageSlots(a)
 	if a.imageModalOpen {

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -565,6 +565,11 @@ func (l MillerLayout) renderPathPrompt(a App) string {
 	return a.pathPrompt.View()
 }
 
+// renderAttachURLPrompt renders the attach-image/gif-URL prompt modal.
+func (l MillerLayout) renderAttachURLPrompt(a App) string {
+	return a.attachURLPrompt.View()
+}
+
 func (l MillerLayout) renderHelpModal(a App) string {
 	title := theme.Title.Render("shortcuts")
 	sectionStyle := theme.Subtle.Bold(true)
@@ -588,6 +593,7 @@ func (l MillerLayout) renderHelpModal(a App) string {
 		row("v", "density"),
 		row("o", "open url"),
 		row("ctrl+]", "icon picker"),
+		row("ctrl+g", "attach image/gif"),
 		row("q", "quit"),
 	)
 	globalSection := lipgloss.JoinVertical(lipgloss.Left, globalRows...)

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -461,6 +461,11 @@ func (l TabsLayout) renderPathPrompt(a App) string {
 	return a.pathPrompt.View()
 }
 
+// renderAttachURLPrompt renders the attach-image/gif-URL prompt modal.
+func (l TabsLayout) renderAttachURLPrompt(a App) string {
+	return a.attachURLPrompt.View()
+}
+
 func (l TabsLayout) renderHelpModal(a App) string {
 	title := theme.Title.Render("shortcuts")
 	sectionStyle := theme.Subtle.Bold(true)
@@ -482,6 +487,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		row("v", "density"),
 		row("o", "open url"),
 		row("ctrl+]", "icon picker"),
+		row("ctrl+g", "attach image/gif"),
 		row("q", "quit"),
 	)
 	globalSection := lipgloss.JoinVertical(lipgloss.Left, globalRows...)

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -567,13 +567,14 @@ type fakeModalRenderer struct {
 	rowOrigin, colOrigin int
 }
 
-func (f fakeModalRenderer) renderThemePicker(a App) string { return "" }
-func (f fakeModalRenderer) renderThemeEditor(a App) string { return "" }
-func (f fakeModalRenderer) renderPathPrompt(a App) string  { return "" }
-func (f fakeModalRenderer) renderHelpModal(a App) string   { return "" }
-func (f fakeModalRenderer) renderURLPicker(a App) string   { return "" }
-func (f fakeModalRenderer) renderIconPicker(a App) string  { return "" }
-func (f fakeModalRenderer) renderImageModal(a App) string  { return "" }
+func (f fakeModalRenderer) renderThemePicker(a App) string     { return "" }
+func (f fakeModalRenderer) renderThemeEditor(a App) string     { return "" }
+func (f fakeModalRenderer) renderPathPrompt(a App) string      { return "" }
+func (f fakeModalRenderer) renderHelpModal(a App) string       { return "" }
+func (f fakeModalRenderer) renderURLPicker(a App) string       { return "" }
+func (f fakeModalRenderer) renderIconPicker(a App) string      { return "" }
+func (f fakeModalRenderer) renderAttachURLPrompt(a App) string { return "" }
+func (f fakeModalRenderer) renderImageModal(a App) string      { return "" }
 func (f fakeModalRenderer) InlineImageSlots(a App) ([]screens.InlineImageSlot, int, int, string) {
 	return f.slots, f.rowOrigin, f.colOrigin, ""
 }

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -1087,6 +1087,13 @@ func (m ChatroomsModel) updateInner(msg tea.Msg) (ChatroomsModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case SetComposeValueMsg:
+		if m.mode == chatroomModeDetail {
+			m.input.SetValue(msg.Value)
+			m.input.CursorEnd()
+		}
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height

--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -894,8 +894,9 @@ func (m ChatroomsModel) SetMessages(roomID string, msgs []model.Message) Chatroo
 	return m
 }
 
-// SetRoomUsers replaces the presence panel's content, sorted admins-first
-// then alphabetical within each block. Recomputes the message viewport width
+// SetRoomUsers replaces the presence panel's content, sorted active before
+// idle, admins-first, then alphabetical within each block (see
+// sortRoomUsers). Recomputes the message viewport width
 // since the panel's presence affects it (panelWidths collapses to zero width
 // until the first snapshot arrives). The live presence stream fires this on
 // every change and on its own 5s re-evaluation timer, so — same as
@@ -903,7 +904,7 @@ func (m ChatroomsModel) SetMessages(roomID string, msgs []model.Message) Chatroo
 // re-home to the bottom if it was already there, or every presence tick
 // silently drifts the scroll position out from under the user.
 func (m ChatroomsModel) SetRoomUsers(users []model.RoomUser) ChatroomsModel {
-	m.roomUsers = sortRoomUsers(users)
+	m.roomUsers = sortRoomUsers(users, m.idleAfterMs)
 	if m.ready {
 		msgW, _ := m.panelWidths()
 		if msgW != m.viewport.Width {
@@ -1975,6 +1976,27 @@ func (m ChatroomsModel) updateBrowsingKey(msg tea.KeyMsg) (ChatroomsModel, tea.C
 		}
 		username := targetMsg.From.Username
 		return m, func() tea.Msg { return ShowUserProfileMsg{Username: username} }
+	case "c":
+		targetMsg, ok := findMessageByID(m.messages, m.selectedMsgID)
+		if !ok {
+			return m, nil
+		}
+		username := targetMsg.From.Username
+		return m, func() tea.Msg { return StartConversationMsg{Username: username} }
+	case "m":
+		targetMsg, ok := findMessageByID(m.messages, m.selectedMsgID)
+		if !ok || targetMsg.From.Username == m.currentUser || m.activeRoom == nil {
+			return m, nil
+		}
+		roomID, username := m.activeRoom.Slug, targetMsg.From.Username
+		return m, func() tea.Msg { return MuteUserMsg{RoomID: roomID, Username: username} }
+	case "y":
+		targetMsg, ok := findMessageByID(m.messages, m.selectedMsgID)
+		if !ok {
+			return m, nil
+		}
+		text := messageCopyText(targetMsg)
+		return m, func() tea.Msg { return CopyMessageTextMsg{Text: text} }
 	}
 	return m, nil
 }
@@ -2163,11 +2185,25 @@ func (m ChatroomsModel) mentionGhostText() string {
 	return string(top[len(q):])
 }
 
-// sortRoomUsers returns a copy of users ordered admins-first, then
-// alphabetically (case-insensitive) within each block.
-func sortRoomUsers(users []model.RoomUser) []model.RoomUser {
+// roomUserIsIdle reports whether u should be treated as idle given the
+// server's idleAfterMs threshold — shared by sortRoomUsers (idle users sort
+// after active ones) and renderRoomUsersPanel (💤 badge) so the two can
+// never disagree about who's idle. A nil LastActivity always means active
+// (the client never reported one), and idleAfterMs <= 0 (not yet known from
+// the server) means nobody is flagged.
+func roomUserIsIdle(u model.RoomUser, idleAfterMs int) bool {
+	return idleAfterMs > 0 && u.LastActivity != nil && time.Since(*u.LastActivity) > time.Duration(idleAfterMs)*time.Millisecond
+}
+
+// sortRoomUsers returns a copy of users ordered into four blocks — active
+// admins, active others, idle admins, idle others — alphabetical
+// (case-insensitive) within each.
+func sortRoomUsers(users []model.RoomUser, idleAfterMs int) []model.RoomUser {
 	out := append([]model.RoomUser(nil), users...)
 	sort.Slice(out, func(i, j int) bool {
+		if idleI, idleJ := roomUserIsIdle(out[i], idleAfterMs), roomUserIsIdle(out[j], idleAfterMs); idleI != idleJ {
+			return !idleI // active sorts before idle
+		}
 		if out[i].IsChatAdmin != out[j].IsChatAdmin {
 			return out[i].IsChatAdmin
 		}
@@ -2199,7 +2235,7 @@ func renderRoomUsersPanel(users []model.RoomUser, currentUser string, idleAfterM
 		case u.IsChatAdmin:
 			name = theme.Highlight.Render(name)
 		}
-		idle := idleAfterMs > 0 && u.LastActivity != nil && time.Since(*u.LastActivity) > time.Duration(idleAfterMs)*time.Millisecond
+		idle := roomUserIsIdle(u, idleAfterMs)
 		if idle {
 			name = theme.Subtle.Render("💤 ") + name
 		}

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -2032,3 +2032,18 @@ func TestChatrooms_VisibleInlineImages_LastMessageImage_AfterRealRowsKnown(t *te
 		t.Fatalf("expected the last message's image to stay visible after its band shrank, got %d slots: %+v", len(slots), slots)
 	}
 }
+
+// TestChatroomsModel_SetComposeValueMsg_ReplacesInput guards ctrl+g's
+// /gif dispatch (see app.go's applyAttachURL): unlike InsertIconMsg, which
+// inserts at the cursor, SetComposeValueMsg must replace the whole input —
+// a /gif command has to be the message's entire content to be recognized.
+func TestChatroomsModel_SetComposeValueMsg_ReplacesInput(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m.input.SetValue("some typed text")
+
+	m, _ = m.Update(SetComposeValueMsg{Value: "/gif https://example.com/pic.gif"})
+
+	if got := m.input.Value(); got != "/gif https://example.com/pic.gif" {
+		t.Errorf("input.Value() = %q, want the replaced /gif command", got)
+	}
+}

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -24,7 +24,7 @@ func TestSortRoomUsers_AdminsFirstThenAlphabetical(t *testing.T) {
 		{UserID: "3", Username: "alice"},
 		{UserID: "4", Username: "bob", IsChatAdmin: true},
 	}
-	out := sortRoomUsers(in)
+	out := sortRoomUsers(in, 0)
 
 	want := []string{"bob", "Molly", "alice", "zeb"}
 	if len(out) != len(want) {
@@ -42,9 +42,59 @@ func TestSortRoomUsers_AdminsFirstThenAlphabetical(t *testing.T) {
 
 func TestSortRoomUsers_DoesNotMutateInput(t *testing.T) {
 	in := []model.RoomUser{{UserID: "1", Username: "zeb"}, {UserID: "2", Username: "alice"}}
-	_ = sortRoomUsers(in)
+	_ = sortRoomUsers(in, 0)
 	if in[0].Username != "zeb" {
 		t.Errorf("input slice was mutated: %+v", in)
+	}
+}
+
+// TestSortRoomUsers_ActiveBeforeIdle_AdminFirstWithinEachBlock covers the
+// full four-block order: active admins, active others, idle admins, idle
+// others, alphabetical within each.
+func TestSortRoomUsers_ActiveBeforeIdle_AdminFirstWithinEachBlock(t *testing.T) {
+	const idleAfterMs = 60_000
+	longAgo := time.Now().Add(-time.Hour)
+	justNow := time.Now()
+
+	in := []model.RoomUser{
+		{UserID: "1", Username: "zeb", LastActivity: &longAgo},                      // idle, non-admin
+		{UserID: "2", Username: "molly", IsChatAdmin: true, LastActivity: &longAgo}, // idle, admin
+		{UserID: "3", Username: "trinity", LastActivity: &justNow},                  // active, non-admin
+		{UserID: "4", Username: "alice", IsChatAdmin: true, LastActivity: &justNow}, // active, admin
+		{UserID: "5", Username: "bob", LastActivity: &justNow},                      // active, non-admin
+		{UserID: "6", Username: "dozer", IsChatAdmin: true, LastActivity: &longAgo}, // idle, admin
+	}
+	out := sortRoomUsers(in, idleAfterMs)
+
+	want := []string{
+		"alice",   // active, admin
+		"bob",     // active, others (alphabetical)
+		"trinity", // active, others (alphabetical)
+		"dozer",   // idle, admin (alphabetical)
+		"molly",   // idle, admin (alphabetical)
+		"zeb",     // idle, others
+	}
+	got := make([]string, len(out))
+	for i, u := range out {
+		got[i] = u.Username
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("order = %v, want %v", got, want)
+	}
+}
+
+// TestSortRoomUsers_NilLastActivity_NeverIdle guards the documented
+// contract on RoomUser.LastActivity: a nil value always sorts as active,
+// even with a real idleAfterMs threshold in effect.
+func TestSortRoomUsers_NilLastActivity_NeverIdle(t *testing.T) {
+	longAgo := time.Now().Add(-time.Hour)
+	in := []model.RoomUser{
+		{UserID: "1", Username: "zeb", LastActivity: &longAgo}, // idle
+		{UserID: "2", Username: "alice"},                       // no LastActivity reported — active
+	}
+	out := sortRoomUsers(in, 60_000)
+	if out[0].Username != "alice" {
+		t.Errorf("out[0].Username = %q, want alice (nil LastActivity sorts as active)", out[0].Username)
 	}
 }
 
@@ -1469,6 +1519,128 @@ func TestBrowsing_P_NoSelectedMessage_IsNoop(t *testing.T) {
 	m = m.SetMessages("zion", nil)
 
 	_, cmd := m.updateBrowsingKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	if cmd != nil {
+		t.Error("expected no-op when nothing is selected")
+	}
+}
+
+// --- start C-Mail conversation (see updateBrowsingKey's "c" case) ---
+
+func TestBrowsing_C_EmitsStartConversationMsg(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "hi", CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	sc, ok := cmd().(StartConversationMsg)
+	if !ok {
+		t.Fatalf("expected StartConversationMsg, got %T", cmd())
+	}
+	if sc.Username != "molly" {
+		t.Errorf("Username = %q, want molly", sc.Username)
+	}
+}
+
+func TestBrowsing_C_NoSelectedMessage_IsNoop(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", nil)
+
+	_, cmd := m.updateBrowsingKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	if cmd != nil {
+		t.Error("expected no-op when nothing is selected")
+	}
+}
+
+// --- mute user (see updateBrowsingKey's "m" case) ---
+
+func TestBrowsing_M_EmitsMuteUserMsg(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "hi", CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("m")})
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	mu, ok := cmd().(MuteUserMsg)
+	if !ok {
+		t.Fatalf("expected MuteUserMsg, got %T", cmd())
+	}
+	if mu.RoomID != "zion" || mu.Username != "molly" {
+		t.Errorf("MuteUserMsg = %+v, want RoomID=zion Username=molly", mu)
+	}
+}
+
+func TestBrowsing_M_OwnMessage_IsNoop(t *testing.T) {
+	// chatroomsInRoom sets the current user to "neo" — see its doc comment.
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "neo"}, Body: "hi", CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+
+	_, cmd := m.updateBrowsingKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("m")})
+	if cmd != nil {
+		t.Error("expected no-op when trying to mute yourself")
+	}
+}
+
+func TestBrowsing_M_NoSelectedMessage_IsNoop(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", nil)
+
+	_, cmd := m.updateBrowsingKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("m")})
+	if cmd != nil {
+		t.Error("expected no-op when nothing is selected")
+	}
+}
+
+// --- copy message text (see updateBrowsingKey's "y" case) ---
+
+func TestBrowsing_Y_EmitsCopyMessageTextMsg(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", []model.Message{
+		{ID: "m1", From: model.User{Username: "molly"}, Body: "hi there", CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	cp, ok := cmd().(CopyMessageTextMsg)
+	if !ok {
+		t.Fatalf("expected CopyMessageTextMsg, got %T", cmd())
+	}
+	if cp.Text != "hi there" {
+		t.Errorf("Text = %q, want %q", cp.Text, "hi there")
+	}
+}
+
+func TestBrowsing_Y_NoSelectedMessage_IsNoop(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m = m.SetMessages("zion", nil)
+
+	_, cmd := m.updateBrowsingKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
 	if cmd != nil {
 		t.Error("expected no-op when nothing is selected")
 	}

--- a/internal/ui/screens/cmail.go
+++ b/internal/ui/screens/cmail.go
@@ -832,6 +832,13 @@ func (m CMailModel) updateInner(msg tea.Msg) (CMailModel, tea.Cmd) {
 		}
 		return m, nil
 
+	case SetComposeValueMsg:
+		if m.mode == cmailModeDetail {
+			m.input.SetValue(msg.Value)
+			m.input.CursorEnd()
+		}
+		return m, nil
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height

--- a/internal/ui/screens/cmail.go
+++ b/internal/ui/screens/cmail.go
@@ -1363,6 +1363,13 @@ func (m CMailModel) updateCMailBrowsingKey(msg tea.KeyMsg) (CMailModel, tea.Cmd)
 		}
 		username := targetMsg.From.Username
 		return m, func() tea.Msg { return ShowUserProfileMsg{Username: username} }
+	case "y":
+		targetMsg, ok := findMessageByID(m.activeConv.Messages, m.selectedMsgID)
+		if !ok {
+			return m, nil
+		}
+		text := messageCopyText(targetMsg)
+		return m, func() tea.Msg { return CopyMessageTextMsg{Text: text} }
 	}
 	return m, nil
 }

--- a/internal/ui/screens/cmail_test.go
+++ b/internal/ui/screens/cmail_test.go
@@ -1038,3 +1038,16 @@ func TestCMailBrowsing_P_NoSelectedMessage_IsNoop(t *testing.T) {
 		t.Error("expected no-op when nothing is selected")
 	}
 }
+
+// TestCMailModel_SetComposeValueMsg_ReplacesInput mirrors the same check in
+// chatrooms_test.go — see its doc comment.
+func TestCMailModel_SetComposeValueMsg_ReplacesInput(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	m.input.SetValue("some typed text")
+
+	m, _ = m.Update(SetComposeValueMsg{Value: "/gif https://example.com/pic.gif"})
+
+	if got := m.input.Value(); got != "/gif https://example.com/pic.gif" {
+		t.Errorf("input.Value() = %q, want the replaced /gif command", got)
+	}
+}

--- a/internal/ui/screens/cmail_test.go
+++ b/internal/ui/screens/cmail_test.go
@@ -1039,6 +1039,41 @@ func TestCMailBrowsing_P_NoSelectedMessage_IsNoop(t *testing.T) {
 	}
 }
 
+// --- copy message text (see updateCMailBrowsingKey's "y" case) ---
+
+func TestCMailBrowsing_Y_EmitsCopyMessageTextMsg(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	m = m.SetConversationMessages("c1", []model.Message{
+		{ID: "m1", From: model.User{Username: "trinity"}, Body: "hi there", CreatedAt: time.Now()},
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.selectedMsgID != "m1" {
+		t.Fatalf("setup: selectedMsgID = %q, want m1", m.selectedMsgID)
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	cp, ok := cmd().(CopyMessageTextMsg)
+	if !ok {
+		t.Fatalf("expected CopyMessageTextMsg, got %T", cmd())
+	}
+	if cp.Text != "hi there" {
+		t.Errorf("Text = %q, want %q", cp.Text, "hi there")
+	}
+}
+
+func TestCMailBrowsing_Y_NoSelectedMessage_IsNoop(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	m = m.SetConversationMessages("c1", nil)
+
+	_, cmd := m.updateCMailBrowsingKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd != nil {
+		t.Error("expected no-op when nothing is selected")
+	}
+}
+
 // TestCMailModel_SetComposeValueMsg_ReplacesInput mirrors the same check in
 // chatrooms_test.go — see its doc comment.
 func TestCMailModel_SetComposeValueMsg_ReplacesInput(t *testing.T) {

--- a/internal/ui/screens/compose.go
+++ b/internal/ui/screens/compose.go
@@ -40,6 +40,14 @@ type ComposeSubmitMsg struct{ Content string }
 // ComposeCancelMsg is emitted when the user presses Esc to cancel.
 type ComposeCancelMsg struct{}
 
+// SetComposeValueMsg replaces the entire value of whatever single-line
+// compose input is focused, cursor moved to the end — unlike InsertIconMsg,
+// which inserts at the cursor and is meant to blend into typed text. Used
+// for ctrl+g attaching a GIF to a circ/C-Mail message: `/gif <url>` must be
+// the message's entire content to be recognized as a command, so it
+// replaces rather than merges with whatever was already typed.
+type SetComposeValueMsg struct{ Value string }
+
 // ComposeModel is a reusable expanding multi-line text editor.
 // Embed it in any screen that needs a compose area.
 //   - Enter inserts a paragraph break (\n\n → <p> on the website)
@@ -299,6 +307,21 @@ type PostComposePanel struct {
 	editing     bool // true when editing an existing post rather than creating one
 	width       int
 	bodyLines   int
+
+	// attachmentURL is a pending image/gif URL attachment, set via ctrl+g
+	// (see app.go). attachmentTouched distinguishes "never touched this
+	// session" from "explicitly cleared" so an edit submit can tell whether
+	// to send the attachments field at all (see SubmitPostEditMsg) — an
+	// edit that never touches attachments must not silently wipe an
+	// existing one (e.g. an audio attachment this panel knows nothing about).
+	attachmentURL     string
+	attachmentTouched bool
+	// otherAttachments holds every attachment OpenForEdit found on the post
+	// besides the one it loaded into attachmentURL (e.g. a /song jukebox
+	// track) — carried through untouched so a submit that sends the
+	// attachments field (attachmentTouched) re-includes them instead of
+	// dropping them, since the API replaces the whole array wholesale.
+	otherAttachments []model.Attachment
 }
 
 func NewPostComposePanel(width int) PostComposePanel {
@@ -343,6 +366,9 @@ func (m PostComposePanel) Open(defaultPublic bool) (PostComposePanel, tea.Cmd) {
 	m.textarea.SetValue("")
 	m.bodyLines = composeMinLines
 	m.textarea.SetHeight(composeMinLines)
+	m.attachmentURL = ""
+	m.attachmentTouched = false
+	m.otherAttachments = nil
 	m.textarea.Blur()
 	m.slugInput.Blur()
 	m.topicsInput.Blur()
@@ -364,6 +390,16 @@ func (m PostComposePanel) OpenForEdit(post model.Post) (PostComposePanel, tea.Cm
 	m.slugError = ""
 	m.topicsInput.SetValue(strings.Join(post.Topics, ", "))
 	m.textarea.SetValue(post.Content)
+	m.attachmentURL = ""
+	m.attachmentTouched = false
+	m.otherAttachments = nil
+	for _, a := range post.Attachments {
+		if m.attachmentURL == "" && (a.Type == "image" || a.Type == "gif") {
+			m.attachmentURL = a.Src
+			continue
+		}
+		m.otherAttachments = append(m.otherAttachments, a)
+	}
 	m.titleInput.Blur()
 	m.slugInput.Blur()
 	m.topicsInput.Blur()
@@ -391,11 +427,30 @@ func (m PostComposePanel) Close() PostComposePanel {
 	m.textarea.SetValue("")
 	m.textarea.Blur()
 	m.topicsInput.Blur()
+	m.attachmentURL = ""
+	m.attachmentTouched = false
+	m.otherAttachments = nil
 	return m
 }
 
 func (m PostComposePanel) IsActive() bool     { return m.active }
 func (m PostComposePanel) Content() string    { return m.textarea.Value() }
+
+// SetAttachmentURL sets (or, given "", clears) the pending image/gif
+// attachment and marks it touched — see the struct's attachmentTouched doc.
+func (m PostComposePanel) SetAttachmentURL(url string) PostComposePanel {
+	m.attachmentURL = url
+	m.attachmentTouched = true
+	return m
+}
+
+func (m PostComposePanel) AttachmentURL() string   { return m.attachmentURL }
+func (m PostComposePanel) AttachmentTouched() bool { return m.attachmentTouched }
+
+// OtherAttachments returns every attachment OpenForEdit found on the post
+// besides the image/gif one tracked by AttachmentURL — see the struct's
+// otherAttachments doc.
+func (m PostComposePanel) OtherAttachments() []model.Attachment { return m.otherAttachments }
 
 // InsertText inserts s (e.g. an icon picked from the Ctrl+] icon picker) at
 // the cursor of whichever free-text field currently has focus. No-op for
@@ -421,10 +476,14 @@ func (m PostComposePanel) IsNSFW() bool      { return m.isNSFW }
 // 2 (border) + 1 (title row) + 1 (slug row) + 1 (sep) + bodyLines + 1 (sep) + 1 (topics row).
 // The slug row is omitted in edit mode (slug is immutable once published).
 func (m PostComposePanel) PanelHeight() int {
+	h := m.bodyLines + 7
 	if m.editing {
-		return m.bodyLines + 6
+		h = m.bodyLines + 6
 	}
-	return m.bodyLines + 7
+	if m.attachmentURL != "" {
+		h++
+	}
+	return h
 }
 
 // SetWidth resizes all inner inputs to fit the new panel width.
@@ -684,6 +743,14 @@ func (m PostComposePanel) View() string {
 		rows = append(rows, slugRow)
 	}
 	rows = append(rows, sep, m.textarea.View(), sep, topicsRow)
+	if m.attachmentURL != "" {
+		const attachLabelW = 7 // "attach " — matches labelW used for title/slug/topics rows
+		url := m.attachmentURL
+		if remaining := innerW - attachLabelW; remaining > 1 {
+			url = ansiTruncate(url, remaining)
+		}
+		rows = append(rows, theme.Subtle.Render("attach ")+theme.Base.Render(url))
+	}
 	inner := lipgloss.JoinVertical(lipgloss.Left, rows...)
 	boxStyle := theme.ActiveBorder
 	if m.width > 2 {

--- a/internal/ui/screens/compose_test.go
+++ b/internal/ui/screens/compose_test.go
@@ -34,3 +34,68 @@ func TestPostComposePanel_OpenForEdit_TextareaHeightMatchesBodyLines(t *testing.
 		t.Errorf("PanelHeight() = %d, want %d", got, want)
 	}
 }
+
+// TestPostComposePanel_OpenForEdit_PrefillsImageAttachment guards the
+// prefill PostDetail/Feed rely on to avoid clobbering an existing attachment
+// on save: OpenForEdit must seed attachmentURL from the post's own
+// image/gif attachment (skipping any audio one), but leave it untouched so
+// a save that never calls SetAttachmentURL omits the attachments field
+// entirely (see EditPost's attachmentTouched). The audio attachment must
+// still be preserved (via OtherAttachments) rather than discarded, since a
+// touched save resends the whole attachments array and would otherwise
+// silently drop it.
+func TestPostComposePanel_OpenForEdit_PrefillsImageAttachment(t *testing.T) {
+	m := NewPostComposePanel(80)
+	audio := model.Attachment{Type: "audio", Src: "https://example.com/track.mp3"}
+	m, _ = m.OpenForEdit(model.Post{
+		Attachments: []model.Attachment{
+			audio,
+			{Type: "image", Src: "https://example.com/pic.png"},
+		},
+	})
+	if got := m.AttachmentURL(); got != "https://example.com/pic.png" {
+		t.Errorf("AttachmentURL() = %q, want the image attachment's src (audio skipped)", got)
+	}
+	if got := m.OtherAttachments(); len(got) != 1 || got[0] != audio {
+		t.Errorf("OtherAttachments() = %v, want [%v] (the audio attachment, preserved)", got, audio)
+	}
+	if m.AttachmentTouched() {
+		t.Error("AttachmentTouched() = true after OpenForEdit, want false — prefilling isn't a user edit")
+	}
+}
+
+// TestPostComposePanel_SetAttachmentURL_MarksTouchedEvenWhenClearing checks
+// the touched flag flips on an explicit clear (empty string), not just a
+// set — that's what tells EditPost to actually send `attachments: []`
+// instead of silently leaving a stale attachment in place.
+func TestPostComposePanel_SetAttachmentURL_MarksTouchedEvenWhenClearing(t *testing.T) {
+	m := NewPostComposePanel(80)
+	m, _ = m.OpenForEdit(model.Post{
+		Attachments: []model.Attachment{{Type: "image", Src: "https://example.com/pic.png"}},
+	})
+	m = m.SetAttachmentURL("")
+	if got := m.AttachmentURL(); got != "" {
+		t.Errorf("AttachmentURL() = %q, want empty after clearing", got)
+	}
+	if !m.AttachmentTouched() {
+		t.Error("AttachmentTouched() = false after an explicit clear, want true")
+	}
+}
+
+// TestPostComposePanel_Open_ResetsAttachment guards against a stale
+// attachment (or touched flag) from a previous edit session leaking into the
+// next new-post compose.
+func TestPostComposePanel_Open_ResetsAttachment(t *testing.T) {
+	m := NewPostComposePanel(80)
+	m, _ = m.OpenForEdit(model.Post{
+		Attachments: []model.Attachment{{Type: "image", Src: "https://example.com/pic.png"}},
+	})
+	m = m.SetAttachmentURL("https://example.com/other.png")
+	m, _ = m.Open(false)
+	if got := m.AttachmentURL(); got != "" {
+		t.Errorf("AttachmentURL() = %q after Open(), want empty", got)
+	}
+	if m.AttachmentTouched() {
+		t.Error("AttachmentTouched() = true after Open(), want false")
+	}
+}

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -69,24 +69,31 @@ const feedMergeAnimDelay = 200 * time.Millisecond
 
 // SubmitNewPostMsg is emitted when the user submits a new post from the Feed.
 type SubmitNewPostMsg struct {
-	Content  string
-	Title    string // empty = no title
-	Slug     string // empty = server-generated
-	Topics   []string
-	IsPublic bool
-	IsNSFW   bool
+	Content       string
+	Title         string // empty = no title
+	Slug          string // empty = server-generated
+	Topics        []string
+	IsPublic      bool
+	IsNSFW        bool
+	AttachmentURL string // empty = no attachment
 }
 
 // SubmitPostEditMsg is emitted when the user submits an edit to an existing
 // post via the 'e' key (Feed or PostDetail). Unlike SubmitNewPostMsg, slug is
 // not included — it's immutable once published.
 type SubmitPostEditMsg struct {
-	PostID   string
-	Content  string
-	Title    string
-	Topics   []string
-	IsPublic bool
-	IsNSFW   bool
+	PostID            string
+	Content           string
+	Title             string
+	Topics            []string
+	IsPublic          bool
+	IsNSFW            bool
+	AttachmentURL     string // only meaningful when AttachmentTouched
+	AttachmentTouched bool   // false = leave existing attachments alone
+	// OtherAttachments are attachments the edit panel found on the post but
+	// doesn't manage (e.g. an audio one) — re-sent alongside AttachmentURL
+	// when AttachmentTouched, since the API replaces the whole array.
+	OtherAttachments []model.Attachment
 }
 
 type FeedModel struct {
@@ -346,8 +353,11 @@ func (m FeedModel) CanEditSelected() bool {
 }
 
 // ApplyPostEdit overwrites the edited fields of a local post by ID after a
-// successful PATCH, leaving AuthorID, CreatedAt, RepliesCount, etc. untouched.
-func (m FeedModel) ApplyPostEdit(postID, content, title string, topics []string, isPublic, isNSFW bool, editedAt time.Time) FeedModel {
+// successful PATCH, leaving AuthorID, CreatedAt, RepliesCount, etc.
+// untouched. Attachments is only applied when attachmentsTouched — the edit
+// didn't change them server-side otherwise, so the cached value is already
+// correct (see EditPost's own attachmentTouched).
+func (m FeedModel) ApplyPostEdit(postID, content, title string, topics []string, isPublic, isNSFW bool, editedAt time.Time, attachments []model.Attachment, attachmentsTouched bool) FeedModel {
 	for i, p := range m.posts {
 		if p.ID == postID {
 			p.Content = content
@@ -356,6 +366,9 @@ func (m FeedModel) ApplyPostEdit(postID, content, title string, topics []string,
 			p.IsPublic = isPublic
 			p.IsNSFW = isNSFW
 			p.EditedAt = editedAt
+			if attachmentsTouched {
+				p.Attachments = attachments
+			}
 			m.posts[i] = p
 			break
 		}
@@ -480,6 +493,17 @@ func (m FeedModel) ComposeActive() bool {
 func (m FeedModel) ComposeHeight() int           { return m.panel.PanelHeight() }
 func (m FeedModel) ComposeView(width int) string { return m.panel.SetWidth(width).View() }
 
+// PanelActive reports whether the new-post/edit-post panel is open, for
+// app.go to decide whether ctrl+g should set a native post attachment
+// instead of inserting markdown into whatever's focused.
+func (m FeedModel) PanelActive() bool { return m.panel.IsActive() }
+
+// SetPanelAttachment sets the panel's pending image/gif attachment URL.
+func (m FeedModel) SetPanelAttachment(url string) FeedModel {
+	m.panel = m.panel.SetAttachmentURL(url)
+	return m
+}
+
 func (m FeedModel) Init() tea.Cmd { return nil }
 
 func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
@@ -580,17 +604,20 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		topics := ParseTopics(m.panel.TopicsRaw())
 		isPublic := m.panel.IsPublic()
 		isNSFW := m.panel.IsNSFW()
+		attachmentURL := m.panel.AttachmentURL()
+		attachmentTouched := m.panel.AttachmentTouched()
+		otherAttachments := m.panel.OtherAttachments()
 		if m.editingPostID != "" {
 			postID := m.editingPostID
 			m = m.closeCompose()
 			return m, func() tea.Msg {
-				return SubmitPostEditMsg{PostID: postID, Content: content, Title: title, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW}
+				return SubmitPostEditMsg{PostID: postID, Content: content, Title: title, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW, AttachmentURL: attachmentURL, AttachmentTouched: attachmentTouched, OtherAttachments: otherAttachments}
 			}
 		}
 		slug := m.panel.SlugValue()
 		m = m.closeCompose()
 		return m, func() tea.Msg {
-			return SubmitNewPostMsg{Content: content, Title: title, Slug: slug, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW}
+			return SubmitNewPostMsg{Content: content, Title: title, Slug: slug, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW, AttachmentURL: attachmentURL}
 		}
 
 	case ComposeCancelMsg:

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -72,9 +72,26 @@ type URLProvider interface {
 type ShowUserProfileMsg struct{ Username string }
 
 // StartConversationMsg is emitted by any screen when the user presses 'c' on a
-// highlighted post, reply, notification, or profile to open (or create) a C-Mail
-// conversation with that user. App guards against self-DMs.
+// highlighted post, reply, notification, profile, or cIRC message to open (or
+// create) a C-Mail conversation with that user. App guards against self-DMs.
 type StartConversationMsg struct{ Username string }
+
+// MuteUserMsg is emitted by Chatrooms when the user presses 'm' on a
+// selected message, to mute that message's sender for the room without
+// having to type "/mute <username>" by hand. cIRC-only — muting isn't a
+// concept in C-Mail's 1:1 conversations. App sends it as that exact slash
+// command (the only way to mute is server-side, via chat content) and
+// notifies on success, since /mute posts nothing to the room itself.
+type MuteUserMsg struct {
+	RoomID   string
+	Username string
+}
+
+// CopyMessageTextMsg is emitted by Chatrooms or CMail when the user presses
+// 'y' on a selected message, to copy its text to the clipboard — the chat
+// equivalent of CopyLinkMsg (posts have a permalink to copy; messages don't,
+// so this copies the content itself). App notifies on success.
+type CopyMessageTextMsg struct{ Text string }
 
 // OpenRoomMsg is emitted by Notifications when the user presses Enter on a
 // chat_mention notification. RoomSlug identifies the target cIRC room; App

--- a/internal/ui/screens/pathprompt.go
+++ b/internal/ui/screens/pathprompt.go
@@ -38,6 +38,12 @@ func (m PathPromptModel) SetWarning(text string) PathPromptModel {
 	return m
 }
 
+// Value returns the current input text. Callers that intercept enter/esc
+// themselves (rather than relying on PathPromptSubmitMsg/PathPromptCancelMsg
+// — e.g. because that message type is already claimed by another open
+// prompt) read the submitted value through here.
+func (m PathPromptModel) Value() string { return m.input.Value() }
+
 func (m PathPromptModel) Update(msg tea.KeyMsg) (PathPromptModel, tea.Cmd) {
 	switch msg.String() {
 	case "enter":

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -312,6 +312,22 @@ func (m PostDetailModel) ComposeActive() bool {
 	return m.compose.IsActive() || m.editPanel.IsActive() || m.flagPrompt.Active() || m.confirming != pdConfirmNone
 }
 
+// EditPanelActive reports whether the post-edit panel specifically (not the
+// reply compose box) is open, for app.go to decide whether ctrl+g should set
+// a native post attachment instead of inserting markdown into the reply box.
+func (m PostDetailModel) EditPanelActive() bool { return m.editPanel.IsActive() }
+
+// ReplyComposeActive reports whether the reply compose box specifically
+// (not the edit panel) is open — see app.go's applyAttachURL, which warns
+// instead of inserting here: the reply API has no attachments field at all.
+func (m PostDetailModel) ReplyComposeActive() bool { return m.compose.IsActive() }
+
+// SetEditPanelAttachment sets the edit panel's pending image/gif attachment URL.
+func (m PostDetailModel) SetEditPanelAttachment(url string) PostDetailModel {
+	m.editPanel = m.editPanel.SetAttachmentURL(url)
+	return m
+}
+
 func (m PostDetailModel) SetError(err error) PostDetailModel {
 	m.err = err
 	m.loading = false
@@ -353,13 +369,19 @@ func (m PostDetailModel) CanEditSelected() bool {
 
 // ApplyPostEdit overwrites the edited fields of the displayed post after a
 // successful PATCH, leaving AuthorID, CreatedAt, RepliesCount, etc. untouched.
-func (m PostDetailModel) ApplyPostEdit(content, title string, topics []string, isPublic, isNSFW bool, editedAt time.Time) PostDetailModel {
+// ApplyPostEdit overwrites the edited fields of the open post after a
+// successful PATCH. Attachments is only applied when attachmentsTouched —
+// see FeedModel.ApplyPostEdit's doc comment for why.
+func (m PostDetailModel) ApplyPostEdit(content, title string, topics []string, isPublic, isNSFW bool, editedAt time.Time, attachments []model.Attachment, attachmentsTouched bool) PostDetailModel {
 	m.post.Content = content
 	m.post.Title = title
 	m.post.Topics = topics
 	m.post.IsPublic = isPublic
 	m.post.IsNSFW = isNSFW
 	m.post.EditedAt = editedAt
+	if attachmentsTouched {
+		m.post.Attachments = attachments
+	}
 	if m.ready {
 		m = m.refreshContent()
 	}
@@ -584,12 +606,15 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 			topics := ParseTopics(m.editPanel.TopicsRaw())
 			isPublic := m.editPanel.IsPublic()
 			isNSFW := m.editPanel.IsNSFW()
+			attachmentURL := m.editPanel.AttachmentURL()
+			attachmentTouched := m.editPanel.AttachmentTouched()
+			otherAttachments := m.editPanel.OtherAttachments()
 			m.editPanel = m.editPanel.Close()
 			if m.ready {
 				m.viewport.Height = m.viewportHeight()
 			}
 			return m, func() tea.Msg {
-				return SubmitPostEditMsg{PostID: postID, Content: content, Title: title, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW}
+				return SubmitPostEditMsg{PostID: postID, Content: content, Title: title, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW, AttachmentURL: attachmentURL, AttachmentTouched: attachmentTouched, OtherAttachments: otherAttachments}
 			}
 		}
 		content := msg.Content

--- a/internal/ui/screens/shared.go
+++ b/internal/ui/screens/shared.go
@@ -248,6 +248,26 @@ func messageURLs(msg model.Message) []string {
 	return urls
 }
 
+// messageCopyText returns the text 'y' should copy for msg: its body, or —
+// for an attachment-only message with no body (an /gif or /song posted with
+// no caption) — the attachment's URL, so copying still does something
+// useful rather than copying an empty string.
+func messageCopyText(msg model.Message) string {
+	if msg.Body != "" {
+		return msg.Body
+	}
+	if msg.ImageUrl != "" {
+		return msg.ImageUrl
+	}
+	if msg.GifUrl != "" {
+		return msg.GifUrl
+	}
+	if msg.AudioAttachment != nil {
+		return msg.AudioAttachment.Src
+	}
+	return ""
+}
+
 // messageDisplayBody returns "" when Body merely duplicates ImageUrl or
 // GifUrl (an attachment-only message posted with no text), so callers can
 // skip printing a redundant line of URL text next to the attachment badge

--- a/internal/ui/screens/shared_test.go
+++ b/internal/ui/screens/shared_test.go
@@ -5,7 +5,32 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ragnar/cyber-tui/internal/model"
 )
+
+// TestMessageCopyText covers 'y's precedence: body text first, then
+// whichever attachment field is set, so copying a caption-less /gif or
+// /song message still copies something useful instead of an empty string.
+func TestMessageCopyText(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  model.Message
+		want string
+	}{
+		{"body wins over attachments", model.Message{Body: "hi", ImageUrl: "https://example.com/a.png"}, "hi"},
+		{"falls back to ImageUrl", model.Message{ImageUrl: "https://example.com/a.png"}, "https://example.com/a.png"},
+		{"falls back to GifUrl", model.Message{GifUrl: "https://example.com/a.gif"}, "https://example.com/a.gif"},
+		{"falls back to AudioAttachment.Src", model.Message{AudioAttachment: &model.Attachment{Src: "https://youtu.be/x"}}, "https://youtu.be/x"},
+		{"empty message copies nothing", model.Message{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := messageCopyText(c.msg); got != c.want {
+				t.Errorf("messageCopyText() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
 
 func runesMsg(s string) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}


### PR DESCRIPTION
## Summary
- Attach images/GIFs to posts (native `attachments`, dimension-checked, 640×640 server cap) and GIFs to circ/C-Mail (via `/gif`, visually confirmed on the live site) through a new `ctrl+g` prompt. Non-GIF chat images and replies warn instead of silently inserting text that won't render anywhere but cyber-tui itself.
- Fix a pre-existing bug where images from hosts with a bot-blocking User-Agent policy (Wikimedia confirmed live) silently failed to fetch and fell back to opening in the browser.
- New circ message shortcuts: `c` (start a C-Mail conversation with the message's author), `m` (mute the author via `/mute`, with a success notification and settings reload so the mute list actually refreshes), `y` (copy message text to clipboard, circ and C-Mail).
- Presence panel now sorts into four blocks — active admins, active others, idle admins, idle others — alphabetical within each, instead of ignoring idle status in the sort order.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean
- [x] Live-verified against the real API: post creation with a native attachment, `/gif` rendering on the website, the User-Agent fix against a real Wikimedia-hosted GIF
- [ ] Manual smoke test in the running TUI: attach an image to a new/edited post, attach a GIF in circ/C-Mail, `c`/`m`/`y` in circ, presence panel ordering with a mix of active/idle/admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)