### PR TITLE
fix: guard Search inline-image/selection lookups against stale rows in query view

### DIFF
--- a/internal/ui/screens/search.go
+++ b/internal/ui/screens/search.go
@@ -746,7 +746,7 @@ func (m SearchModel) refreshContent() SearchModel {
 // if no row is selected or the selected row isn't a post — used by App to
 // detect a selection-only move (see FeedModel.SelectedPostID's doc comment).
 func (m SearchModel) SelectedPostID() string {
-	if m.selected < 0 || m.selected >= len(m.rows) {
+	if m.view == searchViewQuery || m.selected < 0 || m.selected >= len(m.rows) {
 		return ""
 	}
 	row := m.rows[m.selected]
@@ -760,7 +760,7 @@ func (m SearchModel) SelectedPostID() string {
 // the viewport, top to bottom, across every visible post hit — see
 // PostDetailModel.VisibleInlineImages for the full contract.
 func (m SearchModel) VisibleInlineImages() []InlineImageSlot {
-	if !m.ready || !m.inlineImagesEnabled {
+	if !m.ready || !m.inlineImagesEnabled || m.view == searchViewQuery {
 		return nil
 	}
 	top, bottom := m.viewport.YOffset, m.viewport.YOffset+m.viewport.Height


### PR DESCRIPTION
﻿## What
Fixes a panic in Search: `runtime error: index out of range [0] with length 0` in `SearchModel.postAt`, reached via `VisibleInlineImages` -> `App.activeInlineImageSlots` -> `App.syncInlineImages`.

## Root cause
`FocusQuery()` switches `SearchModel.view` to `searchViewQuery` but intentionally leaves the previous view's `m.rows` in place (so `esc` can return to cached results). `VisibleInlineImages` and `SelectedPostID` iterate `m.rows` regardless of the current view, and `postAt`/`replyAt`/`userAt` branch on `m.view` to decide which backing slice to index (`m.preview.Posts` vs `m.posts`).

When the view flips to query, a stale "posts" row left over from the preview view gets resolved against `m.posts` instead of `m.preview.Posts`. `m.posts` is empty unless the user has drilled into a type list, so indexing it at `row.index == 0` panics.

## Fix
`VisibleInlineImages` and `SelectedPostID` now short-circuit when `m.view == searchViewQuery`, since the query view never renders `m.rows` anyway (`View()` shows the text input instead).

## Testing
- `go test ./...` - all pass
- `go vet ./...` - clean
- `staticcheck ./...` - clean
