### PR TITLE
fix: animate gif attachments opened via extensionless URLs

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2780,7 +2780,7 @@ func (a App) routeURL(rawURL string) (App, tea.Cmd) {
 	if a.ephemeral {
 		return a.notify(notifyInfo, "Opening links is disabled in SSH sessions")
 	}
-	if a.canRenderImageInline(rawURL) {
+	if a.canRenderImageInline(rawURL) || a.canProbeImageInline() {
 		return a.openImageInTerminal(rawURL)
 	}
 	return a, openExternalURL(rawURL)
@@ -2795,6 +2795,23 @@ func (a App) routeURL(rawURL string) (App, tea.Cmd) {
 func (a App) canRenderImageInline(u string) bool {
 	return !a.ephemeral &&
 		urlutil.IsImageURL(u) &&
+		a.graphicsProtocol != imgview.ProtocolNone &&
+		a.imageViewer != "browser"
+}
+
+// canProbeImageInline reports whether u is worth an inline-open attempt even
+// though its extension doesn't look like an image: /gif <url> in circ/C-Mail
+// forwards whatever URL the user typed verbatim (chatrooms.go's slash-command
+// handling does no URL validation), and real gif links routinely lack a
+// literal ".gif" suffix (Tenor share pages, extensionless CDN links). Rather
+// than guess further from the URL text, this defers to openImageInTerminal's
+// real fetch+decode (via imgview.FetchAny, which sniffs the downloaded
+// bytes) as the source of truth, falling back to the browser via
+// handleImageViewer's existing error path when the content genuinely isn't a
+// decodable image. Same gates as canRenderImageInline minus the extension
+// check.
+func (a App) canProbeImageInline() bool {
+	return !a.ephemeral &&
 		a.graphicsProtocol != imgview.ProtocolNone &&
 		a.imageViewer != "browser"
 }
@@ -3531,7 +3548,6 @@ func (a App) adjustImageScale(delta float64) (App, tea.Cmd) {
 // edges, not just merely within them.
 func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 	proto := a.graphicsProtocol
-	isGIF := urlutil.IsGIFURL(rawURL)
 	scale := a.imageScale
 	if scale <= 0 {
 		scale = 1.0
@@ -3547,19 +3563,10 @@ func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 		if !hit {
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
-			if isGIF {
-				g, err := imgview.FetchGIF(ctx, rawURL)
-				if err != nil {
-					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
-				}
-				frames, delays = imgview.GIFFrames(g)
-			} else {
-				img, err := imgview.Fetch(ctx, rawURL)
-				if err != nil {
-					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
-				}
-				frames = []image.Image{img}
-				delays = nil
+			var err error
+			frames, delays, err = imgview.FetchAny(ctx, rawURL)
+			if err != nil {
+				return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
 			}
 		}
 		cellW, cellH, _ := imgview.TerminalCellPixelSize(int(os.Stdout.Fd()))
@@ -4699,10 +4706,13 @@ func (a *App) createReplyCmd(postID, content, parentReplyID string) tea.Cmd {
 const maxAttachmentDim = 640
 
 // attachmentTypeForURL infers a wireAttachment's "type" from the URL's path
-// extension (via urlutil.IsGIFURL, already used the same way for graphics-
-// protocol detection in openImageInTerminal — ignores query string/fragment,
-// unlike a raw suffix check, so a signed CDN link like ".gif?token=..."
-// still resolves correctly).
+// extension (via urlutil.IsGIFURL — ignores query string/fragment, unlike a
+// raw suffix check, so a signed CDN link like ".gif?token=..." still
+// resolves correctly). This only covers native post/reply attachments,
+// which are always this client's own upload URLs with a known extension;
+// circ/C-Mail's /gif <url> accepts arbitrary user-typed URLs instead, so
+// openImageInTerminal no longer relies on extension sniffing — see
+// imgview.FetchAny.
 func attachmentTypeForURL(rawURL string) string {
 	if urlutil.IsGIFURL(rawURL) {
 		return "gif"

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1411,6 +1411,49 @@ func TestRouteURL_RelativeURL_ExternalOpen(t *testing.T) {
 	}
 }
 
+// TestRouteURL_ExtensionlessURL_ProbesInlineViewer guards the /gif <url>
+// bug: circ/C-Mail's gif attachments forward whatever URL the user typed,
+// which often has no ".gif" suffix (Tenor share links, extensionless CDN
+// URLs) — canRenderImageInline's extension check alone would reject these
+// and send them straight to the browser. With a graphics protocol
+// available, routeURL must still attempt the inline viewer (via
+// canProbeImageInline) and let the real fetch+decode in imgview.FetchAny
+// decide, rather than trusting the URL's extension. openImageInTerminal
+// bumps imageFetchGen, so that's used here as a proxy for "took the inline
+// path" without needing to inspect the opaque tea.Cmd closure.
+func TestRouteURL_ExtensionlessURL_ProbesInlineViewer(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.imageViewer = "terminal"
+	genBefore := a.imageFetchGen
+
+	a2, cmd := a.routeURL("https://example.com/no-extension-gif")
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	if a2.imageFetchGen == genBefore {
+		t.Error("expected routeURL to probe the inline viewer for an extensionless URL when a graphics protocol is detected")
+	}
+}
+
+// TestRouteURL_ExtensionlessURL_NoProtocol_OpensExternal confirms the probe
+// added for extensionless URLs still respects the same gates as
+// canRenderImageInline — no graphics protocol means straight to the
+// browser, same as today, no wasted fetch attempt.
+func TestRouteURL_ExtensionlessURL_NoProtocol_OpensExternal(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolNone
+	genBefore := a.imageFetchGen
+
+	a2, cmd := a.routeURL("https://example.com/no-extension-gif")
+	if cmd == nil {
+		t.Fatal("expected a cmd")
+	}
+	if a2.imageFetchGen != genBefore {
+		t.Error("expected no inline-viewer attempt without a detected graphics protocol")
+	}
+}
+
 func TestRouteURL_ReservedWord_NotTreatedAsUsername(t *testing.T) {
 	a := loggedInApp()
 	a.active = screenFeed

--- a/internal/ui/imgview/fetch.go
+++ b/internal/ui/imgview/fetch.go
@@ -128,6 +128,10 @@ func FetchGIF(ctx context.Context, rawURL string) (*gif.GIF, error) {
 	if err != nil {
 		return nil, err
 	}
+	return decodeGIF(body)
+}
+
+func decodeGIF(body []byte) (*gif.GIF, error) {
 	cfg, err := gif.DecodeConfig(bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("imgview: decode: %w", err)
@@ -146,4 +150,38 @@ func FetchGIF(ctx context.Context, rawURL string) (*gif.GIF, error) {
 		return nil, fmt.Errorf("imgview: gif frames×dimensions %d exceed %d pixel budget", total, maxGIFTotalPixels)
 	}
 	return g, nil
+}
+
+// FetchAny downloads the resource at rawURL and decodes it as an animated
+// GIF (all frames) or a static image (single frame), deciding which from the
+// downloaded bytes' own GIF87a/GIF89a magic header rather than rawURL's file
+// extension — /gif <url> in circ/C-Mail accepts any user-supplied URL, and
+// plenty of real gif links (Tenor share pages, extensionless CDN links)
+// don't end in literal ".gif", so extension sniffing false-negatives on
+// them. Returns one frame with a nil delay slice for a non-GIF image.
+func FetchAny(ctx context.Context, rawURL string) (frames []image.Image, delays []time.Duration, err error) {
+	body, err := fetchBody(ctx, rawURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(body) >= 6 && (string(body[:6]) == "GIF87a" || string(body[:6]) == "GIF89a") {
+		g, err := decodeGIF(body)
+		if err != nil {
+			return nil, nil, err
+		}
+		frames, delays = GIFFrames(g)
+		return frames, delays, nil
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, fmt.Errorf("imgview: decode: %w", err)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 || cfg.Width*cfg.Height > maxImagePixels {
+		return nil, nil, fmt.Errorf("imgview: image dimensions %dx%d exceed limit", cfg.Width, cfg.Height)
+	}
+	img, _, err := image.Decode(bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, fmt.Errorf("imgview: decode: %w", err)
+	}
+	return []image.Image{img}, nil, nil
 }

--- a/internal/ui/imgview/fetch_test.go
+++ b/internal/ui/imgview/fetch_test.go
@@ -172,3 +172,48 @@ func TestFetchGIF_RejectsExcessiveDimensions(t *testing.T) {
 		t.Errorf("err = %v, want dimensions error", err)
 	}
 }
+
+// TestFetchAny_DetectsGIFFromExtensionlessURL guards the actual bug this
+// fixes: /gif <url> in circ/C-Mail forwards an arbitrary user-typed URL
+// (Tenor share links, CDN links with no ".gif" suffix, etc.) with no
+// extension to key off, so FetchAny must decide GIF-vs-static from the
+// downloaded bytes' own GIF87a/GIF89a header, not the URL's path.
+func TestFetchAny_DetectsGIFFromExtensionlessURL(t *testing.T) {
+	srv := serve(t, http.StatusOK, gifBytes(t, 4, 3, 3))
+	url := srv.URL + "/no-extension-here"
+	frames, delays, err := imgview.FetchAny(context.Background(), url)
+	if err != nil {
+		t.Fatalf("FetchAny: %v", err)
+	}
+	if len(frames) != 3 {
+		t.Errorf("frame count = %d, want 3", len(frames))
+	}
+	if len(delays) != 3 {
+		t.Errorf("delay count = %d, want 3", len(delays))
+	}
+}
+
+func TestFetchAny_StaticImageReturnsOneFrameNoDelays(t *testing.T) {
+	srv := serve(t, http.StatusOK, pngBytes(t, 4, 3))
+	frames, delays, err := imgview.FetchAny(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("FetchAny: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Errorf("frame count = %d, want 1", len(frames))
+	}
+	if delays != nil {
+		t.Errorf("delays = %v, want nil", delays)
+	}
+	if b := frames[0].Bounds(); b.Dx() != 4 || b.Dy() != 3 {
+		t.Errorf("bounds = %v, want 4x3", b)
+	}
+}
+
+func TestFetchAny_RejectsUndecodableContent(t *testing.T) {
+	srv := serve(t, http.StatusOK, []byte("<html>not an image</html>"))
+	_, _, err := imgview.FetchAny(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("FetchAny: want error for non-image content, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
`/gif <url>` in circ/C-Mail forwards whatever URL the user typed verbatim, with no extension validation. Both `canRenderImageInline` and `openImageInTerminal` decided GIF-vs-static purely from the URL's `.gif` file extension, so real gif links without one (Tenor share pages, extensionless CDN links) fell straight through to the OS browser instead of animating in the TUI's modal viewer.

## Changes
- `imgview.FetchAny` fetches the body once and sniffs the `GIF87a`/`GIF89a` magic header from the downloaded bytes instead of the URL, replacing the extension-based branch in `openImageInTerminal`.
- `routeURL` now also tries the inline viewer (`canProbeImageInline`) for URLs that fail the extension pre-check but otherwise qualify (graphics protocol detected, viewer not forced to browser, not an ephemeral SSH session), falling back to the browser via the existing fetch-error path when the content genuinely is not a decodable image.

## Testing
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- New tests: `imgview.FetchAny` GIF-from-extensionless-URL / static-image / undecodable-content cases; `routeURL` probe-path and no-protocol-fallback cases.
