### PR TITLE
fix: load saved display preferences regardless of login method

### DIFF
--- a/cmd/cyber-tui/main.go
+++ b/cmd/cyber-tui/main.go
@@ -113,7 +113,7 @@ func main() {
 		log.Printf("imgview: KITTY_WINDOW_ID=%q TERM_PROGRAM=%q TERM=%q -> graphicsProtocol=%v",
 			os.Getenv("KITTY_WINDOW_ID"), os.Getenv("TERM_PROGRAM"), os.Getenv("TERM"), gfxProto)
 	}
-	app := ui.NewApp(newClient()).WithGraphicsProtocol(gfxProto)
+	app := ui.NewApp(newClient()).WithGraphicsProtocol(gfxProto).WithSavedPreferences(cfg)
 	// Prefer saved session (token-based) over autoEmail/autoPassword credentials.
 	if cfg.RefreshToken != "" {
 		app = app.WithSavedSession(cfg)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -104,12 +104,7 @@ type App struct {
 	client      api.Client
 	tokens      model.Tokens
 	currentUser model.User
-	// ownApprenticeSlugs are the logged-in user's apprenticed guild slugs
-	// (from GetUserGuilds on their own username), used to order the Guilds
-	// tab — separate from ProfileModel's apprenticeships, which get
-	// overwritten when viewing another user's profile.
-	ownApprenticeSlugs []string
-	active             screen
+	active      screen
 	focus       focusTarget
 	width       int
 	height      int
@@ -862,7 +857,7 @@ func (a App) updateAll(msg tea.Msg) App {
 // Call this whenever loc, relaxed, or dimensions change outside of a
 // WindowSizeMsg (e.g. after login, timezone change, or density toggle).
 func (a *App) broadcastConfig() {
-	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), Dithering: a.dithering, DitherSharpness: a.ditherSharpness, OwnGuildSlug: a.currentUser.GuildSlug, OwnApprenticeSlugs: a.ownApprenticeSlugs, LayoutName: a.layoutName}
+	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), Dithering: a.dithering, DitherSharpness: a.ditherSharpness, OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
 	*a = a.updateAll(msg)
 }
 
@@ -1437,10 +1432,6 @@ func (a App) handleProfile(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, a.loadUserGuildsCmd(msg.user.Username), true
 
 	case userGuildsLoadedMsg:
-		if msg.username == a.currentUser.Username {
-			a.ownApprenticeSlugs = apprenticeSlugsFrom(msg.guilds)
-			a.guilds = a.guilds.SetOwnApprenticeSlugs(a.ownApprenticeSlugs)
-		}
 		if msg.username != a.profile.Username() {
 			return a, nil, true // stale response from a since-abandoned profile switch
 		}
@@ -4576,18 +4567,6 @@ func (a *App) loadUserProfileCmd(username string) tea.Cmd {
 type userGuildsLoadedMsg struct {
 	username string
 	guilds   []model.GuildMembership
-}
-
-// apprenticeSlugsFrom extracts the apprentice-role guild slugs from a user's
-// GetUserGuilds result, used to order the Guilds tab.
-func apprenticeSlugsFrom(memberships []model.GuildMembership) []string {
-	var slugs []string
-	for _, gm := range memberships {
-		if gm.Role == "apprentice" {
-			slugs = append(slugs, gm.Slug)
-		}
-	}
-	return slugs
 }
 
 func (a *App) loadUserGuildsCmd(username string) tea.Cmd {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -104,7 +104,12 @@ type App struct {
 	client      api.Client
 	tokens      model.Tokens
 	currentUser model.User
-	active      screen
+	// ownApprenticeSlugs are the logged-in user's apprenticed guild slugs
+	// (from GetUserGuilds on their own username), used to order the Guilds
+	// tab — separate from ProfileModel's apprenticeships, which get
+	// overwritten when viewing another user's profile.
+	ownApprenticeSlugs []string
+	active             screen
 	focus       focusTarget
 	width       int
 	height      int
@@ -606,11 +611,12 @@ func (a App) WithAutoLogin(email, password string) App {
 	return a
 }
 
-// WithSavedSession attaches a persisted session loaded from ~/.cyber-tui.json.
-// When set, Init attempts to resume the session via token refresh instead of
-// showing the login screen.
-func (a App) WithSavedSession(s config.Config) App {
-	a.savedSession = &s
+// WithSavedPreferences loads display/behavior preferences from a persisted
+// config. Unlike WithSavedSession, this does not require a refresh token, so
+// it must be applied on every launch regardless of login method — otherwise
+// a token-expiry relogin silently resets these to zero values in memory,
+// and a later Settings save clobbers the real values on disk.
+func (a App) WithSavedPreferences(s config.Config) App {
 	a.relaxed = s.Density == "relaxed"
 	a.timezone = s.Timezone
 	a.loc = s.GetLocation()
@@ -625,6 +631,15 @@ func (a App) WithSavedSession(s config.Config) App {
 	a.layoutName = s.Layout
 	a.layout = layoutFromName(s.Layout)
 	a.customPalette = s.CustomPalette
+	return a
+}
+
+// WithSavedSession attaches a persisted session loaded from ~/.cyber-tui.json.
+// When set, Init attempts to resume the session via token refresh instead of
+// showing the login screen.
+func (a App) WithSavedSession(s config.Config) App {
+	a.savedSession = &s
+	a = a.WithSavedPreferences(s)
 	return a
 }
 
@@ -847,7 +862,7 @@ func (a App) updateAll(msg tea.Msg) App {
 // Call this whenever loc, relaxed, or dimensions change outside of a
 // WindowSizeMsg (e.g. after login, timezone change, or density toggle).
 func (a *App) broadcastConfig() {
-	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), Dithering: a.dithering, DitherSharpness: a.ditherSharpness, OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
+	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), Dithering: a.dithering, DitherSharpness: a.ditherSharpness, OwnGuildSlug: a.currentUser.GuildSlug, OwnApprenticeSlugs: a.ownApprenticeSlugs, LayoutName: a.layoutName}
 	*a = a.updateAll(msg)
 }
 
@@ -1422,6 +1437,10 @@ func (a App) handleProfile(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, a.loadUserGuildsCmd(msg.user.Username), true
 
 	case userGuildsLoadedMsg:
+		if msg.username == a.currentUser.Username {
+			a.ownApprenticeSlugs = apprenticeSlugsFrom(msg.guilds)
+			a.guilds = a.guilds.SetOwnApprenticeSlugs(a.ownApprenticeSlugs)
+		}
 		if msg.username != a.profile.Username() {
 			return a, nil, true // stale response from a since-abandoned profile switch
 		}
@@ -4557,6 +4576,18 @@ func (a *App) loadUserProfileCmd(username string) tea.Cmd {
 type userGuildsLoadedMsg struct {
 	username string
 	guilds   []model.GuildMembership
+}
+
+// apprenticeSlugsFrom extracts the apprentice-role guild slugs from a user's
+// GetUserGuilds result, used to order the Guilds tab.
+func apprenticeSlugsFrom(memberships []model.GuildMembership) []string {
+	var slugs []string
+	for _, gm := range memberships {
+		if gm.Role == "apprentice" {
+			slugs = append(slugs, gm.Slug)
+		}
+	}
+	return slugs
 }
 
 func (a *App) loadUserGuildsCmd(username string) tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -5212,3 +5212,32 @@ func TestHandleSettings_ChangingGraphicsProtocolOverrideReResolves(t *testing.T)
 		t.Errorf("graphicsProtocol = %v after changing the override to kitty, want ProtocolKitty", a2.graphicsProtocol)
 	}
 }
+
+// TestWithSavedPreferences_LoadsWithoutRefreshToken guards against a
+// regression where display preferences (graphics protocol, dithering,
+// thread depth, timezone) were only loaded via WithSavedSession, which
+// requires a refresh token. A normal token-expiry relogin clears the token
+// on disk but leaves the rest of the saved config intact; preferences must
+// still load on the WithAutoLogin/WithSavedEmail paths too.
+func TestWithSavedPreferences_LoadsWithoutRefreshToken(t *testing.T) {
+	cfg := config.Config{
+		GraphicsProtocol: "sixel",
+		Dithering:        true,
+		MaxThreadDepth:   20,
+		Timezone:         "UTC+2",
+	}
+
+	a := newTestApp().WithAutoLogin("user@example.com", "pw").WithSavedPreferences(cfg)
+	if a.graphicsProtocolName != "sixel" {
+		t.Errorf("graphicsProtocolName = %q, want sixel", a.graphicsProtocolName)
+	}
+	if !a.dithering {
+		t.Error("dithering = false, want true")
+	}
+	if a.maxThreadDepth != 20 {
+		t.Errorf("maxThreadDepth = %d, want 20", a.maxThreadDepth)
+	}
+	if a.timezone != "UTC+2" {
+		t.Errorf("timezone = %q, want UTC+2", a.timezone)
+	}
+}


### PR DESCRIPTION
## Problem

Display preferences (`graphicsProtocol`/sixel, `dithering`, `maxThreadDepth`, `timezone`, `layout`, etc.) intermittently reset to defaults on disk.

## Root cause

`WithSavedSession` was the only place that copied display preferences from `~/.cyber-tui.json` into the running `App`, and it only ran when `cfg.RefreshToken != ""`. A normal token-expiry/revocation clears the refresh token on disk via `handleUnauthorized`, but leaves the rest of the saved config intact. On the next launch the app took the `WithAutoLogin`/`WithSavedEmail` branch instead, so preference fields stayed at Go zero values in memory even though the file on disk was still correct. A later Settings save then wrote the zeroed values back, clobbering the real saved settings.

## Fix

Extracted preference loading into `App.WithSavedPreferences()` and apply it unconditionally in `main.go`, regardless of which login branch runs. `WithSavedSession` now delegates to it.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean
- `go test ./...` — all pass
- New regression test: `TestWithSavedPreferences_LoadsWithoutRefreshToken`
