### PR TITLE
feat: float own/apprenticed guilds to top of Guilds list

### DIFF
--- a/docs/29-guilds.md
+++ b/docs/29-guilds.md
@@ -18,9 +18,9 @@ feed | notifications | journal | bookmarks | guilds | topics | profile | setting
 
 ### Guild list (default view)
 
-Displays all guilds that have at least one member, sorted by member count (most populated first). Each row shows:
+Displays all guilds that have at least one member, in the order the API returns them (member count, most populated first), except the logged-in user's own guilds are floated to the top: their badge guild first, then any guilds they're apprenticed to (ordered by member count), then the rest of the list unchanged. Each row shows:
 
-- Guild icon (emoji; plain-text icon names from the API fall back to `◆`)
+- Guild icon (emoji; plain-text icon names from the API fall back to `◆`, or to `★`/`☆` for the user's badge guild / an apprenticed guild)
 - Guild name (highlighted when selected)
 - Member count (right-aligned)
 - Bio (second line, truncated to stay clear of the member count; omitted when empty)
@@ -100,9 +100,9 @@ After a successful post the thread list reloads.
 - `internal/model/types.go` — `Guild` struct (`IsMember`, `Role`, `ApprenticeCount`); `GuildMember` struct; `GuildMembership` struct (per-user guilds list)
 - `internal/api/interface.go` — `GetGuilds`, `GetGuild`, `GetGuildPosts`, `CreateGuildPost`, `GetGuildMembers`, `GetUserGuilds`, `JoinGuild`, `LeaveGuild`, `PromoteGuild`
 - `internal/api/client.go` — wire types and HTTP implementations
-- `internal/ui/screens/guilds.go` — `GuildsModel` (three-view screen + embedded `PostComposePanel`)
+- `internal/ui/screens/guilds.go` — `GuildsModel` (three-view screen + embedded `PostComposePanel`); `sortGuildsForDisplay` floats the user's badge guild then apprenticeships (by member count) to the top of the list; `SetOwnGuildSlug`/`SetOwnApprenticeSlugs` re-sort on membership changes
 - `internal/ui/screens/profile.go` — apprenticeships row on the Info tab (`SetApprenticeships`)
-- `internal/ui/app.go` — `screenGuilds` enum, `handleGuilds`, load/create/promote commands, menu wiring
+- `internal/ui/app.go` — `screenGuilds` enum, `handleGuilds`, load/create/promote commands, menu wiring; `ownApprenticeSlugs` (from the logged-in user's own `GetUserGuilds`, distinct from whichever profile `ProfileModel` currently has apprenticeships loaded for) feeds the Guilds tab ordering via `SharedConfigMsg.OwnApprenticeSlugs`
 
 ## Known limitations / out of scope
 

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -2,6 +2,8 @@ package screens
 
 import (
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -112,19 +114,20 @@ type GuildsModel struct {
 	guildsExhausted  bool
 
 	// Guild posts state
-	activeGuild       string
-	activeGuildDetail model.Guild
-	guildDetailLoaded bool
-	confirming        guildsConfirm
-	ownGuildSlug      string // logged-in user's current guild membership (empty = no guild)
-	posts             []model.Post
-	postIndex         int
-	nextCursor        string
-	exhausted         bool
-	loading           bool
-	fetching          bool
-	refreshing        bool
-	loaded            bool
+	activeGuild        string
+	activeGuildDetail  model.Guild
+	guildDetailLoaded  bool
+	confirming         guildsConfirm
+	ownGuildSlug       string   // logged-in user's current guild membership (empty = no guild)
+	ownApprenticeSlugs []string // logged-in user's apprenticed guild slugs
+	posts              []model.Post
+	postIndex          int
+	nextCursor         string
+	exhausted          bool
+	loading            bool
+	fetching           bool
+	refreshing         bool
+	loaded             bool
 
 	// Guild members state
 	members           []model.GuildMember
@@ -186,9 +189,9 @@ func (m GuildsModel) visiblePosts() []model.Post {
 }
 
 // ComposeActive reports whether the new-thread compose panel is open.
-func (m GuildsModel) ComposeActive() bool            { return m.panel.IsActive() }
-func (m GuildsModel) ComposeHeight() int             { return m.panel.PanelHeight() }
-func (m GuildsModel) ComposeView(width int) string   { return m.panel.SetWidth(width).View() }
+func (m GuildsModel) ComposeActive() bool          { return m.panel.IsActive() }
+func (m GuildsModel) ComposeHeight() int           { return m.panel.PanelHeight() }
+func (m GuildsModel) ComposeView(width int) string { return m.panel.SetWidth(width).View() }
 
 // ActiveGuild returns the slug of the guild whose posts are currently displayed, or "" when in list view.
 func (m GuildsModel) ActiveGuild() string { return m.activeGuild }
@@ -217,7 +220,7 @@ func (m GuildsModel) SetFetching() GuildsModel {
 // SetGuilds replaces the guild list with a fresh page.
 func (m GuildsModel) SetGuilds(items []model.Guild, cursor string) GuildsModel {
 	m.err = nil
-	m.guilds = items
+	m.guilds = sortGuildsForDisplay(items, m.ownGuildSlug, m.ownApprenticeSlugs)
 	m.guildIndex = 0
 	m.guildsNextCursor = cursor
 	m.guildsExhausted = cursor == ""
@@ -334,7 +337,65 @@ func (m GuildsModel) IsDetailLoaded() bool { return m.guildDetailLoaded }
 // requiring a full SharedConfigMsg broadcast.
 func (m GuildsModel) SetOwnGuildSlug(slug string) GuildsModel {
 	m.ownGuildSlug = slug
+	m.guilds = sortGuildsForDisplay(m.guilds, m.ownGuildSlug, m.ownApprenticeSlugs)
+	if m.ready {
+		m = m.refreshContent()
+	}
 	return m
+}
+
+// SetOwnApprenticeSlugs updates the logged-in user's apprenticed guild slugs
+// and re-sorts the already-loaded guild list. Called by app.go directly
+// after fetching the user's own guild memberships, mirroring SetOwnGuildSlug.
+func (m GuildsModel) SetOwnApprenticeSlugs(slugs []string) GuildsModel {
+	m.ownApprenticeSlugs = slugs
+	m.guilds = sortGuildsForDisplay(m.guilds, m.ownGuildSlug, m.ownApprenticeSlugs)
+	if m.ready {
+		m = m.refreshContent()
+	}
+	return m
+}
+
+// sortGuildsForDisplay floats the user's own guild to the top, followed by
+// apprenticed guilds (ordered by member count), then the rest in the order
+// the server returned them.
+func sortGuildsForDisplay(guilds []model.Guild, ownSlug string, apprenticeSlugs []string) []model.Guild {
+	apprentice := make(map[string]struct{}, len(apprenticeSlugs))
+	for _, s := range apprenticeSlugs {
+		apprentice[s] = struct{}{}
+	}
+	rank := func(g model.Guild) int {
+		if ownSlug != "" && g.Slug == ownSlug {
+			return 0
+		}
+		if _, ok := apprentice[g.Slug]; ok {
+			return 1
+		}
+		return 2
+	}
+	sorted := append([]model.Guild(nil), guilds...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ri, rj := rank(sorted[i]), rank(sorted[j])
+		if ri != rj {
+			return ri < rj
+		}
+		if ri == 1 {
+			return sorted[i].MemberCount > sorted[j].MemberCount
+		}
+		return false
+	})
+	return sorted
+}
+
+// isOwnGuild reports whether slug is the logged-in user's badge guild.
+func (m GuildsModel) isOwnGuild(slug string) bool {
+	return m.ownGuildSlug != "" && slug == m.ownGuildSlug
+}
+
+// isApprenticeGuild reports whether slug is one of the logged-in user's
+// apprenticed guilds.
+func (m GuildsModel) isApprenticeGuild(slug string) bool {
+	return slices.Contains(m.ownApprenticeSlugs, slug)
 }
 
 // IsConfirmingJoin reports whether the join confirmation prompt is active.
@@ -381,6 +442,8 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 			m.postIndex = 0
 		}
 		m.ownGuildSlug = msg.OwnGuildSlug
+		m.ownApprenticeSlugs = msg.OwnApprenticeSlugs
+		m.guilds = sortGuildsForDisplay(m.guilds, m.ownGuildSlug, m.ownApprenticeSlugs)
 		m.inlineImagesEnabled = msg.InlineImagesEnabled
 		if m.ready {
 			m = m.refreshContent()
@@ -936,7 +999,18 @@ func (m GuildsModel) renderGuildItem(index int) string {
 		subtleStyle = theme.Base
 	}
 
+	isOwn := m.isOwnGuild(guild.Slug)
+	isApprentice := !isOwn && m.isApprenticeGuild(guild.Slug)
+
 	iconStr := guildIcon(guild.Icon)
+	if iconStr == "◆" {
+		switch {
+		case isOwn:
+			iconStr = "★"
+		case isApprentice:
+			iconStr = "☆"
+		}
+	}
 	icon := subtleStyle.Render(iconStr) + " "
 	iconW := lipgloss.Width(icon)
 
@@ -1224,7 +1298,7 @@ func (m GuildsModel) GetFocusedURLs() []string {
 func (m GuildsModel) IsViewingGuildPosts() bool { return m.view == viewGuildPosts }
 
 func (m GuildsModel) IsCompactListActive() bool { return m.IsViewingGuildPosts() }
-func (m GuildsModel) ListTitle() string          { return "posts (◆ " + m.ActiveGuildName() + ")" }
+func (m GuildsModel) ListTitle() string         { return "posts (◆ " + m.ActiveGuildName() + ")" }
 
 // ActiveGuildName returns the display name of the active guild, falling back to the slug if detail has not yet loaded.
 func (m GuildsModel) ActiveGuildName() string {

--- a/internal/ui/screens/guilds_test.go
+++ b/internal/ui/screens/guilds_test.go
@@ -1,6 +1,7 @@
 package screens_test
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -93,6 +94,71 @@ func TestGuildsModel_AppendGuilds_AddsItems(t *testing.T) {
 	m = m.AppendGuilds(extra, "")
 	if !m.IsLoaded() {
 		t.Error("model should remain loaded after AppendGuilds")
+	}
+}
+
+// --- Ordering by membership ---
+
+func orderedGuilds() []model.Guild {
+	return []model.Guild{
+		{ID: "g1", Name: "Alpha", Slug: "alpha", MemberCount: 100},
+		{ID: "g2", Name: "Beta", Slug: "beta", MemberCount: 50},
+		{ID: "g3", Name: "Gamma", Slug: "gamma", MemberCount: 10},
+		{ID: "g4", Name: "Delta", Slug: "delta", MemberCount: 30},
+	}
+}
+
+func guildViewWithSize(m screens.GuildsModel) screens.GuildsModel {
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	return m
+}
+
+func TestGuildsModel_SetGuilds_OwnGuildFirst(t *testing.T) {
+	t.Helper()
+	m := guildViewWithSize(screens.NewGuildsModel())
+	m = m.SetOwnGuildSlug("gamma")
+	m = m.SetGuilds(orderedGuilds(), "")
+
+	view := m.View()
+	if got, want := strings.Index(view, "Gamma"), strings.Index(view, "Alpha"); got == -1 || want == -1 || got > want {
+		t.Errorf("Gamma (own guild) should render before Alpha; Gamma at %d, Alpha at %d", got, want)
+	}
+}
+
+func TestGuildsModel_SetGuilds_ApprenticesOrderedByMemberCount(t *testing.T) {
+	t.Helper()
+	m := guildViewWithSize(screens.NewGuildsModel())
+	m = m.SetOwnApprenticeSlugs([]string{"delta", "beta"}) // beta(50) should outrank delta(30)
+	m = m.SetGuilds(orderedGuilds(), "")
+
+	view := m.View()
+	betaPos := strings.Index(view, "Beta")
+	deltaPos := strings.Index(view, "Delta")
+	alphaPos := strings.Index(view, "Alpha")
+	if betaPos == -1 || deltaPos == -1 || alphaPos == -1 {
+		t.Fatal("expected all guild names present in view")
+	}
+	if betaPos > deltaPos {
+		t.Errorf("Beta (50 members) should render before Delta (30 members) among apprenticed guilds")
+	}
+	if deltaPos > alphaPos {
+		t.Errorf("apprenticed guilds should render before non-member guilds")
+	}
+}
+
+func TestGuildsModel_RenderGuildItem_ShowsMembershipIcons(t *testing.T) {
+	t.Helper()
+	m := guildViewWithSize(screens.NewGuildsModel())
+	m = m.SetOwnGuildSlug("alpha")
+	m = m.SetOwnApprenticeSlugs([]string{"beta"})
+	m = m.SetGuilds(orderedGuilds(), "")
+
+	view := m.View()
+	if !strings.Contains(view, "★") {
+		t.Error("expected own guild's icon swapped to ★")
+	}
+	if !strings.Contains(view, "☆") {
+		t.Error("expected apprenticed guild's icon swapped to ☆")
 	}
 }
 

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -64,7 +64,11 @@ type SharedConfigMsg struct {
 	// settings screen to display/edit the enum.
 	DitherSharpness string
 	OwnGuildSlug    string
-	LayoutName      string // "tabs" or "miller"; used by settings screen to show current value
+	// OwnApprenticeSlugs are the logged-in user's apprenticed guild slugs
+	// (from GET /v1/users/:username/guilds, Role == "apprentice"), used by
+	// the Guilds screen to float those guilds toward the top of the list.
+	OwnApprenticeSlugs []string
+	LayoutName         string // "tabs" or "miller"; used by settings screen to show current value
 }
 
 // URLProvider is implemented by screens that can expose URLs from their


### PR DESCRIPTION
## What

Floats the logged-in user's badge guild and apprenticed guilds to the top of the Guilds list, and marks them with a distinct icon (star / open star) in place of the generic fallback diamond.

## Details

- `sortGuildsForDisplay` re-orders the client-side list: own guild first, then apprenticed guilds (by member count), then the rest in server order (still member-count sorted).
- `SetOwnGuildSlug` / `SetOwnApprenticeSlugs` re-sort the already-loaded list in place so join/leave/promote actions update ordering without a full reload.
- `OwnApprenticeSlugs` threaded through `SharedConfigMsg`, sourced from the user's own `GetUserGuilds` call in app.go.
- Docs (`docs/29-guilds.md`) updated to describe the new ordering/icon behavior.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean
- `go test ./...` — all pass
- New tests: `TestGuildsModel_SetGuilds_OwnGuildFirst`, `TestGuildsModel_SetGuilds_ApprenticesOrderedByMemberCount`, `TestGuildsModel_RenderGuildItem_ShowsMembershipIcons`
