### PR TITLE
fix: cap C-Mail/Feed caches and fix cIRC progressive slowdown

### DIFF
--- a/internal/ui/screens/chatrooms.go
+++ b/internal/ui/screens/chatrooms.go
@@ -275,6 +275,12 @@ type ChatroomsModel struct {
 	// its reserved band can shrink from the fallback-max placeholder down
 	// to its real size once known — see SetImageRealRows.
 	imageRealRows map[string]int
+	// chatBodyCache memoizes renderCircMessagesStyled's per-message output,
+	// keyed by message ID, so refreshMessages() doesn't re-parse/re-style
+	// every held message on every call — critical since styleAnimTickMsg
+	// calls refreshMessages() ~6.7x/sec for as long as any animated-style
+	// message is visible. See chatBodyCacheEntry's doc comment.
+	chatBodyCache map[string]chatBodyCacheEntry
 	flagPrompt          FlagPrompt
 	flagTargetMsgID     string // message ID being flagged, set right before flagPrompt.Open()
 	confirmingDeleteMsg bool   // true while the y/n delete-confirm overlay for the selected message is showing
@@ -374,11 +380,12 @@ func NewChatroomsModel(currentUser string, client api.Client) ChatroomsModel {
 	inp := textinput.New()
 	inp.Placeholder = "type a message..."
 	return ChatroomsModel{
-		input:       inp,
-		currentUser: currentUser,
-		client:      client,
-		mode:        chatroomModeList,
-		flagPrompt:  NewFlagPrompt(),
+		input:         inp,
+		currentUser:   currentUser,
+		client:        client,
+		mode:          chatroomModeList,
+		flagPrompt:    NewFlagPrompt(),
+		chatBodyCache: make(map[string]chatBodyCacheEntry),
 	}
 }
 
@@ -838,6 +845,9 @@ func (m ChatroomsModel) trimMessageBuffer() ChatroomsModel {
 		i++
 	}
 	if i > 0 {
+		for j := 0; j < i; j++ {
+			delete(m.chatBodyCache, m.messages[j].ID)
+		}
 		m.messages = m.messages[i:]
 		m.historyExhausted = false
 	}
@@ -880,6 +890,26 @@ func (m ChatroomsModel) AppendSystemMessage(roomID, text string) ChatroomsModel 
 	})
 }
 
+// evictStaleBodyCache drops chatBodyCache entries for messages no longer
+// present in m.messages. Called from SetMessages, whose wholesale replace of
+// m.messages (room open/switch) is the point a message can permanently drop
+// out of the loaded history — without this, chatBodyCache would keep every
+// entry from every room ever opened this session. trimMessageBuffer handles
+// the other eviction point (rolling history cap) directly, since it already
+// knows exactly which messages it's dropping.
+func (m ChatroomsModel) evictStaleBodyCache() ChatroomsModel {
+	live := make(map[string]bool, len(m.messages))
+	for _, msg := range m.messages {
+		live[msg.ID] = true
+	}
+	for id := range m.chatBodyCache {
+		if !live[id] {
+			delete(m.chatBodyCache, id)
+		}
+	}
+	return m
+}
+
 // SetMessages replaces the message history for the active room.
 func (m ChatroomsModel) SetMessages(roomID string, msgs []model.Message) ChatroomsModel {
 	if m.activeRoom == nil || m.activeRoom.Slug != roomID {
@@ -887,6 +917,7 @@ func (m ChatroomsModel) SetMessages(roomID string, msgs []model.Message) Chatroo
 	}
 	m.messages = msgs
 	m.err = nil
+	m = m.evictStaleBodyCache()
 	if m.ready {
 		m = m.refreshMessages()
 		m.viewport.GotoBottom()
@@ -1650,7 +1681,7 @@ func (m ChatroomsModel) refreshMessages() ChatroomsModel {
 	}
 	content, offsets, heights, imgSlots := renderCircMessagesWithSelection(
 		m.messages, m.location(), m.timeDisplayFormat, m.viewport.Width, m.currentUser, m.selectedMsgID,
-		m.revealed, m.styleAnimFrame, m.mutedUsers(), m.inlineImagesEnabled, m.imageRealRows)
+		m.revealed, m.styleAnimFrame, m.mutedUsers(), m.inlineImagesEnabled, m.imageRealRows, m.chatBodyCache)
 	m.viewport.SetContent(content)
 	m.msgOffsets, m.msgHeights = offsets, heights
 	m.msgImages = imgSlots

--- a/internal/ui/screens/chatrooms_test.go
+++ b/internal/ui/screens/chatrooms_test.go
@@ -1409,7 +1409,7 @@ func TestBrowsing_Enter_TogglesSpoilerReveal(t *testing.T) {
 	}
 	renderedWithReveal := func(m ChatroomsModel) string {
 		content, _, _, _ := renderCircMessagesWithSelection(m.messages, m.location(), m.timeDisplayFormat,
-			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame, nil, false, nil)
+			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame, nil, false, nil, nil)
 		return content
 	}
 	if strings.Contains(renderedWithReveal(m), "the ending is a twist") {
@@ -1462,7 +1462,7 @@ func TestBrowsing_Enter_TogglesL33tReveal(t *testing.T) {
 
 	renderedWithReveal := func(m ChatroomsModel) string {
 		content, _, _, _ := renderCircMessagesWithSelection(m.messages, m.location(), m.timeDisplayFormat,
-			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame, nil, false, nil)
+			m.viewport.Width, m.currentUser, m.selectedMsgID, m.revealed, m.styleAnimFrame, nil, false, nil, nil)
 		return content
 	}
 	if !strings.Contains(renderedWithReveal(m), "3l173") {
@@ -1720,6 +1720,52 @@ func TestPrependMessages_NotSubjectToByteCap(t *testing.T) {
 	}
 }
 
+// TestTrimMessageBuffer_EvictsStaleBodyCache guards against chatBodyCache
+// outliving the messages it was rendered from — an entry for a message
+// that's been evicted from m.messages by the byte cap must be dropped too,
+// or it sits in memory forever keyed by an ID nothing will ever look up
+// again.
+func TestTrimMessageBuffer_EvictsStaleBodyCache(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	big := chatMessageBufferMaxBytes
+	m.messages = []model.Message{bigMessage("old1", big), bigMessage("old2", big)}
+	m.chatBodyCache = map[string]chatBodyCacheEntry{
+		"old1": {rendered: "stale"},
+		"old2": {rendered: "kept"},
+	}
+
+	m = m.trimMessageBuffer()
+
+	if _, ok := m.chatBodyCache["old1"]; ok {
+		t.Error("expected chatBodyCache entry for the evicted message to be removed")
+	}
+	if _, ok := m.chatBodyCache["old2"]; !ok {
+		t.Error("expected chatBodyCache entry for the surviving message to remain")
+	}
+}
+
+// TestSetMessages_EvictsStaleBodyCache mirrors the Feed screen's
+// TestFeedSetPosts_EvictsStaleBodyCache — SetMessages wholesale-replacing
+// m.messages (room open/switch, or a fresh history load) is the other point
+// a message can permanently drop out of the loaded history, so it needs the
+// same cache cleanup as trimMessageBuffer.
+func TestSetMessages_EvictsStaleBodyCache(t *testing.T) {
+	m := chatroomsInRoom(api.NewMockClient(), "zion")
+	m.chatBodyCache = map[string]chatBodyCacheEntry{
+		"gone": {rendered: "stale"},
+		"kept": {rendered: "fresh"},
+	}
+
+	m = m.SetMessages("zion", []model.Message{{ID: "kept", From: model.User{Username: "trinity"}, CreatedAt: time.Now()}})
+
+	if _, ok := m.chatBodyCache["gone"]; ok {
+		t.Error("expected chatBodyCache entry for a message no longer in m.messages to be evicted")
+	}
+	if _, ok := m.chatBodyCache["kept"]; !ok {
+		t.Error("expected chatBodyCache entry for a message still in m.messages to survive")
+	}
+}
+
 func TestAppendMessage_EvictionResetsHistoryExhausted(t *testing.T) {
 	m := chatroomsInRoom(api.NewMockClient(), "zion")
 	big := chatMessageBufferMaxBytes / 2
@@ -1783,13 +1829,13 @@ func TestChatrooms_InlineImages_SuppressesRedundantTextOnceEnabled(t *testing.T)
 	}
 
 	disabled, _, _, _ := renderCircMessagesWithSelection(msgs, m.location(), m.timeDisplayFormat,
-		m.viewport.Width, m.currentUser, "", m.revealed, m.styleAnimFrame, nil, false, nil)
+		m.viewport.Width, m.currentUser, "", m.revealed, m.styleAnimFrame, nil, false, nil, nil)
 	if !strings.Contains(disabled, "https://example.com/attach.png") || !strings.Contains(disabled, "https://example.com/pic.png") {
 		t.Fatalf("setup: expected both URLs visible while disabled, got: %q", disabled)
 	}
 
 	enabled, _, _, _ := renderCircMessagesWithSelection(msgs, m.location(), m.timeDisplayFormat,
-		m.viewport.Width, m.currentUser, "", m.revealed, m.styleAnimFrame, nil, true, nil)
+		m.viewport.Width, m.currentUser, "", m.revealed, m.styleAnimFrame, nil, true, nil, nil)
 	if strings.Contains(enabled, "https://example.com/attach.png") {
 		t.Errorf("expected the attachment URL suppressed once enabled, got: %q", enabled)
 	}

--- a/internal/ui/screens/cmail.go
+++ b/internal/ui/screens/cmail.go
@@ -652,6 +652,7 @@ func (m CMailModel) SetActiveConversation(conv model.Conversation) CMailModel {
 	m.err = nil
 	m.input.Focus()
 	m.selectedMsgID = ""
+	m.imageRealRows = nil
 	if m.ready {
 		m = m.refreshMessages()
 		m.viewport.GotoBottom()
@@ -1645,6 +1646,7 @@ func (m CMailModel) AppendMessage(msg model.Message) CMailModel {
 	conv := *m.activeConv
 	conv.Messages = append(conv.Messages, msg)
 	m.activeConv = &conv
+	m = m.trimMessageBuffer()
 	m.err = nil
 	if m.ready {
 		wasAtBottom := m.viewport.AtBottom()
@@ -1696,6 +1698,42 @@ func (m CMailModel) PrependMessages(convID string, msgs []model.Message) CMailMo
 		newLines := lipgloss.Height(m.renderMessages())
 		m = m.refreshMessages()
 		m.viewport.SetYOffset(oldOffset + newLines - oldLines)
+	}
+	return m
+}
+
+// trimMessageBuffer evicts oldest messages from the active conversation's
+// history while the estimated total size exceeds chatMessageBufferMaxBytes,
+// always keeping at least the most recent message. Mirrors
+// ChatroomsModel.trimMessageBuffer — same const and estimatedMessageSize
+// helper, just operating on m.activeConv.Messages. Clears m.selectedMsgID if
+// the evicted range contained the current selection, and resets
+// m.historyExhausted so a later scroll-to-top re-fetches the evicted range
+// from the server instead of treating it as permanently gone — the
+// pagination cursor is activeConv.Messages[0] (see
+// maybeLoadOlderConvMessages), so this is always safe to re-trigger.
+func (m CMailModel) trimMessageBuffer() CMailModel {
+	if m.activeConv == nil {
+		return m
+	}
+	msgs := m.activeConv.Messages
+	total := 0
+	for _, msg := range msgs {
+		total += estimatedMessageSize(msg)
+	}
+	i := 0
+	for total > chatMessageBufferMaxBytes && i < len(msgs)-1 {
+		if msgs[i].ID != "" && msgs[i].ID == m.selectedMsgID {
+			m.selectedMsgID = ""
+		}
+		total -= estimatedMessageSize(msgs[i])
+		i++
+	}
+	if i > 0 {
+		conv := *m.activeConv
+		conv.Messages = msgs[i:]
+		m.activeConv = &conv
+		m.historyExhausted = false
 	}
 	return m
 }

--- a/internal/ui/screens/cmail_test.go
+++ b/internal/ui/screens/cmail_test.go
@@ -938,6 +938,90 @@ func TestCMail_TotalUnread_NoIncrementWhileFocusedAndAtBottom(t *testing.T) {
 	}
 }
 
+// --- message buffer cap ---
+// Mirrors TestAppendMessage_TrimsOldestWhenOverByteCap /
+// TestAppendMessage_ClearsSelectionOnEviction /
+// TestPrependMessages_NotSubjectToByteCap in chatrooms_test.go — CMail's
+// AppendMessage is meant to behave identically, just scoped to
+// m.activeConv.Messages instead of m.messages.
+
+func TestCMailAppendMessage_TrimsOldestWhenOverByteCap(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	big := chatMessageBufferMaxBytes / 3
+	m = m.SetConversationMessages("c1", []model.Message{
+		bigMessage("old1", big),
+		bigMessage("old2", big),
+	})
+
+	m = m.AppendMessage(bigMessage("new1", big))
+	m = m.AppendMessage(bigMessage("new2", big))
+
+	msgs := m.activeConv.Messages
+	if len(msgs) == 0 {
+		t.Fatal("expected at least one message to remain")
+	}
+	if msgs[len(msgs)-1].ID != "new2" {
+		t.Errorf("expected newest message to survive, got last ID %q", msgs[len(msgs)-1].ID)
+	}
+	for _, msg := range msgs {
+		if msg.ID == "old1" {
+			t.Error("expected oldest message to be evicted, found old1 still present")
+		}
+	}
+	total := 0
+	for _, msg := range msgs {
+		total += estimatedMessageSize(msg)
+	}
+	if total > chatMessageBufferMaxBytes {
+		t.Errorf("total estimated size = %d, want <= %d", total, chatMessageBufferMaxBytes)
+	}
+}
+
+func TestCMailAppendMessage_ClearsSelectionOnEviction(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	big := chatMessageBufferMaxBytes / 2
+	m = m.SetConversationMessages("c1", []model.Message{bigMessage("old1", big)})
+	m.selectedMsgID = "old1"
+
+	m = m.AppendMessage(bigMessage("new1", big))
+	m = m.AppendMessage(bigMessage("new2", big))
+
+	if m.selectedMsgID != "" {
+		t.Errorf("expected selectedMsgID cleared after its message was evicted, got %q", m.selectedMsgID)
+	}
+}
+
+func TestCMailPrependMessages_NotSubjectToByteCap(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	big := chatMessageBufferMaxBytes
+	m = m.SetConversationMessages("c1", []model.Message{bigMessage("recent", 10)})
+
+	m = m.PrependMessages("c1", []model.Message{bigMessage("history", big)})
+
+	msgs := m.activeConv.Messages
+	if len(msgs) != 2 {
+		t.Fatalf("expected prepend to keep both messages regardless of byte cap, got %d messages", len(msgs))
+	}
+	if msgs[0].ID != "history" {
+		t.Errorf("expected prepended message first, got %q", msgs[0].ID)
+	}
+}
+
+// TestCMailSetActiveConversation_ClearsImageRealRows guards against
+// imageRealRows (keyed per image-bearing message) accumulating one entry per
+// image ever viewed across every conversation opened in a session — it must
+// reset when switching conversations, same as selectedMsgID does.
+func TestCMailSetActiveConversation_ClearsImageRealRows(t *testing.T) {
+	m := cmailInConversation(api.NewMockClient(), "c1")
+	m.imageRealRows = map[string]int{"c1:msg1:0": 3}
+
+	m = m.SetActiveConversation(model.Conversation{ID: "c2", Participants: []model.User{{Username: "neo"}, {Username: "morpheus"}}})
+
+	if len(m.imageRealRows) != 0 {
+		t.Errorf("expected imageRealRows cleared on conversation switch, got %v", m.imageRealRows)
+	}
+}
+
 // TestCMail_TotalUnread_ClearsWhenScrolledBackToBottom confirms the badge
 // clears once the user scrolls back down themselves.
 func TestCMail_TotalUnread_ClearsWhenScrolledBackToBottom(t *testing.T) {

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -204,6 +204,7 @@ func (m FeedModel) SetPosts(posts []model.Post, cursor string) FeedModel {
 	m.posts = posts
 	m.nextCursor = cursor
 	m.exhausted = cursor == ""
+	m = m.evictStaleBodyCache()
 	m.loading = false
 	m.fetching = false
 	m.refreshing = false
@@ -932,6 +933,24 @@ type feedBodyCacheEntry struct {
 	editedAt            time.Time
 	inlineImagesEnabled bool
 	themeName           string
+}
+
+// evictStaleBodyCache drops bodyCache entries for posts no longer present in
+// m.posts. Called from SetPosts, whose wholesale replace of m.posts is the
+// only point where a post can permanently drop out of the loaded list —
+// without this, bodyCache grows for the life of the session since it's keyed
+// by post ID and otherwise only ever gains entries in renderPost.
+func (m FeedModel) evictStaleBodyCache() FeedModel {
+	live := make(map[string]bool, len(m.posts))
+	for _, p := range m.posts {
+		live[p.ID] = true
+	}
+	for id := range m.bodyCache {
+		if !live[id] {
+			delete(m.bodyCache, id)
+		}
+	}
+	return m
 }
 
 func (m FeedModel) renderPost(p model.Post, selected bool) (string, []postImageSlot) {

--- a/internal/ui/screens/feed_internal_test.go
+++ b/internal/ui/screens/feed_internal_test.go
@@ -1,0 +1,27 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/ragnar/cyber-tui/internal/model"
+)
+
+// TestFeedSetPosts_EvictsStaleBodyCache guards against bodyCache (keyed by
+// post ID, populated in renderPost) growing for the life of the session —
+// SetPosts wholesale-replacing m.posts is the only point a post can
+// permanently drop out of the loaded list, so that's where stale cache
+// entries must be dropped too.
+func TestFeedSetPosts_EvictsStaleBodyCache(t *testing.T) {
+	m := NewFeedModel()
+	m.bodyCache["gone"] = feedBodyCacheEntry{body: "stale"}
+	m.bodyCache["kept"] = feedBodyCacheEntry{body: "fresh"}
+
+	m = m.SetPosts([]model.Post{{ID: "kept"}}, "")
+
+	if _, ok := m.bodyCache["gone"]; ok {
+		t.Error("expected bodyCache entry for a post no longer in m.posts to be evicted")
+	}
+	if _, ok := m.bodyCache["kept"]; !ok {
+		t.Error("expected bodyCache entry for a post still in m.posts to survive")
+	}
+}

--- a/internal/ui/screens/render.go
+++ b/internal/ui/screens/render.go
@@ -441,6 +441,25 @@ func renderDeletedTombstone(username, ts string, viewportWidth int) string {
 	return prefix + theme.Subtle.Render(plainBody) + strings.Repeat(" ", pad) + theme.Subtle.Render(ts) + "\n"
 }
 
+// chatBodyCacheEntry is a memoized single-message renderCircMessagesStyled
+// result plus the inputs it was computed from, so a stale hit (width resize,
+// theme switch, reveal toggle, mute change, inline-images setting, or an
+// edited/tombstoned body) can be detected and recomputed instead of served.
+// Never populated for messages with an animated style (see hasAnimatedStyle)
+// — those must redraw every animation frame regardless.
+type chatBodyCacheEntry struct {
+	rendered            string
+	width               int
+	currentUser         string
+	timeDisplayFormat   string
+	revealed            bool
+	muted               bool
+	inlineImagesEnabled bool
+	body                string
+	deleted             bool
+	themeName           string
+}
+
 // renderCircMessagesWithSelection renders msgs exactly like renderCircMessages
 // (byte-identical when selectedID == ""), additionally returning each
 // message's start-line offset and rendered line-height (1:1 with msgs, so
@@ -464,7 +483,7 @@ func renderDeletedTombstone(username, ts string, viewportWidth int) string {
 // matching postImageSlot's convention elsewhere. realRows (keyed by
 // circMsgImageKey) supplies each image's already-known real row count, if
 // any — see chatImageBandRows.
-func renderCircMessagesWithSelection(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, selectedID string, revealed map[string]bool, frame int, muted map[string]bool, inlineImagesEnabled bool, realRows map[string]int) (content string, offsets []int, heights []int, imgSlots [][]postImageSlot) {
+func renderCircMessagesWithSelection(msgs []model.Message, loc *time.Location, timeDisplayFormat string, viewportWidth int, currentUser string, selectedID string, revealed map[string]bool, frame int, muted map[string]bool, inlineImagesEnabled bool, realRows map[string]int, cache map[string]chatBodyCacheEntry) (content string, offsets []int, heights []int, imgSlots [][]postImageSlot) {
 	offsets = make([]int, len(msgs))
 	heights = make([]int, len(msgs))
 	imgSlots = make([][]postImageSlot, len(msgs))
@@ -480,7 +499,30 @@ func renderCircMessagesWithSelection(msgs []model.Message, loc *time.Location, t
 				renderMsg = sanitizeChatMessageForInlineImage(msg, url)
 			}
 		}
-		rendered := renderCircMessagesStyled([]model.Message{renderMsg}, loc, timeDisplayFormat, viewportWidth, currentUser, revealed, frame, muted)
+		animated := hasAnimatedStyle(msg.Style)
+		muteState := muted[strings.ToLower(msg.From.Username)]
+		revealState := revealed[msg.ID]
+		themeName := theme.CurrentName()
+
+		rendered, ok := "", false
+		if !animated {
+			if e, hit := cache[msg.ID]; hit && e.width == viewportWidth && e.currentUser == currentUser &&
+				e.timeDisplayFormat == timeDisplayFormat && e.revealed == revealState && e.muted == muteState &&
+				e.inlineImagesEnabled == inlineImagesEnabled && e.body == msg.Body && e.deleted == msg.Deleted &&
+				e.themeName == themeName {
+				rendered, ok = e.rendered, true
+			}
+		}
+		if !ok {
+			rendered = renderCircMessagesStyled([]model.Message{renderMsg}, loc, timeDisplayFormat, viewportWidth, currentUser, revealed, frame, muted)
+			if !animated && cache != nil {
+				cache[msg.ID] = chatBodyCacheEntry{
+					rendered: rendered, width: viewportWidth, currentUser: currentUser,
+					timeDisplayFormat: timeDisplayFormat, revealed: revealState, muted: muteState,
+					inlineImagesEnabled: inlineImagesEnabled, body: msg.Body, deleted: msg.Deleted, themeName: themeName,
+				}
+			}
+		}
 		if selectedID != "" && msg.ID == selectedID {
 			plain := strings.TrimSuffix(ansi.Strip(rendered), "\n")
 			rendered = theme.SelectedRow.Width(viewportWidth).Render(plain) + "\n"

--- a/internal/ui/screens/render_test.go
+++ b/internal/ui/screens/render_test.go
@@ -713,7 +713,7 @@ func TestRenderCircMessagesWithSelection_MutedSenderKeepsOffsetsAligned(t *testi
 	msgs := []model.Message{muted, visible}
 
 	content, offsets, heights, _ := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "", "", nil, 0,
-		map[string]bool{"alice": true}, false, nil)
+		map[string]bool{"alice": true}, false, nil, nil)
 
 	if len(offsets) != len(msgs) || len(heights) != len(msgs) {
 		t.Fatalf("offsets/heights not 1:1 with msgs: len(offsets)=%d len(heights)=%d want %d", len(offsets), len(heights), len(msgs))
@@ -874,8 +874,8 @@ func TestRenderCircMessagesWithSelection_HighlightsImageBandWhenSelected(t *test
 	msg.ImageUrl = "https://example.com/a.png"
 	msgs := []model.Message{msg}
 
-	unselected, _, unselHeights, unselSlots := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "alice", "", nil, 0, nil, true, nil)
-	selected, _, selHeights, selSlots := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "alice", "m1", nil, 0, nil, true, nil)
+	unselected, _, unselHeights, unselSlots := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "alice", "", nil, 0, nil, true, nil, nil)
+	selected, _, selHeights, selSlots := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "alice", "m1", nil, 0, nil, true, nil, nil)
 
 	if unselHeights[0] != selHeights[0] {
 		t.Errorf("heights differ between selected/unselected: %d vs %d, want equal", unselHeights[0], selHeights[0])
@@ -895,6 +895,102 @@ func TestRenderCircMessagesWithSelection_HighlightsImageBandWhenSelected(t *test
 	}
 	if !strings.Contains(selLines[bandStart], "\x1b[") {
 		t.Errorf("expected the selected message's image band to carry the SelectedRow background escape, got plain %q", selLines[bandStart])
+	}
+}
+
+// --- chatBodyCache ---
+
+// TestRenderCircMessagesWithSelection_UsesCachedBodyOnHit guards the whole
+// point of chatBodyCache: a matching entry must be served as-is instead of
+// re-rendered, since refreshMessages() calls this on every 150ms animation
+// tick and re-parsing/re-styling every held message on every tick is what
+// makes a long-lived room CPU-bound on weak hardware. Seeds a cache entry
+// with a sentinel body distinct from what a real render would ever produce,
+// so a passing test proves the cached value was actually served.
+func TestRenderCircMessagesWithSelection_UsesCachedBodyOnHit(t *testing.T) {
+	const width = 60
+	msg := circMsg("bob", "hi from bob")
+	msg.ID = "m1"
+	msgs := []model.Message{msg}
+
+	cache := map[string]chatBodyCacheEntry{
+		"m1": {
+			rendered:          "CACHED-SENTINEL\n",
+			width:             width,
+			currentUser:       "alice",
+			timeDisplayFormat: "datetime",
+			body:              msg.Body,
+			themeName:         theme.CurrentName(),
+		},
+	}
+
+	content, _, _, _ := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "alice", "", nil, 0, nil, false, nil, cache)
+
+	if !strings.Contains(content, "CACHED-SENTINEL") {
+		t.Errorf("expected the matching cache entry to be reused, got: %q", content)
+	}
+}
+
+// TestRenderCircMessagesWithSelection_StaleCacheEntryIsRecomputed guards the
+// invalidation side of the same mechanism: a cache entry whose body no
+// longer matches the message (e.g. after an edit or delete-tombstone) must
+// not be served.
+func TestRenderCircMessagesWithSelection_StaleCacheEntryIsRecomputed(t *testing.T) {
+	const width = 60
+	msg := circMsg("bob", "hi from bob")
+	msg.ID = "m1"
+	msgs := []model.Message{msg}
+
+	cache := map[string]chatBodyCacheEntry{
+		"m1": {
+			rendered:          "CACHED-SENTINEL\n",
+			width:             width,
+			currentUser:       "alice",
+			timeDisplayFormat: "datetime",
+			body:              "a different body than msg.Body",
+			themeName:         theme.CurrentName(),
+		},
+	}
+
+	content, _, _, _ := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "alice", "", nil, 0, nil, false, nil, cache)
+
+	if strings.Contains(content, "CACHED-SENTINEL") {
+		t.Errorf("expected a stale cache entry (body mismatch) to be recomputed, not reused, got: %q", content)
+	}
+	if !strings.Contains(content, "hi from bob") {
+		t.Errorf("expected the message's real body in freshly rendered output, got: %q", content)
+	}
+}
+
+// TestRenderCircMessagesWithSelection_AnimatedMessageNeverCached guards
+// against the animation-skips-the-cache rule silently regressing — an
+// animated-style message must never be served from (or written to) the
+// cache, since its rendered output legitimately changes every frame.
+func TestRenderCircMessagesWithSelection_AnimatedMessageNeverCached(t *testing.T) {
+	const width = 60
+	msg := circMsg("bob", "hi from bob")
+	msg.ID = "m1"
+	msg.Style = []string{styleBlink}
+	msgs := []model.Message{msg}
+
+	cache := map[string]chatBodyCacheEntry{
+		"m1": {
+			rendered:          "CACHED-SENTINEL\n",
+			width:             width,
+			currentUser:       "alice",
+			timeDisplayFormat: "datetime",
+			body:              msg.Body,
+			themeName:         theme.CurrentName(),
+		},
+	}
+
+	content, _, _, _ := renderCircMessagesWithSelection(msgs, time.UTC, "datetime", width, "alice", "", nil, 0, nil, false, nil, cache)
+
+	if strings.Contains(content, "CACHED-SENTINEL") {
+		t.Errorf("expected an animated-style message to bypass the cache entirely, got: %q", content)
+	}
+	if e, hit := cache["m1"]; !hit || e.rendered != "CACHED-SENTINEL\n" {
+		t.Errorf("expected the pre-existing cache entry to be left untouched, not overwritten, for an animated message")
 	}
 }
 
@@ -949,7 +1045,7 @@ func BenchmarkRenderCircMessagesWithSelection(b *testing.B) {
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				renderCircMessagesWithSelection(msgs, time.UTC, "datetime", 80, "alice", "", nil, 0, nil, false, nil)
+				renderCircMessagesWithSelection(msgs, time.UTC, "datetime", 80, "alice", "", nil, 0, nil, false, nil, nil)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Two related memory/CPU-management fixes for long-running sessions:

1. **C-Mail / Feed unbounded caches** — `CMailModel` never capped its live
   message buffer the way `ChatroomsModel` already does, and both
   `CMailModel.imageRealRows` and `FeedModel.bodyCache` grew for the life of
   a session with no eviction. C-Mail now trims its message buffer the same
   way cIRC does (mirroring `trimMessageBuffer`/`estimatedMessageSize`),
   `imageRealRows` resets on conversation switch, and `bodyCache` evicts
   entries for posts no longer loaded.

2. **cIRC progressive slowdown (Raspberry Pi 3 report)** — a user reported
   the app becomes unusably slow after leaving cIRC open for a full day on a
   Pi 3 (2 GB RAM), needing a restart. Root cause: `refreshMessages()`
   unconditionally re-renders *every* message in the buffer on every call,
   including on every 150ms style-animation tick for as long as an
   animated-style message (`/blink`, `/wave`, `/glitch`) stays visible. Since
   the buffer is already capped at 2 MiB, a long-lived room sits near that
   ceiling most of the day — meaning ~6.7 full-buffer re-renders/sec, each
   redoing markdown+lipgloss work for up to thousands of unchanged messages.
   Fixed by adding a per-message render cache (`chatBodyCache`, mirroring
   `FeedModel.bodyCache`), skipped only for animated-style messages.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` all clean.
- `go test ./...` — all passing.
- 10 new unit tests covering: message-buffer trim + selection-clear +
  cache eviction on both trim and conversation/room switch, cache hit reuse,
  stale-entry invalidation, and animated messages always bypassing the
  cache.

| Group | Tests | Result |
|---|---|---|
| CMail message buffer cap | 3 | Pass |
| CMail imageRealRows reset | 1 | Pass |
| Feed bodyCache eviction | 1 | Pass |
| cIRC chatBodyCache (hit/stale/animated) | 3 | Pass |
| cIRC chatBodyCache eviction (trim/SetMessages) | 2 | Pass |
| Full existing suite | all | Pass |

## Notes

No new screens, types, API methods, or keyboard shortcuts — internal
performance/memory hardening only, so no `docs/XX-feature-name.md` page was
added. Docs backlog/API reference untouched (no API surface changes).
