### PR TITLE
Add duotone Bayer-dither effect for terminal image rendering

### DIFF
--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -95,6 +95,16 @@ type Config struct {
 	// supports Sixel but doesn't reliably answer the DA1 probe query.
 	GraphicsProtocol string `json:"graphicsProtocol,omitempty"`
 
+	// Dithering enables Bayer-ordered dithering and duotone recoloring for
+	// terminal-rendered images — a port of cyberspace.online webui's
+	// RasterImage shader effect. Only applies when ImageViewer != "browser".
+	Dithering bool `json:"dithering,omitempty"`
+
+	// DitherSharpness controls the dithering pixelation block size: "rough"
+	// (chunkiest), "medium" (default), "sharp", or "crisp" (no pixelation).
+	// Only meaningful when Dithering is on. See GetDitherSharpness.
+	DitherSharpness string `json:"ditherSharpness,omitempty"`
+
 	// ImageScale multiplies the fullscreen image modal's display size,
 	// relative to the image's own native (1:1 pixel) size — 1.0 shows it at
 	// native size (clamped to fit the terminal), not a fraction of the
@@ -131,6 +141,17 @@ func (c Config) GetImageScale() float64 {
 		s = MaxImageScale
 	}
 	return s
+}
+
+// GetDitherSharpness returns DitherSharpness, substituting the default
+// ("medium") for an empty or unrecognized value.
+func (c Config) GetDitherSharpness() string {
+	switch c.DitherSharpness {
+	case "rough", "sharp", "crisp":
+		return c.DitherSharpness
+	default:
+		return "medium"
+	}
 }
 
 // GetMaxThreadDepth returns MaxThreadDepth, substituting the default (3) when

--- a/internal/config/session_test.go
+++ b/internal/config/session_test.go
@@ -243,3 +243,26 @@ func TestGetImageScale(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDitherSharpness(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty defaults to medium", "", "medium"},
+		{"rough passes through", "rough", "rough"},
+		{"medium passes through", "medium", "medium"},
+		{"sharp passes through", "sharp", "sharp"},
+		{"crisp passes through", "crisp", "crisp"},
+		{"unrecognized defaults to medium", "garbage", "medium"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := config.Config{DitherSharpness: c.in}.GetDitherSharpness()
+			if got != c.want {
+				t.Errorf("GetDitherSharpness(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -478,6 +478,16 @@ type App struct {
 	// See canInlineImages for the fully-gated value broadcast to screens.
 	inlineImages bool
 
+	// dithering is the user's preference from config.Dithering. See
+	// ditheringEnabled for the gated value used when encoding images.
+	dithering bool
+
+	// ditherSharpness is the user's preference from config.GetDitherSharpness
+	// ("rough"/"medium"/"sharp"), controlling the dithering pixelation block
+	// size via imgview.PixelSizeForSharpness. Only meaningful when dithering
+	// is on.
+	ditherSharpness string
+
 	// imageScale multiplies the computed size of the fullscreen image modal.
 	// Starts from config.Config.GetImageScale() and is live-adjustable with
 	// +/- while the modal is open (session-only, not persisted). <= 0 is
@@ -609,6 +619,8 @@ func (a App) WithSavedSession(s config.Config) App {
 	a.imageViewer = s.ImageViewer
 	a.graphicsProtocolName = s.GraphicsProtocol
 	a.inlineImages = s.InlineImages
+	a.dithering = s.Dithering
+	a.ditherSharpness = s.GetDitherSharpness()
 	a.imageScale = s.GetImageScale()
 	a.layoutName = s.Layout
 	a.layout = layoutFromName(s.Layout)
@@ -835,7 +847,7 @@ func (a App) updateAll(msg tea.Msg) App {
 // Call this whenever loc, relaxed, or dimensions change outside of a
 // WindowSizeMsg (e.g. after login, timezone change, or density toggle).
 func (a *App) broadcastConfig() {
-	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
+	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), Dithering: a.dithering, DitherSharpness: a.ditherSharpness, OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
 	*a = a.updateAll(msg)
 }
 
@@ -1524,6 +1536,8 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		iv := msg.ImageViewer
 		gp := msg.GraphicsProtocol
 		ii := msg.InlineImages
+		dt := msg.Dithering
+		ds := msg.DitherSharpness
 		ln := msg.LayoutName
 		return a, func() tea.Msg {
 			if msg.RemoteChanged {
@@ -1538,9 +1552,11 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 				cfg.ImageViewer = iv
 				cfg.GraphicsProtocol = gp
 				cfg.InlineImages = ii
+				cfg.Dithering = dt
+				cfg.DitherSharpness = ds
 				cfg.Layout = ln
 			})
-			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, graphicsProtocol: gp, inlineImages: ii, layoutName: ln}
+			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, graphicsProtocol: gp, inlineImages: ii, dithering: dt, ditherSharpness: ds, layoutName: ln}
 		}, true
 
 	case settingsSavedMsg:
@@ -1549,22 +1565,33 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.maxThreadDepth = msg.maxThreadDepth
 		a.timezone = msg.timezone
 		a.imageViewer = msg.imageViewer
-		a.graphicsProtocolName = msg.graphicsProtocol
-		if proto, ok := imgview.ProtocolFromName(msg.graphicsProtocol); ok {
-			a.graphicsProtocol = proto
-		} else {
-			// "" (auto): re-resolve via env-var detection only. The Sixel DA1
-			// probe (imgview.ProbeSixel) needs raw terminal access before Bubble
-			// Tea takes over stdin, so it can't safely re-run mid-session — see
-			// its doc comment. Best-effort here; a full restart re-probes Sixel.
-			a.graphicsProtocol = imgview.DetectProtocol()
+		if msg.graphicsProtocol != a.graphicsProtocolName {
+			// Only re-resolve when the override actually changed — saving an
+			// unrelated setting (dithering, wander mode, etc.) must not touch
+			// this. "" (auto) can only be re-resolved via env-var detection
+			// here: the Sixel DA1 probe (imgview.ProbeSixel) needs raw
+			// terminal access before Bubble Tea takes over stdin, so it can't
+			// safely re-run mid-session — see its doc comment. Without this
+			// guard, any settings save on a DA1-probed Sixel terminal would
+			// silently downgrade a.graphicsProtocol to whatever env-var
+			// detection alone finds (often ProtocolNone), breaking inline
+			// images and the image viewer until a full restart re-probes
+			// Sixel.
+			if proto, ok := imgview.ProtocolFromName(msg.graphicsProtocol); ok {
+				a.graphicsProtocol = proto
+			} else {
+				a.graphicsProtocol = imgview.DetectProtocol()
+			}
 		}
+		a.graphicsProtocolName = msg.graphicsProtocol
 		a.inlineImages = msg.inlineImages
+		a.dithering = msg.dithering
+		a.ditherSharpness = msg.ditherSharpness
 		a.layoutName = msg.layoutName
 		a.layout = layoutFromName(msg.layoutName)
 		a.focus = focusMenu
 		a.loc = config.ParseTimezoneLabel(msg.timezone)
-		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.graphicsProtocol, msg.inlineImages, msg.layoutName)
+		a.settingsScreen = a.settingsScreen.SetSaved(msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.graphicsProtocol, msg.inlineImages, msg.dithering, msg.ditherSharpness, msg.layoutName)
 		a.broadcastConfig()
 		a.refreshViewports()
 		var notifyCmd tea.Cmd
@@ -2828,6 +2855,36 @@ func (a App) canInlineImages() bool {
 		a.imageViewer != "browser"
 }
 
+// ditheringEnabled reports whether images encoded for the terminal should
+// have the RasterImage-style duotone dither effect applied (see Dither):
+// the user's Dithering preference is on, gated by the same imageViewer
+// check as graphicsProtocol/inlineImages — dithering is meaningless when
+// images open in the OS browser instead.
+func (a App) ditheringEnabled() bool {
+	return a.dithering && a.imageViewer != "browser"
+}
+
+// ditherOptions builds the imgview.DitherOptions to pass to Encode* when
+// ditheringEnabled is true, resolving the current theme's colors. Returns
+// nil when dithering is off.
+func (a App) ditherOptions() *imgview.DitherOptions {
+	if !a.ditheringEnabled() {
+		return nil
+	}
+	fg, _ := imgview.ParseHexColor(theme.CurrentPalette().Foreground)
+	bg, ok := imgview.ParseHexColor(theme.CurrentPalette().Background)
+	if !ok {
+		// Palette.Background is reserved/usually empty (see theme.go's Palette
+		// doc comment) — fall back to the theme's actual rendered background.
+		bg, _ = imgview.ParseHexColor(string(theme.ColorBackground))
+	}
+	return &imgview.DitherOptions{
+		PixelSize: imgview.PixelSizeForSharpness(a.ditherSharpness),
+		FgColor:   fg,
+		BgColor:   bg,
+	}
+}
+
 // activeInlineImageSlots returns the active screen's currently visible
 // inline image slots, or nil for screens that don't support inline images.
 // Used by TabsLayout.InlineImageSlots; MillerLayout has its own equivalent
@@ -2974,13 +3031,32 @@ func syncInlineImageErasures(slots []screens.InlineImageSlot, rowOrigin, colOrig
 }
 
 // inlineImageCacheKey identifies one encoded rendering of a slot's image —
-// slot key, URL, column budget, and protocol. Keying by slot (not just URL)
-// matters for Kitty, whose encoded bytes embed a placement id specific to
-// one on-screen instance (see imgview.EncodeKitty) — two slots showing the
-// same URL must never share an encode. Also matches how a resize (which
-// changes MaxCols) or a protocol change naturally invalidates old entries.
-func inlineImageCacheKey(slot screens.InlineImageSlot, proto imgview.GraphicsProtocol) string {
-	return fmt.Sprintf("%s|%s|%d|%d", slot.Key, slot.URL, slot.MaxCols, proto)
+// slot key, URL, column budget, protocol, and dithering state. Keying by
+// slot (not just URL) matters for Kitty, whose encoded bytes embed a
+// placement id specific to one on-screen instance (see imgview.EncodeKitty)
+// — two slots showing the same URL must never share an encode. Also matches
+// how a resize (which changes MaxCols) or a protocol change naturally
+// invalidates old entries — and, via ditherKeyFragment, how toggling
+// dithering, changing sharpness, or switching themes must too: without the
+// dither component, an already-cached encode from before such a change
+// would keep being served as-is (see syncInlineImages/fetchInlineImageCmd),
+// making the change appear to require a restart to take effect.
+func inlineImageCacheKey(slot screens.InlineImageSlot, proto imgview.GraphicsProtocol, dither *imgview.DitherOptions) string {
+	return fmt.Sprintf("%s|%s|%d|%d|%s", slot.Key, slot.URL, slot.MaxCols, proto, ditherKeyFragment(dither))
+}
+
+// ditherKeyFragment returns a compact, deterministic string identifying
+// dither's effect on the encoded output, for use as an inlineImageCacheKey
+// component — "-" when dithering is off, otherwise a value that changes
+// whenever the resulting pixels would: sharpness (PixelSize) or the active
+// theme's colors (FgColor/BgColor).
+func ditherKeyFragment(dither *imgview.DitherOptions) string {
+	if dither == nil {
+		return "-"
+	}
+	return fmt.Sprintf("d%d,%02x%02x%02x,%02x%02x%02x", dither.PixelSize,
+		dither.FgColor.R, dither.FgColor.G, dither.FgColor.B,
+		dither.BgColor.R, dither.BgColor.G, dither.BgColor.B)
 }
 
 // kittyModalPlacementID is a fixed, reserved Kitty placement/image id used
@@ -3210,8 +3286,9 @@ func (a App) syncInlineImages() (App, tea.Cmd) {
 	if a.inlineImageFetching == nil {
 		a.inlineImageFetching = make(map[string]bool)
 	}
+	ditherOpts := a.ditherOptions()
 	for _, slot := range slots {
-		key := inlineImageCacheKey(slot, a.graphicsProtocol)
+		key := inlineImageCacheKey(slot, a.graphicsProtocol, ditherOpts)
 		if _, cached := a.inlineImageCache[key]; cached {
 			a.touchInlineImageCache(key)
 			continue
@@ -3227,7 +3304,7 @@ func (a App) syncInlineImages() (App, tea.Cmd) {
 		if isKitty {
 			placementID = placementIDs[slot.Key]
 		}
-		cmds = append(cmds, a.fetchInlineImageCmd(slot, key, placementID))
+		cmds = append(cmds, a.fetchInlineImageCmd(slot, key, placementID, ditherOpts))
 	}
 	if len(cmds) == 0 {
 		return a, nil
@@ -3252,11 +3329,14 @@ type inlineImageFetchedMsg struct {
 
 // fetchInlineImageCmd fetches and encodes slot's image for the currently
 // detected protocol. placementID is only used for Kitty (see
-// imgview.EncodeKitty); callers pass 0 for Sixel/iTerm2. Unlike the
-// fullscreen modal, there's no user-visible loading state to manage: a miss
-// this frame just means the reserved blank band stays blank until the
-// result lands.
-func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string, placementID int) tea.Cmd {
+// imgview.EncodeKitty); callers pass 0 for Sixel/iTerm2. ditherOpts is
+// passed in (rather than recomputed via a.ditherOptions()) so it always
+// matches exactly what the caller used to compute key via
+// inlineImageCacheKey — a mismatch there would cache the encode under one
+// dither state while the bytes reflect another. Unlike the fullscreen
+// modal, there's no user-visible loading state to manage: a miss this frame
+// just means the reserved blank band stays blank until the result lands.
+func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string, placementID int, ditherOpts *imgview.DitherOptions) tea.Cmd {
 	proto := a.graphicsProtocol
 	maxCols, maxRows := slot.MaxCols, slot.MaxRows
 	url := slot.URL
@@ -3273,11 +3353,11 @@ func (a App) fetchInlineImageCmd(slot screens.InlineImageSlot, key string, place
 		cellW, cellH, _ := imgview.TerminalCellPixelSize(int(os.Stdout.Fd()))
 		switch proto {
 		case imgview.ProtocolITerm2:
-			encoded, _, rows, err = imgview.EncodeITerm2(img, maxCols, maxRows, cellW, cellH, false)
+			encoded, _, rows, err = imgview.EncodeITerm2(img, maxCols, maxRows, cellW, cellH, false, ditherOpts)
 		case imgview.ProtocolSixel:
-			encoded, _, rows, err = imgview.EncodeSixel(img, maxCols, maxRows, cellW, cellH, false)
+			encoded, _, rows, err = imgview.EncodeSixel(img, maxCols, maxRows, cellW, cellH, false, ditherOpts)
 		case imgview.ProtocolKitty:
-			encoded, _, rows, err = imgview.EncodeKitty(img, maxCols, maxRows, cellW, cellH, placementID, false)
+			encoded, _, rows, err = imgview.EncodeKitty(img, maxCols, maxRows, cellW, cellH, placementID, false, ditherOpts)
 		default:
 			err = fmt.Errorf("inline images: unsupported protocol %v", proto)
 		}
@@ -3548,6 +3628,7 @@ func (a App) adjustImageScale(delta float64) (App, tea.Cmd) {
 // edges, not just merely within them.
 func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 	proto := a.graphicsProtocol
+	ditherOpts := a.ditherOptions()
 	scale := a.imageScale
 	if scale <= 0 {
 		scale = 1.0
@@ -3592,19 +3673,19 @@ func (a App) openImageInTerminal(rawURL string) (App, tea.Cmd) {
 			switch proto {
 			case imgview.ProtocolKitty:
 				var err error
-				encodedFrames[i], cols, rows, err = imgview.EncodeKitty(img, displayCols, displayRows, cellW, cellH, kittyModalPlacementID, true)
+				encodedFrames[i], cols, rows, err = imgview.EncodeKitty(img, displayCols, displayRows, cellW, cellH, kittyModalPlacementID, true, ditherOpts)
 				if err != nil {
 					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
 				}
 			case imgview.ProtocolITerm2:
 				var err error
-				encodedFrames[i], cols, rows, err = imgview.EncodeITerm2(img, displayCols, displayRows, cellW, cellH, true)
+				encodedFrames[i], cols, rows, err = imgview.EncodeITerm2(img, displayCols, displayRows, cellW, cellH, true, ditherOpts)
 				if err != nil {
 					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
 				}
 			case imgview.ProtocolSixel:
 				var err error
-				encodedFrames[i], cols, rows, err = imgview.EncodeSixel(img, displayCols, displayRows, cellW, cellH, true)
+				encodedFrames[i], cols, rows, err = imgview.EncodeSixel(img, displayCols, displayRows, cellW, cellH, true, ditherOpts)
 				if err != nil {
 					return imageFetchedMsg{rawURL: rawURL, gen: gen, err: err}
 				}
@@ -4095,6 +4176,8 @@ type settingsSavedMsg struct {
 	imageViewer      string
 	graphicsProtocol string
 	inlineImages     bool
+	dithering        bool
+	ditherSharpness  string
 	layoutName       string
 }
 type wanderTickMsg struct{ gen int }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"image/color"
 	"image/png"
 	"net/http"
 	"net/http/httptest"
@@ -4476,20 +4477,59 @@ func TestSyncInlineImageErasures(t *testing.T) {
 // encodes rather than reuse a wrongly-sized/wrongly-encoded one.
 func TestInlineImageCacheKey_VariesByColsAndProtocol(t *testing.T) {
 	slot := screens.InlineImageSlot{URL: "https://example.com/a.png", MaxCols: 76}
-	key1 := inlineImageCacheKey(slot, imgview.ProtocolSixel)
-	key2 := inlineImageCacheKey(slot, imgview.ProtocolSixel)
+	key1 := inlineImageCacheKey(slot, imgview.ProtocolSixel, nil)
+	key2 := inlineImageCacheKey(slot, imgview.ProtocolSixel, nil)
 	if key1 != key2 {
 		t.Error("expected the same slot+protocol to produce the same key")
 	}
 
 	wider := slot
 	wider.MaxCols = 100
-	if inlineImageCacheKey(wider, imgview.ProtocolSixel) == key1 {
+	if inlineImageCacheKey(wider, imgview.ProtocolSixel, nil) == key1 {
 		t.Error("expected a different MaxCols to produce a different key")
 	}
 
-	if inlineImageCacheKey(slot, imgview.ProtocolITerm2) == key1 {
+	if inlineImageCacheKey(slot, imgview.ProtocolITerm2, nil) == key1 {
 		t.Error("expected a different protocol to produce a different key")
+	}
+}
+
+// TestInlineImageCacheKey_VariesByDitherState is a regression test: toggling
+// dithering, changing sharpness, or switching themes (which changes the
+// duotone colors) must invalidate an already-cached encode — otherwise a
+// cached image keeps showing whatever dither state produced it until the
+// cache entry is evicted or the app restarts (see inlineImageCacheKey's doc
+// comment).
+func TestInlineImageCacheKey_VariesByDitherState(t *testing.T) {
+	slot := screens.InlineImageSlot{URL: "https://example.com/a.png", MaxCols: 76}
+	proto := imgview.ProtocolKitty
+
+	noDither := inlineImageCacheKey(slot, proto, nil)
+	dithered := inlineImageCacheKey(slot, proto, &imgview.DitherOptions{
+		PixelSize: 2,
+		FgColor:   color.RGBA{R: 0, G: 255, B: 65, A: 255},
+		BgColor:   color.RGBA{R: 13, G: 13, B: 13, A: 255},
+	})
+	if noDither == dithered {
+		t.Error("expected turning dithering on to produce a different key")
+	}
+
+	sharp := inlineImageCacheKey(slot, proto, &imgview.DitherOptions{
+		PixelSize: 1, // "crisp" instead of "medium"
+		FgColor:   color.RGBA{R: 0, G: 255, B: 65, A: 255},
+		BgColor:   color.RGBA{R: 13, G: 13, B: 13, A: 255},
+	})
+	if sharp == dithered {
+		t.Error("expected a different sharpness (PixelSize) to produce a different key")
+	}
+
+	otherTheme := inlineImageCacheKey(slot, proto, &imgview.DitherOptions{
+		PixelSize: 2,
+		FgColor:   color.RGBA{R: 255, G: 176, B: 0, A: 255}, // amber, e.g. vt320 theme
+		BgColor:   color.RGBA{R: 13, G: 13, B: 13, A: 255},
+	})
+	if otherTheme == dithered {
+		t.Error("expected a different theme's FgColor to produce a different key")
 	}
 }
 
@@ -4579,7 +4619,7 @@ func feedAppWithOneImage(t *testing.T) (a App, key string) {
 	if len(slots) != 1 {
 		t.Fatalf("setup: expected 1 visible slot, got %d", len(slots))
 	}
-	return a, inlineImageCacheKey(slots[0], a.graphicsProtocol)
+	return a, inlineImageCacheKey(slots[0], a.graphicsProtocol, nil)
 }
 
 // TestInlineImageFailureCooldown_SkipsRefetchUntilCooldownLapses is a
@@ -4612,6 +4652,40 @@ func TestInlineImageFailureCooldown_SkipsRefetchUntilCooldownLapses(t *testing.T
 	a, _ = a.syncInlineImages()
 	if !a.inlineImageFetching[key] {
 		t.Error("expected syncInlineImages to retry once the cooldown has lapsed")
+	}
+}
+
+// TestSyncInlineImages_DitherToggleInvalidatesCache is a regression test:
+// before inlineImageCacheKey included dither state, an image already cached
+// (fetched and encoded before dithering was turned on) kept being served
+// as-is by syncInlineImages/injectInlineImages, since its cache key never
+// changed — dithering appeared to require a restart to take visible effect.
+func TestSyncInlineImages_DitherToggleInvalidatesCache(t *testing.T) {
+	a, key := feedAppWithOneImage(t)
+
+	a, _, _ = a.handleInlineImageFetched(inlineImageFetchedMsg{key: key, encoded: "\x1b_Gfake\x1b\\"})
+	if _, cached := a.inlineImageCache[key]; !cached {
+		t.Fatal("setup: expected the encode to be cached under the no-dither key")
+	}
+
+	a, cmd := a.syncInlineImages()
+	if cmd != nil {
+		t.Fatal("setup: expected a cache hit (no fetch) before enabling dithering")
+	}
+
+	a.dithering = true
+	a.ditherSharpness = "sharp"
+
+	a, cmd = a.syncInlineImages()
+	if cmd == nil {
+		t.Fatal("expected enabling dithering to invalidate the cached key and schedule a fresh fetch")
+	}
+	newKey := inlineImageCacheKey(a.feed.VisibleInlineImages()[0], a.graphicsProtocol, a.ditherOptions())
+	if newKey == key {
+		t.Fatal("setup: expected the dither-enabled key to differ from the no-dither key")
+	}
+	if !a.inlineImageFetching[newKey] {
+		t.Errorf("expected a fetch scheduled under the new dither-enabled key %q, fetching=%v", newKey, a.inlineImageFetching)
 	}
 }
 
@@ -5071,5 +5145,70 @@ func TestHandleGuilds_UserGuildsLoaded_GuardsOnUsernameMatch(t *testing.T) {
 	}
 	if len(a3.profile.Apprenticeships()) != 1 {
 		t.Errorf("expected apprenticeships applied for matching username, got %+v", a3.profile.Apprenticeships())
+	}
+}
+
+// TestHandleSettings_SavingUnrelatedSettingPreservesProbedProtocol is a
+// regression test: a.graphicsProtocol can be ProtocolSixel here only because
+// the startup DA1 probe (imgview.ProbeSixel) found it — that probe can't
+// safely re-run mid-session (it needs raw terminal access before Bubble Tea
+// takes over stdin). Saving any setting whose graphics-protocol override
+// (graphicsProtocolName) hasn't changed must leave a.graphicsProtocol alone;
+// re-resolving it via imgview.DetectProtocol()'s env-var-only detection on
+// every save would silently downgrade a DA1-probed Sixel session to
+// ProtocolNone, breaking inline images and the image viewer until a full
+// restart re-probes Sixel.
+func TestHandleSettings_SavingUnrelatedSettingPreservesProbedProtocol(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolSixel
+	a.graphicsProtocolName = "" // auto — the only way DetectProtocol() ever gets consulted
+
+	_, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
+		GraphicsProtocol: "", // unchanged
+		Dithering:        true,
+		ImageViewer:      "terminal",
+	})
+	if !ok || cmd == nil {
+		t.Fatal("expected handleSettings to handle SaveSettingsMsg with a non-nil cmd")
+	}
+	msg := cmd()
+	saved, ok := msg.(settingsSavedMsg)
+	if !ok {
+		t.Fatalf("expected settingsSavedMsg, got %T", msg)
+	}
+
+	a2, _, ok := a.handleSettings(saved)
+	if !ok {
+		t.Fatal("expected handleSettings to handle settingsSavedMsg")
+	}
+	if a2.graphicsProtocol != imgview.ProtocolSixel {
+		t.Errorf("graphicsProtocol = %v after saving an unrelated setting, want unchanged ProtocolSixel", a2.graphicsProtocol)
+	}
+}
+
+// TestHandleSettings_ChangingGraphicsProtocolOverrideReResolves confirms the
+// override still takes effect when the user actually changes it — the fix
+// for the regression above only skips re-resolution when the override is
+// unchanged.
+func TestHandleSettings_ChangingGraphicsProtocolOverrideReResolves(t *testing.T) {
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolSixel
+	a.graphicsProtocolName = ""
+
+	_, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
+		GraphicsProtocol: "kitty", // changed
+		ImageViewer:      "terminal",
+	})
+	if !ok || cmd == nil {
+		t.Fatal("expected handleSettings to handle SaveSettingsMsg with a non-nil cmd")
+	}
+	saved := cmd().(settingsSavedMsg)
+
+	a2, _, ok := a.handleSettings(saved)
+	if !ok {
+		t.Fatal("expected handleSettings to handle settingsSavedMsg")
+	}
+	if a2.graphicsProtocol != imgview.ProtocolKitty {
+		t.Errorf("graphicsProtocol = %v after changing the override to kitty, want ProtocolKitty", a2.graphicsProtocol)
 	}
 }

--- a/internal/ui/imgview/dither.go
+++ b/internal/ui/imgview/dither.go
@@ -1,0 +1,134 @@
+package imgview
+
+import (
+	"image"
+	"image/color"
+	"math"
+	"strconv"
+)
+
+// DitherOptions configures Dither. PixelSize is the pixelation block size in
+// source pixels (see PixelSizeForSharpness). FgColor/BgColor are the two
+// colors the dithered result is recolored through.
+type DitherOptions struct {
+	PixelSize int
+	FgColor   color.RGBA
+	BgColor   color.RGBA
+}
+
+// ditherAmount blends a flat 0.5 threshold (0.0) against the full Bayer
+// ordered-dither pattern (1.0). Fixed rather than user-configurable —
+// PixelSize alone differentiates the exposed sharpness levels.
+const ditherAmount = 0.75
+
+// ditherLevels is 2^bitDepth with bitDepth fixed at 2, matching the source
+// shader's default. Not exposed as a setting.
+const ditherLevels = 4.0
+
+// bayer8x8 is the classic 8x8 ordered-dither threshold matrix, normalized to
+// 0..1, row-major (index = y*8+x). Ported from cyberspace.online webui's
+// RasterImage shader.
+var bayer8x8 = [64]float64{
+	0 / 64.0, 32 / 64.0, 8 / 64.0, 40 / 64.0, 2 / 64.0, 34 / 64.0, 10 / 64.0, 42 / 64.0,
+	48 / 64.0, 16 / 64.0, 56 / 64.0, 24 / 64.0, 50 / 64.0, 18 / 64.0, 58 / 64.0, 26 / 64.0,
+	12 / 64.0, 44 / 64.0, 4 / 64.0, 36 / 64.0, 14 / 64.0, 46 / 64.0, 6 / 64.0, 38 / 64.0,
+	60 / 64.0, 28 / 64.0, 52 / 64.0, 20 / 64.0, 62 / 64.0, 30 / 64.0, 54 / 64.0, 22 / 64.0,
+	3 / 64.0, 35 / 64.0, 11 / 64.0, 43 / 64.0, 1 / 64.0, 33 / 64.0, 9 / 64.0, 41 / 64.0,
+	51 / 64.0, 19 / 64.0, 59 / 64.0, 27 / 64.0, 49 / 64.0, 17 / 64.0, 57 / 64.0, 25 / 64.0,
+	15 / 64.0, 47 / 64.0, 7 / 64.0, 39 / 64.0, 13 / 64.0, 45 / 64.0, 5 / 64.0, 37 / 64.0,
+	63 / 64.0, 31 / 64.0, 55 / 64.0, 23 / 64.0, 61 / 64.0, 29 / 64.0, 53 / 64.0, 21 / 64.0,
+}
+
+// Dither applies cyberspace.online webui's RasterImage duotone-dithering
+// effect: block-pixelate, convert to grayscale, threshold against an 8x8
+// Bayer ordered-dither pattern blended with posterization, then recolor the
+// result through opts.FgColor/opts.BgColor. Always returns a new image; img
+// is never mutated.
+func Dither(img image.Image, opts DitherOptions) *image.RGBA {
+	bounds := img.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	out := image.NewRGBA(image.Rect(0, 0, w, h))
+
+	pixelSize := opts.PixelSize
+	if pixelSize < 1 {
+		pixelSize = 1
+	}
+
+	fgR, fgG, fgB := float64(opts.FgColor.R), float64(opts.FgColor.G), float64(opts.FgColor.B)
+	bgR, bgG, bgB := float64(opts.BgColor.R), float64(opts.BgColor.G), float64(opts.BgColor.B)
+
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			blockX := (x / pixelSize) * pixelSize
+			blockY := (y / pixelSize) * pixelSize
+			// ponytail: grayscale is computed from RGBA()'s alpha-premultiplied
+			// values rather than straight RGB, so partially transparent source
+			// pixels read slightly darker than the shader (which reads straight
+			// texture RGB). Only visible on non-opaque source pixels; upgrade to
+			// per-channel unpremultiply if that ever matters for this feature.
+			r, g, b, _ := img.At(bounds.Min.X+blockX, bounds.Min.Y+blockY).RGBA()
+			gray := (0.299*float64(r) + 0.587*float64(g) + 0.114*float64(b)) / 65535.0
+
+			bayerValue := bayer8x8[(y%8)*8+(x%8)]
+			noise := pseudoNoise(x, y) * 0.1
+			bayerValue = bayerValue*0.7 + noise*0.3
+			threshold := 0.5*(1-ditherAmount) + bayerValue*ditherAmount
+
+			dithered := 0.0
+			if gray >= threshold {
+				dithered = 1.0
+			}
+			quantized := math.Floor(gray*ditherLevels) / ditherLevels
+			final := quantized*(1-ditherAmount) + dithered*ditherAmount
+
+			out.SetRGBA(x, y, color.RGBA{
+				R: uint8(math.Round(bgR + (fgR-bgR)*final)),
+				G: uint8(math.Round(bgG + (fgG-bgG)*final)),
+				B: uint8(math.Round(bgB + (fgB-bgB)*final)),
+				A: 255,
+			})
+		}
+	}
+	return out
+}
+
+// pseudoNoise reproduces the source shader's cheap GLSL hash-based random(),
+// called as random(vec2(x,y)*0.01) with dot product weights (12.9898,78.233)
+// and scale 43758.5453, taking the fractional part of the result.
+func pseudoNoise(x, y int) float64 {
+	v := math.Sin(float64(x)*0.01*12.9898+float64(y)*0.01*78.233) * 43758.5453
+	return v - math.Floor(v)
+}
+
+// PixelSizeForSharpness maps a dithering sharpness setting to a pixelation
+// block size in source pixels. Unrecognized or empty values fail closed to
+// "medium", mirroring ProtocolFromName's convention.
+func PixelSizeForSharpness(level string) int {
+	switch level {
+	case "rough":
+		return 4
+	case "sharp":
+		return 2
+	case "crisp":
+		return 1
+	default:
+		return 3
+	}
+}
+
+// ParseHexColor parses a "#RRGGBB" hex color string.
+func ParseHexColor(s string) (color.RGBA, bool) {
+	if len(s) != 7 || s[0] != '#' {
+		return color.RGBA{}, false
+	}
+	v, err := strconv.ParseUint(s[1:], 16, 32)
+	if err != nil {
+		return color.RGBA{}, false
+	}
+	return color.RGBA{
+		R: uint8(v >> 16),
+		G: uint8(v >> 8),
+		B: uint8(v),
+		A: 255,
+	}, true
+}

--- a/internal/ui/imgview/dither_test.go
+++ b/internal/ui/imgview/dither_test.go
@@ -1,0 +1,159 @@
+package imgview_test
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/ragnar/cyber-tui/internal/ui/imgview"
+)
+
+var (
+	testFg = color.RGBA{R: 0, G: 255, B: 65, A: 255}
+	testBg = color.RGBA{R: 13, G: 13, B: 13, A: 255}
+)
+
+// TestDither_OutputIsBlendBetweenFgAndBg checks the core duotone invariant:
+// every output channel lies between the corresponding BgColor and FgColor
+// channel values (inclusive) — the recolor step is always a mix(bg, fg, t)
+// for some t in [0,1], never a color outside that range.
+func TestDither_OutputIsBlendBetweenFgAndBg(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 16, 16))
+	for y := 0; y < 16; y++ {
+		for x := 0; x < 16; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x * 16), G: uint8(y * 16), B: 128, A: 255})
+		}
+	}
+	out := imgview.Dither(img, imgview.DitherOptions{PixelSize: 1, FgColor: testFg, BgColor: testBg})
+	inRange := func(v, a, b uint8) bool {
+		if a > b {
+			a, b = b, a
+		}
+		return v >= a && v <= b
+	}
+	for y := 0; y < 16; y++ {
+		for x := 0; x < 16; x++ {
+			c := out.RGBAAt(x, y)
+			if !inRange(c.R, testFg.R, testBg.R) || !inRange(c.G, testFg.G, testBg.G) || !inRange(c.B, testFg.B, testBg.B) || c.A != 255 {
+				t.Fatalf("pixel (%d,%d) = %+v, want a blend between FgColor %+v and BgColor %+v with A=255", x, y, c, testFg, testBg)
+			}
+		}
+	}
+}
+
+// TestDither_PixelationSamplesTopLeftTexelOnly checks that pixelation picks
+// the top-left texel of each PixelSize block and ignores the rest of the
+// block's content, rather than averaging it.
+func TestDither_PixelationSamplesTopLeftTexelOnly(t *testing.T) {
+	const size = 16
+	const blockSize = 4
+	uniform := image.NewRGBA(image.Rect(0, 0, size, size))
+	noisy := image.NewRGBA(image.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			blockX := (x / blockSize) * blockSize
+			blockY := (y / blockSize) * blockSize
+			v := uint8(((blockX/blockSize)*37+(blockY/blockSize)*59)%200 + 20)
+			topLeft := color.RGBA{R: v, G: v, B: v, A: 255}
+			uniform.Set(x, y, topLeft)
+			if x == blockX && y == blockY {
+				noisy.Set(x, y, topLeft)
+			} else {
+				// Different value elsewhere in the block — pixelation must ignore it.
+				noisy.Set(x, y, color.RGBA{R: 255 - v, G: 255 - v, B: 255 - v, A: 255})
+			}
+		}
+	}
+	opts := imgview.DitherOptions{PixelSize: blockSize, FgColor: testFg, BgColor: testBg}
+	outUniform := imgview.Dither(uniform, opts)
+	outNoisy := imgview.Dither(noisy, opts)
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			if a, b := outUniform.RGBAAt(x, y), outNoisy.RGBAAt(x, y); a != b {
+				t.Fatalf("pixel (%d,%d): top-left-only=%+v, full-block-noisy=%+v, want equal", x, y, a, b)
+			}
+		}
+	}
+}
+
+// TestDither_Deterministic guards against accidentally introducing
+// time-/rand-seeded noise: the same input must always produce the same
+// output.
+func TestDither_Deterministic(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 12, 12))
+	for y := 0; y < 12; y++ {
+		for x := 0; x < 12; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x * 20), G: uint8(y * 20), B: 100, A: 255})
+		}
+	}
+	opts := imgview.DitherOptions{PixelSize: 2, FgColor: testFg, BgColor: testBg}
+	a := imgview.Dither(img, opts)
+	b := imgview.Dither(img, opts)
+	for y := 0; y < 12; y++ {
+		for x := 0; x < 12; x++ {
+			if av, bv := a.RGBAAt(x, y), b.RGBAAt(x, y); av != bv {
+				t.Fatalf("pixel (%d,%d): run1=%+v run2=%+v, want identical (Dither must be deterministic)", x, y, av, bv)
+			}
+		}
+	}
+}
+
+// TestDither_NonZeroOriginBoundsHandledConsistently checks that a source
+// image whose bounds don't start at (0,0) — e.g. a sub-image — produces the
+// same dither pattern as an equivalent (0,0)-origin image, since Dither
+// indexes the pixelation/Bayer pattern by output-relative coordinates.
+func TestDither_NonZeroOriginBoundsHandledConsistently(t *testing.T) {
+	base := image.NewRGBA(image.Rect(0, 0, 16, 16))
+	shifted := image.NewRGBA(image.Rect(5, 7, 21, 23))
+	for y := 0; y < 16; y++ {
+		for x := 0; x < 16; x++ {
+			c := color.RGBA{R: 160, G: 160, B: 160, A: 255}
+			base.Set(x, y, c)
+			shifted.Set(5+x, 7+y, c)
+		}
+	}
+	opts := imgview.DitherOptions{PixelSize: 1, FgColor: testFg, BgColor: testBg}
+	outBase := imgview.Dither(base, opts)
+	outShifted := imgview.Dither(shifted, opts)
+	for y := 0; y < 16; y++ {
+		for x := 0; x < 16; x++ {
+			if a, b := outBase.RGBAAt(x, y), outShifted.RGBAAt(x, y); a != b {
+				t.Fatalf("pixel (%d,%d): base=%+v shifted=%+v, want equal", x, y, a, b)
+			}
+		}
+	}
+}
+
+func TestPixelSizeForSharpness(t *testing.T) {
+	cases := map[string]int{
+		"rough":   4,
+		"medium":  3,
+		"sharp":   2,
+		"crisp":   1,
+		"":        3,
+		"garbage": 3,
+	}
+	for level, want := range cases {
+		if got := imgview.PixelSizeForSharpness(level); got != want {
+			t.Errorf("PixelSizeForSharpness(%q) = %d, want %d", level, got, want)
+		}
+	}
+}
+
+func TestParseHexColor(t *testing.T) {
+	c, ok := imgview.ParseHexColor("#00FF41")
+	if !ok {
+		t.Fatal("ParseHexColor(#00FF41): ok = false, want true")
+	}
+	want := color.RGBA{R: 0, G: 255, B: 65, A: 255}
+	if c != want {
+		t.Errorf("ParseHexColor(#00FF41) = %+v, want %+v", c, want)
+	}
+
+	invalid := []string{"", "#fff", "00FF41", "#00FF4", "#GGFF41", "#00FF411"}
+	for _, s := range invalid {
+		if _, ok := imgview.ParseHexColor(s); ok {
+			t.Errorf("ParseHexColor(%q): ok = true, want false", s)
+		}
+	}
+}

--- a/internal/ui/imgview/encode_test.go
+++ b/internal/ui/imgview/encode_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"image"
 	"image/color"
+	"image/png"
 	"math/rand"
 	"strings"
 	"testing"
@@ -15,7 +16,7 @@ import (
 func TestEncodeKitty_ContainsAPC(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{R: 255, A: 255})
-	seq, cols, rows, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false)
+	seq, cols, rows, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -36,7 +37,7 @@ func TestEncodeKitty_ContainsAPC(t *testing.T) {
 func TestEncodeKitty_CapsRows(t *testing.T) {
 	// Tall portrait image: without a row cap this would need 50 rows at 10 cols.
 	img := image.NewRGBA(image.Rect(0, 0, 100, 1000))
-	_, cols, rows, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false)
+	_, cols, rows, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -55,7 +56,7 @@ func TestEncodeKitty_PrependsDeleteAllPlacements(t *testing.T) {
 	// close-cleanup frame never reached the terminal (e.g. dropped behind a
 	// slow flush of a large prior image).
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false)
+	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -65,7 +66,7 @@ func TestEncodeKitty_PrependsDeleteAllPlacements(t *testing.T) {
 
 	// Back-to-back calls (as would happen opening several images in a row)
 	// must each still lead with the delete-all command.
-	seq2, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false)
+	seq2, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestEncodeKitty_PrependsDeleteAllPlacements(t *testing.T) {
 // target it precisely later.
 func TestEncodeKitty_NamedPlacement_NeverBluntDeletes(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 7, false)
+	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 7, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -104,7 +105,7 @@ func TestEncodeKitty_NamedPlacement_NeverBluntDeletes(t *testing.T) {
 func TestEncodeKitty_SuppressesTerminalResponse(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 
-	seqAnon, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false)
+	seqAnon, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -112,7 +113,7 @@ func TestEncodeKitty_SuppressesTerminalResponse(t *testing.T) {
 		t.Errorf("anonymous-mode EncodeKitty must set q=2, got %q", seqAnon)
 	}
 
-	seqNamed, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 7, false)
+	seqNamed, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 7, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -130,7 +131,7 @@ func TestEncodeKitty_SuppressesTerminalResponse(t *testing.T) {
 func TestEncodeKitty_UsesPNGFormat(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
 	img.Set(1, 1, color.RGBA{B: 255, A: 255})
-	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false)
+	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -151,6 +152,62 @@ func TestEncodeKitty_UsesPNGFormat(t *testing.T) {
 	if len(raw) < 8 || !bytes.HasPrefix(raw, []byte("\x89PNG\r\n\x1a\n")) {
 		t.Errorf("expected the payload to be a PNG (magic bytes), got %d bytes starting %x", len(raw), raw[:min(len(raw), 8)])
 	}
+}
+
+// TestEncodeKitty_AppliesDither confirms a non-nil DitherOptions actually
+// reaches the encoded image: the decoded PNG payload differs from the
+// undithered encoding, and every pixel is limited to the two supplied
+// colors (see imgview.Dither's own tests for the blend invariant details).
+func TestEncodeKitty_AppliesDither(t *testing.T) {
+	img := noisyImage(8, 8)
+	plain, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false, nil)
+	if err != nil {
+		t.Fatalf("EncodeKitty (no dither): %v", err)
+	}
+	fg := color.RGBA{R: 0, G: 255, B: 65, A: 255}
+	bg := color.RGBA{R: 13, G: 13, B: 13, A: 255}
+	dithered, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 0, false, &imgview.DitherOptions{PixelSize: 1, FgColor: fg, BgColor: bg})
+	if err != nil {
+		t.Fatalf("EncodeKitty (dithered): %v", err)
+	}
+	if dithered == plain {
+		t.Fatal("EncodeKitty: dithered output identical to undithered output")
+	}
+	decoded := decodeKittyPNGPayload(t, dithered)
+	bounds := decoded.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, a := decoded.At(x, y).RGBA()
+			c := color.RGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(b >> 8), A: uint8(a >> 8)}
+			if !channelBetween(c.R, fg.R, bg.R) || !channelBetween(c.G, fg.G, bg.G) || !channelBetween(c.B, fg.B, bg.B) {
+				t.Fatalf("pixel (%d,%d) = %+v, want a blend between fg %+v and bg %+v", x, y, c, fg, bg)
+			}
+		}
+	}
+}
+
+func channelBetween(v, a, b uint8) bool {
+	if a > b {
+		a, b = b, a
+	}
+	return v >= a && v <= b
+}
+
+// decodeKittyPNGPayload extracts and decodes the PNG payload from a Kitty
+// APC escape sequence produced by EncodeKitty.
+func decodeKittyPNGPayload(t *testing.T, seq string) image.Image {
+	t.Helper()
+	semi := strings.LastIndex(seq, ";")
+	payload := strings.TrimSuffix(seq[semi+1:], "\x1b\\")
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		t.Fatalf("payload did not decode as base64: %v", err)
+	}
+	img, err := png.Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("payload did not decode as PNG: %v", err)
+	}
+	return img
 }
 
 // noisyImage returns a deterministic pseudo-random RGBA image — PNG
@@ -179,7 +236,7 @@ func noisyImage(w, h int) *image.RGBA {
 // and continuation chunks must carry no control keys besides m/q.
 func TestEncodeKitty_ChunksLargePayloads(t *testing.T) {
 	img := noisyImage(200, 200)
-	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 7, false)
+	seq, _, _, err := imgview.EncodeKitty(img, 40, 20, 0, 0, 7, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty: %v", err)
 	}
@@ -220,11 +277,11 @@ func TestEncodeKitty_ChunksLargePayloads(t *testing.T) {
 // for a target box close to its own size.
 func TestEncodeITerm2_DownscalesLargeSourceToTargetBox(t *testing.T) {
 	img := noisyImage(400, 400)
-	small, _, _, err := imgview.EncodeITerm2(img, 4, 2, 10, 20, false)
+	small, _, _, err := imgview.EncodeITerm2(img, 4, 2, 10, 20, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeITerm2 (small box): %v", err)
 	}
-	large, _, _, err := imgview.EncodeITerm2(img, 200, 200, 10, 20, false)
+	large, _, _, err := imgview.EncodeITerm2(img, 200, 200, 10, 20, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeITerm2 (large box): %v", err)
 	}
@@ -235,11 +292,11 @@ func TestEncodeITerm2_DownscalesLargeSourceToTargetBox(t *testing.T) {
 
 func TestEncodeKitty_DownscalesLargeSourceToTargetBox(t *testing.T) {
 	img := noisyImage(400, 400)
-	small, _, _, err := imgview.EncodeKitty(img, 4, 2, 10, 20, 0, false)
+	small, _, _, err := imgview.EncodeKitty(img, 4, 2, 10, 20, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty (small box): %v", err)
 	}
-	large, _, _, err := imgview.EncodeKitty(img, 200, 200, 10, 20, 0, false)
+	large, _, _, err := imgview.EncodeKitty(img, 200, 200, 10, 20, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty (large box): %v", err)
 	}
@@ -264,7 +321,7 @@ func TestDeleteKittyPlacement_TargetsExactIDPair(t *testing.T) {
 func TestEncodeITerm2_ContainsOSC(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{G: 255, A: 255})
-	seq, cols, rows, err := imgview.EncodeITerm2(img, 80, 40, 0, 0, false)
+	seq, cols, rows, err := imgview.EncodeITerm2(img, 80, 40, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeITerm2: %v", err)
 	}
@@ -282,6 +339,44 @@ func TestEncodeITerm2_ContainsOSC(t *testing.T) {
 	}
 }
 
+// TestEncodeITerm2_AppliesDither mirrors TestEncodeKitty_AppliesDither.
+func TestEncodeITerm2_AppliesDither(t *testing.T) {
+	img := noisyImage(8, 8)
+	plain, _, _, err := imgview.EncodeITerm2(img, 80, 40, 0, 0, false, nil)
+	if err != nil {
+		t.Fatalf("EncodeITerm2 (no dither): %v", err)
+	}
+	fg := color.RGBA{R: 0, G: 255, B: 65, A: 255}
+	bg := color.RGBA{R: 13, G: 13, B: 13, A: 255}
+	dithered, _, _, err := imgview.EncodeITerm2(img, 80, 40, 0, 0, false, &imgview.DitherOptions{PixelSize: 1, FgColor: fg, BgColor: bg})
+	if err != nil {
+		t.Fatalf("EncodeITerm2 (dithered): %v", err)
+	}
+	if dithered == plain {
+		t.Fatal("EncodeITerm2: dithered output identical to undithered output")
+	}
+	colon := strings.LastIndex(dithered, ":")
+	payload := strings.TrimSuffix(dithered[colon+1:], "\x07")
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		t.Fatalf("payload did not decode as base64: %v", err)
+	}
+	decoded, err := png.Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("payload did not decode as PNG: %v", err)
+	}
+	bounds := decoded.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, _ := decoded.At(x, y).RGBA()
+			c := color.RGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(b >> 8)}
+			if !channelBetween(c.R, fg.R, bg.R) || !channelBetween(c.G, fg.G, bg.G) || !channelBetween(c.B, fg.B, bg.B) {
+				t.Fatalf("pixel (%d,%d) = %+v, want a blend between fg %+v and bg %+v", x, y, c, fg, bg)
+			}
+		}
+	}
+}
+
 // TestEncodeITerm2_SetsDoNotMoveCursor is a regression test: without
 // doNotMoveCursor=1, WezTerm scrolls its whole screen once an inline image's
 // footprint reaches the terminal's last line (wezterm/wezterm#3266), which
@@ -290,7 +385,7 @@ func TestEncodeITerm2_ContainsOSC(t *testing.T) {
 // advance, so this is safe to always send.
 func TestEncodeITerm2_SetsDoNotMoveCursor(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	seq, _, _, err := imgview.EncodeITerm2(img, 80, 40, 0, 0, false)
+	seq, _, _, err := imgview.EncodeITerm2(img, 80, 40, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeITerm2: %v", err)
 	}
@@ -306,11 +401,11 @@ func TestEncodeITerm2_SetsDoNotMoveCursor(t *testing.T) {
 // preserveAspectRatio letterboxing leaves — see EncodeITerm2's doc comment).
 func TestEncodeITerm2_UsesRealCellSize(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 400, 400))
-	_, defaultCols, defaultRows, err := imgview.EncodeITerm2(img, 200, 200, 0, 0, false)
+	_, defaultCols, defaultRows, err := imgview.EncodeITerm2(img, 200, 200, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeITerm2 (default cell size): %v", err)
 	}
-	_, largeCellCols, largeCellRows, err := imgview.EncodeITerm2(img, 200, 200, 40, 80, false)
+	_, largeCellCols, largeCellRows, err := imgview.EncodeITerm2(img, 200, 200, 40, 80, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeITerm2 (large cell size): %v", err)
 	}
@@ -325,11 +420,11 @@ func TestEncodeITerm2_UsesRealCellSize(t *testing.T) {
 // TestEncodeKitty_UsesRealCellSize mirrors TestEncodeSixel_UsesRealCellSize.
 func TestEncodeKitty_UsesRealCellSize(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 400, 400))
-	_, defaultCols, defaultRows, err := imgview.EncodeKitty(img, 200, 200, 0, 0, 0, false)
+	_, defaultCols, defaultRows, err := imgview.EncodeKitty(img, 200, 200, 0, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty (default cell size): %v", err)
 	}
-	_, largeCellCols, largeCellRows, err := imgview.EncodeKitty(img, 200, 200, 40, 80, 0, false)
+	_, largeCellCols, largeCellRows, err := imgview.EncodeKitty(img, 200, 200, 40, 80, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeKitty (large cell size): %v", err)
 	}

--- a/internal/ui/imgview/iterm2.go
+++ b/internal/ui/imgview/iterm2.go
@@ -22,16 +22,22 @@ import (
 // natural pixel size to fill maxCols/maxRows (used only by the fullscreen
 // modal's user-driven zoom — see imgview.NativeCellBox); false (inline
 // thumbnails) never upscales. Returns the OSC escape sequence and the
-// computed display size in terminal columns and rows.
-func EncodeITerm2(img image.Image, maxCols, maxRows, cellPxW, cellPxH int, allowUpscale bool) (encoded string, cols, rows int, err error) {
+// computed display size in terminal columns and rows. dither, when non-nil,
+// applies the RasterImage-style duotone dither effect (see Dither) to the
+// image before encoding.
+func EncodeITerm2(img image.Image, maxCols, maxRows, cellPxW, cellPxH int, allowUpscale bool, dither *DitherOptions) (encoded string, cols, rows int, err error) {
 	cellPxW, cellPxH = EffectiveCellPx(cellPxW, cellPxH)
 	bounds := img.Bounds()
 	w := bounds.Max.X - bounds.Min.X
 	h := bounds.Max.Y - bounds.Min.Y
 	cols, rows = fitBox(w, h, maxCols, maxRows, cellPxW, cellPxH, allowUpscale)
 
+	src := downscaleToBox(img, cols, rows, cellPxW, cellPxH, allowUpscale)
+	if dither != nil {
+		src = Dither(src, *dither)
+	}
 	var buf bytes.Buffer
-	if encErr := png.Encode(&buf, downscaleToBox(img, cols, rows, cellPxW, cellPxH, allowUpscale)); encErr != nil {
+	if encErr := png.Encode(&buf, src); encErr != nil {
 		return "", 0, 0, fmt.Errorf("imgview: png encode: %w", encErr)
 	}
 	payload := base64.StdEncoding.EncodeToString(buf.Bytes())

--- a/internal/ui/imgview/kitty.go
+++ b/internal/ui/imgview/kitty.go
@@ -42,15 +42,21 @@ import (
 // true, lets the image be scaled up past its natural pixel size to fill
 // maxCols/maxRows (used only by the fullscreen modal's user-driven zoom —
 // see imgview.NativeCellBox); false (inline thumbnails) never upscales.
-func EncodeKitty(img image.Image, maxCols, maxRows, cellPxW, cellPxH, placementID int, allowUpscale bool) (encoded string, cols, rows int, err error) {
+// dither, when non-nil, applies the RasterImage-style duotone dither effect
+// (see Dither) to the image before encoding.
+func EncodeKitty(img image.Image, maxCols, maxRows, cellPxW, cellPxH, placementID int, allowUpscale bool, dither *DitherOptions) (encoded string, cols, rows int, err error) {
 	cellPxW, cellPxH = EffectiveCellPx(cellPxW, cellPxH)
 	bounds := img.Bounds()
 	w := bounds.Max.X - bounds.Min.X
 	h := bounds.Max.Y - bounds.Min.Y
 	cols, rows = fitBox(w, h, maxCols, maxRows, cellPxW, cellPxH, allowUpscale)
 
+	src := downscaleToBox(img, cols, rows, cellPxW, cellPxH, allowUpscale)
+	if dither != nil {
+		src = Dither(src, *dither)
+	}
 	var buf bytes.Buffer
-	if encErr := png.Encode(&buf, downscaleToBox(img, cols, rows, cellPxW, cellPxH, allowUpscale)); encErr != nil {
+	if encErr := png.Encode(&buf, src); encErr != nil {
 		return "", 0, 0, fmt.Errorf("imgview: png encode: %w", encErr)
 	}
 	payload := base64.StdEncoding.EncodeToString(buf.Bytes())

--- a/internal/ui/imgview/sixel.go
+++ b/internal/ui/imgview/sixel.go
@@ -21,8 +21,10 @@ import (
 // past its natural pixel size to fill maxCols/maxRows (used only by the
 // fullscreen modal's user-driven zoom — see imgview.NativeCellBox); false
 // (inline thumbnails) never upscales. Returns the DCS escape sequence and
-// the computed display size in terminal columns and rows.
-func EncodeSixel(img image.Image, maxCols, maxRows, cellPxW, cellPxH int, allowUpscale bool) (encoded string, cols, rows int, err error) {
+// the computed display size in terminal columns and rows. dither, when
+// non-nil, applies the RasterImage-style duotone dither effect (see Dither)
+// to the image before encoding.
+func EncodeSixel(img image.Image, maxCols, maxRows, cellPxW, cellPxH int, allowUpscale bool, dither *DitherOptions) (encoded string, cols, rows int, err error) {
 	cellPxW, cellPxH = EffectiveCellPx(cellPxW, cellPxH)
 	bounds := img.Bounds()
 	w := bounds.Dx()
@@ -30,6 +32,9 @@ func EncodeSixel(img image.Image, maxCols, maxRows, cellPxW, cellPxH int, allowU
 
 	cols, rows = fitBox(w, h, maxCols, maxRows, cellPxW, cellPxH, allowUpscale)
 	src := downscaleToBox(img, cols, rows, cellPxW, cellPxH, allowUpscale)
+	if dither != nil {
+		src = Dither(src, *dither)
+	}
 
 	var buf bytes.Buffer
 	enc := sixel.NewEncoder(&buf)

--- a/internal/ui/imgview/sixel_test.go
+++ b/internal/ui/imgview/sixel_test.go
@@ -12,7 +12,7 @@ import (
 func TestEncodeSixel_ContainsDCS(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{R: 255, A: 255})
-	seq, cols, rows, err := imgview.EncodeSixel(img, 40, 20, 0, 0, false)
+	seq, cols, rows, err := imgview.EncodeSixel(img, 40, 20, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeSixel: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestEncodeSixel_ContainsDCS(t *testing.T) {
 func TestEncodeSixel_CapsRows(t *testing.T) {
 	// Tall portrait image: without a row cap this would need 50 rows at 10 cols.
 	img := image.NewRGBA(image.Rect(0, 0, 100, 1000))
-	_, cols, rows, err := imgview.EncodeSixel(img, 40, 20, 0, 0, false)
+	_, cols, rows, err := imgview.EncodeSixel(img, 40, 20, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeSixel: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestEncodeSixel_NeverUpscales(t *testing.T) {
 	// A tiny image with generous bounds should stay tiny, not get blown up,
 	// when allowUpscale is false (the inline-thumbnail case).
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	_, cols, rows, err := imgview.EncodeSixel(img, 200, 100, 0, 0, false)
+	_, cols, rows, err := imgview.EncodeSixel(img, 200, 100, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeSixel: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestEncodeSixel_NeverUpscales(t *testing.T) {
 // requested box instead of being left at its native 1x1-cell size.
 func TestEncodeSixel_AllowUpscaleFillsBox(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
-	_, cols, rows, err := imgview.EncodeSixel(img, 20, 10, 0, 0, true)
+	_, cols, rows, err := imgview.EncodeSixel(img, 20, 10, 0, 0, true, nil)
 	if err != nil {
 		t.Fatalf("EncodeSixel: %v", err)
 	}
@@ -85,11 +85,11 @@ func TestEncodeSixel_UsesRealCellSize(t *testing.T) {
 	// cell size (as Konsole or similar can report) — confirms cellPxW/cellPxH
 	// actually drives the sizing math instead of being ignored.
 	img := image.NewRGBA(image.Rect(0, 0, 400, 400))
-	_, defaultCols, defaultRows, err := imgview.EncodeSixel(img, 200, 200, 0, 0, false)
+	_, defaultCols, defaultRows, err := imgview.EncodeSixel(img, 200, 200, 0, 0, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeSixel (default cell size): %v", err)
 	}
-	_, largeCellCols, largeCellRows, err := imgview.EncodeSixel(img, 200, 200, 40, 80, false)
+	_, largeCellCols, largeCellRows, err := imgview.EncodeSixel(img, 200, 200, 40, 80, false, nil)
 	if err != nil {
 		t.Fatalf("EncodeSixel (large cell size): %v", err)
 	}
@@ -98,5 +98,35 @@ func TestEncodeSixel_UsesRealCellSize(t *testing.T) {
 	}
 	if largeCellRows >= defaultRows {
 		t.Errorf("EncodeSixel: rows with a 4x larger cell size = %d, want < default rows = %d", largeCellRows, defaultRows)
+	}
+}
+
+// TestEncodeSixel_AppliesDither confirms a non-nil DitherOptions changes the
+// encoded output. Unlike Kitty/iTerm2, Sixel's DCS payload isn't a
+// self-contained decodable image format in this codebase (no Sixel decoder
+// is available), so this checks the byte-level effect rather than decoding
+// pixels back out — see imgview.Dither's own tests for the pixel-level
+// invariants.
+func TestEncodeSixel_AppliesDither(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	for y := 0; y < 8; y++ {
+		for x := 0; x < 8; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x * 30), G: uint8(y * 30), B: 128, A: 255})
+		}
+	}
+	plain, _, _, err := imgview.EncodeSixel(img, 40, 20, 0, 0, false, nil)
+	if err != nil {
+		t.Fatalf("EncodeSixel (no dither): %v", err)
+	}
+	dithered, _, _, err := imgview.EncodeSixel(img, 40, 20, 0, 0, false, &imgview.DitherOptions{
+		PixelSize: 1,
+		FgColor:   color.RGBA{R: 0, G: 255, B: 65, A: 255},
+		BgColor:   color.RGBA{R: 13, G: 13, B: 13, A: 255},
+	})
+	if err != nil {
+		t.Fatalf("EncodeSixel (dithered): %v", err)
+	}
+	if dithered == plain {
+		t.Fatal("EncodeSixel: dithered output identical to undithered output")
 	}
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -378,8 +378,9 @@ func injectInlineImages(a App, base string, slots []screens.InlineImageSlot, row
 	// syncInlineImages keeps re-running on every subsequent Update either
 	// way, ticks included.
 	if time.Since(a.screenSwitchedAt) >= inlineImageSwitchSettleDelay {
+		ditherOpts := a.ditherOptions()
 		for _, slot := range slots {
-			encoded, ok := a.inlineImageCache[inlineImageCacheKey(slot, a.graphicsProtocol)]
+			encoded, ok := a.inlineImageCache[inlineImageCacheKey(slot, a.graphicsProtocol, ditherOpts)]
 			if !ok {
 				continue
 			}

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -593,7 +593,7 @@ func TestCompositeOverlays_KittyCleanupFallsThroughToInlineImages(t *testing.T) 
 		graphicsProtocol:  imgview.ProtocolKitty,
 		imageNeedsCleanup: true,
 		imageModalRows:    3,
-		inlineImageCache:  map[string]string{inlineImageCacheKey(slot, imgview.ProtocolKitty): "\x1b_Gfake\x1b\\"},
+		inlineImageCache:  map[string]string{inlineImageCacheKey(slot, imgview.ProtocolKitty, nil): "\x1b_Gfake\x1b\\"},
 	}
 	l := fakeModalRenderer{slots: []screens.InlineImageSlot{slot}, rowOrigin: 5, colOrigin: 7}
 	out := compositeOverlays(l, a, strings.Repeat("x\n", 9)+"x")
@@ -622,7 +622,7 @@ func TestCompositeOverlays_ImageModalOpen_StillDrawsInlineImagesBehindIt(t *test
 		width: 40, height: 10,
 		graphicsProtocol: imgview.ProtocolKitty,
 		imageModalOpen:   true,
-		inlineImageCache: map[string]string{inlineImageCacheKey(slot, imgview.ProtocolKitty): "\x1b_Gfake\x1b\\"},
+		inlineImageCache: map[string]string{inlineImageCacheKey(slot, imgview.ProtocolKitty, nil): "\x1b_Gfake\x1b\\"},
 	}
 	l := fakeModalRenderer{slots: []screens.InlineImageSlot{slot}, rowOrigin: 5, colOrigin: 7}
 	out := compositeOverlays(l, a, strings.Repeat("x\n", 9)+"x")
@@ -741,7 +741,7 @@ func TestCompositeOverlays_ImageModalCycle_SixelGetsFullRepaint(t *testing.T) {
 // imageRepaintGen was extended to cover both protocols.
 func TestInjectInlineImages_ITerm2RepaintGenAlwaysDiffersOnChange(t *testing.T) {
 	slot := screens.InlineImageSlot{Key: "post:p1:0", URL: "https://example.com/a.png", Row: 1, ColIndent: 2}
-	cache := map[string]string{inlineImageCacheKey(slot, imgview.ProtocolITerm2): "\x1b]1337;fake\x07"}
+	cache := map[string]string{inlineImageCacheKey(slot, imgview.ProtocolITerm2, nil): "\x1b]1337;fake\x07"}
 	slots := []screens.InlineImageSlot{slot}
 
 	a1 := App{width: 40, height: 10, graphicsProtocol: imgview.ProtocolITerm2, inlineImageCache: cache, imageRepaintGen: 1}
@@ -764,7 +764,7 @@ func TestInjectInlineImages_ITerm2RepaintGenAlwaysDiffersOnChange(t *testing.T) 
 // and the Sixel protocol path through injectInlineImages too.
 func TestInjectInlineImages_SixelRepaintGenAlwaysDiffersOnChange(t *testing.T) {
 	slot := screens.InlineImageSlot{Key: "post:p1:0", URL: "https://example.com/a.png", Row: 1, ColIndent: 2}
-	cache := map[string]string{inlineImageCacheKey(slot, imgview.ProtocolSixel): "\x1bPq...fake\x1b\\"}
+	cache := map[string]string{inlineImageCacheKey(slot, imgview.ProtocolSixel, nil): "\x1bPq...fake\x1b\\"}
 	slots := []screens.InlineImageSlot{slot}
 
 	a1 := App{width: 40, height: 10, graphicsProtocol: imgview.ProtocolSixel, inlineImageCache: cache, imageRepaintGen: 1}
@@ -887,7 +887,7 @@ func TestInjectInlineImages_ForcesStaleRowsDirty(t *testing.T) {
 // must still happen immediately regardless.
 func TestInjectInlineImages_HoldsBackDrawsWithinSwitchSettleDelay(t *testing.T) {
 	slot := screens.InlineImageSlot{Key: "post:p1:0", URL: "https://example.com/a.png", Row: 1, ColIndent: 2}
-	cache := map[string]string{inlineImageCacheKey(slot, imgview.ProtocolITerm2): "\x1b]1337;fake\x07"}
+	cache := map[string]string{inlineImageCacheKey(slot, imgview.ProtocolITerm2, nil): "\x1b]1337;fake\x07"}
 	slots := []screens.InlineImageSlot{slot}
 
 	withinDelay := App{
@@ -924,7 +924,7 @@ func TestTabsLayoutView_InjectsInlineImages(t *testing.T) {
 	if len(slots) != 1 {
 		t.Fatalf("setup: expected 1 slot from the feed, got %d: %+v", len(slots), slots)
 	}
-	a.inlineImageCache = map[string]string{inlineImageCacheKey(slots[0], a.graphicsProtocol): "\x1b_Gfake\x1b\\"}
+	a.inlineImageCache = map[string]string{inlineImageCacheKey(slots[0], a.graphicsProtocol, nil): "\x1b_Gfake\x1b\\"}
 
 	out := (TabsLayout{}).View(a)
 	if !strings.Contains(out, "\x1b_Gfake\x1b\\") {
@@ -953,7 +953,7 @@ func TestMillerLayoutView_InjectsInlineImages(t *testing.T) {
 	if len(slots) != 1 {
 		t.Fatalf("setup: expected 1 slot from Miller's Feed detail pane, got %d: %+v", len(slots), slots)
 	}
-	a.inlineImageCache = map[string]string{inlineImageCacheKey(slots[0], a.graphicsProtocol): "\x1b_Gfake\x1b\\"}
+	a.inlineImageCache = map[string]string{inlineImageCacheKey(slots[0], a.graphicsProtocol, nil): "\x1b_Gfake\x1b\\"}
 
 	out := (MillerLayout{}).View(a)
 	if !strings.Contains(out, "\x1b_Gfake\x1b\\") {

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -56,8 +56,15 @@ type SharedConfigMsg struct {
 	// session isn't ephemeral (SSH-hosted). Feed and PostDetail should check
 	// only this field; they never need to know about the individual gates.
 	InlineImagesEnabled bool
-	OwnGuildSlug        string
-	LayoutName          string // "tabs" or "miller"; used by settings screen to show current value
+	// Dithering is the user's raw preference (config.Config.Dithering), used
+	// by the settings screen to display/edit the toggle.
+	Dithering bool
+	// DitherSharpness is the user's raw preference
+	// (config.Config.DitherSharpness): "rough"/"medium"/"sharp". Used by the
+	// settings screen to display/edit the enum.
+	DitherSharpness string
+	OwnGuildSlug    string
+	LayoutName      string // "tabs" or "miller"; used by settings screen to show current value
 }
 
 // URLProvider is implemented by screens that can expose URLs from their
@@ -129,6 +136,8 @@ type SaveSettingsMsg struct {
 	ImageViewer      string
 	GraphicsProtocol string
 	InlineImages     bool
+	Dithering        bool
+	DitherSharpness  string
 	LayoutName       string // "tabs" or "miller"
 	RemoteChanged    bool   // true when API-managed fields differ from the last saved baseline
 }

--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -201,6 +201,36 @@ var settingsGroups = []settingsGroup{
 					return m.imageViewer != "browser"
 				},
 			},
+			{
+				label: "  dithering", kind: "bool",
+				getBool: func(m SettingsModel) bool { return m.dithering },
+				toggle:  func(m SettingsModel) SettingsModel { m.dithering = !m.dithering; return m },
+				showIf: func(m SettingsModel) bool {
+					return m.imageViewer != "browser"
+				},
+			},
+			{
+				label:   "    sharpness",
+				kind:    "enum",
+				options: []string{"rough", "medium", "sharp", "crisp"},
+				getEnum: func(m SettingsModel) string {
+					if m.ditherSharpness == "" {
+						return "medium"
+					}
+					return m.ditherSharpness
+				},
+				cycle: func(m SettingsModel, delta int) SettingsModel {
+					cur := m.ditherSharpness
+					if cur == "" {
+						cur = "medium"
+					}
+					m.ditherSharpness = cycleStringEnum(cur, []string{"rough", "medium", "sharp", "crisp"}, delta)
+					return m
+				},
+				showIf: func(m SettingsModel) bool {
+					return m.imageViewer != "browser" && m.dithering
+				},
+			},
 		},
 	},
 	{
@@ -231,6 +261,10 @@ type SettingsModel struct {
 	originalGraphicsProtocol string         // last saved baseline
 	inlineImages             bool           // live local config value
 	originalInlineImages     bool           // last saved baseline
+	dithering                bool           // live local config value
+	originalDithering        bool           // last saved baseline
+	ditherSharpness          string         // live local config value ("rough"/"medium"/"sharp")
+	originalDitherSharpness  string         // last saved baseline
 	layoutName               string         // live local config value ("tabs" or "miller")
 	originalLayoutName       string         // last saved baseline
 	cursor                   int
@@ -253,7 +287,7 @@ func (m SettingsModel) SetSettings(s model.Settings) SettingsModel {
 }
 
 // SetSaved marks the current settings as saved and advances the baseline.
-func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, imageViewer, graphicsProtocol string, inlineImages bool, layoutName string) SettingsModel {
+func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, imageViewer, graphicsProtocol string, inlineImages bool, dithering bool, ditherSharpness string, layoutName string) SettingsModel {
 	m.err = nil
 	m.original = m.settings
 	m.wanderLust = wanderLust
@@ -268,6 +302,10 @@ func (m SettingsModel) SetSaved(wanderLust bool, maxThreadDepth int, timezone, i
 	m.originalGraphicsProtocol = graphicsProtocol
 	m.inlineImages = inlineImages
 	m.originalInlineImages = inlineImages
+	m.dithering = dithering
+	m.originalDithering = dithering
+	m.ditherSharpness = ditherSharpness
+	m.originalDitherSharpness = ditherSharpness
 	m.layoutName = layoutName
 	m.originalLayoutName = layoutName
 	return m
@@ -288,6 +326,8 @@ func (m SettingsModel) IsDirty() bool {
 		m.imageViewer != m.originalImageViewer ||
 		m.graphicsProtocol != m.originalGraphicsProtocol ||
 		m.inlineImages != m.originalInlineImages ||
+		m.dithering != m.originalDithering ||
+		m.ditherSharpness != m.originalDitherSharpness ||
 		m.layoutName != m.originalLayoutName
 }
 
@@ -382,6 +422,10 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			m.originalGraphicsProtocol = msg.GraphicsProtocol
 			m.inlineImages = msg.InlineImages
 			m.originalInlineImages = msg.InlineImages
+			m.dithering = msg.Dithering
+			m.originalDithering = msg.Dithering
+			m.ditherSharpness = msg.DitherSharpness
+			m.originalDitherSharpness = msg.DitherSharpness
 			m.layoutName = msg.LayoutName
 			m.originalLayoutName = msg.LayoutName
 		}
@@ -434,10 +478,12 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 				iv := m.imageViewer
 				gp := m.graphicsProtocol
 				ii := m.inlineImages
+				dt := m.dithering
+				ds := m.ditherSharpness
 				ln := m.layoutName
 				remoteChanged := !settingsEqual(m.settings, m.original)
 				return m, func() tea.Msg {
-					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, GraphicsProtocol: gp, InlineImages: ii, LayoutName: ln, RemoteChanged: remoteChanged}
+					return SaveSettingsMsg{Settings: s, WanderLust: wl, MaxThreadDepth: td, Timezone: tz, ImageViewer: iv, GraphicsProtocol: gp, InlineImages: ii, Dithering: dt, DitherSharpness: ds, LayoutName: ln, RemoteChanged: remoteChanged}
 				}
 			}
 			return m, nil
@@ -451,6 +497,8 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 			m.imageViewer = m.originalImageViewer
 			m.graphicsProtocol = m.originalGraphicsProtocol
 			m.inlineImages = m.originalInlineImages
+			m.dithering = m.originalDithering
+			m.ditherSharpness = m.originalDitherSharpness
 			m.layoutName = m.originalLayoutName
 			m.err = nil
 			return m, nil

--- a/internal/ui/screens/settings_test.go
+++ b/internal/ui/screens/settings_test.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -250,7 +251,7 @@ func TestSettings_Esc_ClearsError(t *testing.T) {
 func TestSettings_SetSaved_ClearsError(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m = m.SetError(testErr)
-	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, false, "", "tabs")
 	if m.err != nil {
 		t.Error("SetSaved should clear error")
 	}
@@ -262,9 +263,93 @@ func TestSettings_SetSaved_AdvancesBaseline(t *testing.T) {
 	if !m.IsDirty() {
 		t.Error("should be dirty after change")
 	}
-	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, false, "", "tabs")
 	if m.IsDirty() {
 		t.Error("after SetSaved, should not be dirty")
+	}
+}
+
+// --- Dithering Tests ---
+
+// hasItemLabelled reports whether any of m's currently visible (showIf-passing)
+// items has a label containing sub — the same set flatItems/View iterate over,
+// checked directly rather than through View's height-limited scroll viewport.
+func hasItemLabelled(m SettingsModel, sub string) bool {
+	for _, item := range flatItems(m) {
+		if strings.Contains(item.label, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSettings_Dithering_ShowIf_HiddenWhenBrowser(t *testing.T) {
+	m := initSettings(defaultSettings())
+	m.imageViewer = "terminal"
+	if !hasItemLabelled(m, "dithering") {
+		t.Error("dithering item should be visible when imageViewer != browser")
+	}
+	m.imageViewer = "browser"
+	if hasItemLabelled(m, "dithering") {
+		t.Error("dithering item should be hidden when imageViewer == browser")
+	}
+}
+
+func TestSettings_Sharpness_ShowIf_HiddenUntilDitheringOn(t *testing.T) {
+	m := initSettings(defaultSettings())
+	m.imageViewer = "terminal"
+	m.dithering = false
+	if hasItemLabelled(m, "sharpness") {
+		t.Error("sharpness item should be hidden while dithering is off")
+	}
+	m.dithering = true
+	if !hasItemLabelled(m, "sharpness") {
+		t.Error("sharpness item should be visible once dithering is on")
+	}
+	m.imageViewer = "browser"
+	if hasItemLabelled(m, "sharpness") {
+		t.Error("sharpness item should stay hidden when imageViewer == browser, even with dithering on")
+	}
+}
+
+func TestSettings_Dithering_SaveMsg(t *testing.T) {
+	m := initSettings(defaultSettings())
+	m.dithering = true
+	m.originalDithering = false // make it dirty
+	m.ditherSharpness = "rough"
+	m.originalDitherSharpness = "medium"
+	var got tea.Msg
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd != nil {
+		got = cmd()
+	}
+	save, ok := got.(SaveSettingsMsg)
+	if !ok {
+		t.Fatal("ctrl+s should emit SaveSettingsMsg")
+	}
+	if !save.Dithering {
+		t.Error("SaveSettingsMsg.Dithering should reflect current dithering value")
+	}
+	if save.DitherSharpness != "rough" {
+		t.Errorf("SaveSettingsMsg.DitherSharpness = %q, want %q", save.DitherSharpness, "rough")
+	}
+}
+
+func TestSettings_Dithering_SetSaved_AdvancesBaseline(t *testing.T) {
+	m := initSettings(defaultSettings())
+	m.dithering = true
+	m.originalDithering = false
+	m.ditherSharpness = "sharp"
+	m.originalDitherSharpness = "medium"
+	if !m.IsDirty() {
+		t.Error("should be dirty before SetSaved")
+	}
+	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, true, "sharp", "tabs")
+	if m.originalDithering != true || m.originalDitherSharpness != "sharp" {
+		t.Error("SetSaved should update originalDithering/originalDitherSharpness to the saved values")
+	}
+	if m.IsDirty() {
+		t.Error("should not be dirty after SetSaved")
 	}
 }
 
@@ -387,7 +472,7 @@ func TestSettings_View_DirtyFooterHint(t *testing.T) {
 
 func TestSettings_View_SavedMessage(t *testing.T) {
 	m := initSettings(defaultSettings())
-	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, "tabs")
+	m = m.SetSaved(false, 3, "UTC", "terminal", "", false, false, "", "tabs")
 	view := m.View()
 	if !containsSubstring(view, "saved!") {
 		t.Error("View should show 'saved!' when saved=true")
@@ -416,7 +501,7 @@ func TestSettings_WanderGroup_Visible(t *testing.T) {
 func TestSettings_WanderToggle(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
-	m.cursor = 13 // wander mode item
+	m.cursor = 14 // wander mode item (shifted by the new dithering toggle above it)
 	m, _ = m.Update(keyMsg("enter"))
 	if m.wanderLust {
 		t.Error("toggling wander mode should flip wanderLust to false")
@@ -458,7 +543,7 @@ func TestSettings_WanderSetSaved(t *testing.T) {
 	m := initSettings(defaultSettings())
 	m.wanderLust = true
 	m.originalWanderLust = false // dirty
-	m = m.SetSaved(true, 3, "UTC", "terminal", "", false, "tabs")
+	m = m.SetSaved(true, 3, "UTC", "terminal", "", false, false, "", "tabs")
 	if m.originalWanderLust != true {
 		t.Error("SetSaved should update originalWanderLust to the saved value")
 	}


### PR DESCRIPTION
## Summary
- Ports cyberspace.online webui's `RasterImage` shader (pixelate → grayscale → 8x8 Bayer ordered dither → duotone recolor through the active theme) as a pure Go transform in `internal/ui/imgview/dither.go`, wired into the Kitty/iTerm2/Sixel encoders for both inline post images and the fullscreen modal.
- New nested settings: `dithering` (shown when image viewer != browser) → `sharpness` (rough/medium/sharp/crisp, shown when dithering is on).
- Fixes a pre-existing bug where any settings save re-resolved the graphics protocol via env-var-only detection, silently dropping a DA1-probed Sixel session to no-protocol until restart.
- Fixes the inline-image cache key not accounting for dither state, so cached thumbnails kept showing stale dithering after a settings change until eviction or restart.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l` clean on all touched files
- [x] Manually verified inline images and fullscreen modal on Kitty (Ghostty) and Sixel (Foot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)