### PR TITLE
Release v0.8.6.2

### DIFF
--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -267,6 +267,7 @@ type SettingsModel struct {
 	originalDitherSharpness  string         // last saved baseline
 	layoutName               string         // live local config value ("tabs" or "miller")
 	originalLayoutName       string         // last saved baseline
+	prefsSeeded              bool           // whether the SharedConfigMsg preference fields above have been seeded once
 	cursor                   int
 	width                    int
 	height                   int
@@ -398,10 +399,18 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 	case SharedConfigMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		// Populate from shared config only on first load (when original is zero).
-		// Subsequent broadcasts preserve any unsaved edits.
+		// Populate settings from shared config only on first load (when original
+		// is zero). Subsequent broadcasts preserve any unsaved edits.
 		if m.original.TimeDisplayFormat == "" && (m.original.Notifications == model.NotificationPrefs{}) {
 			m = m.SetSettings(msg.Settings)
+		}
+		// prefsSeeded gates the preference fields below independently of the
+		// m.original guard above — SetSettings can run before this handler
+		// ever sees a SharedConfigMsg (see settingsLoadedMsg in app.go), which
+		// would otherwise trip a shared guard and skip seeding these fields,
+		// leaving them at zero values that later get saved back to disk.
+		if !m.prefsSeeded {
+			m.prefsSeeded = true
 			m.wanderLust = msg.WanderLust
 			m.originalWanderLust = msg.WanderLust
 			m.maxThreadDepth = msg.MaxThreadDepth

--- a/internal/ui/screens/settings_test.go
+++ b/internal/ui/screens/settings_test.go
@@ -393,6 +393,44 @@ func TestSettings_SharedConfigMsg_PreservesEditsOnRebroadcast(t *testing.T) {
 	}
 }
 
+// TestSettings_SharedConfigMsg_SeedsPrefsAfterSetSettings reproduces the
+// exact ordering app.go's settingsLoadedMsg handler uses: SetSettings(...)
+// runs first, then broadcastConfig() sends a SharedConfigMsg. A stale guard
+// tied to m.original's zero-ness (rather than a dedicated seeded flag) would
+// already be tripped by SetSettings, silently skipping the preference fields
+// below and leaving them zeroed — which then get saved back to disk.
+func TestSettings_SharedConfigMsg_SeedsPrefsAfterSetSettings(t *testing.T) {
+	m := NewSettingsModel()
+	m = m.SetSettings(defaultSettings())
+
+	m, _ = m.Update(SharedConfigMsg{
+		Width:            80,
+		Height:           24,
+		Settings:         defaultSettings(),
+		WanderLust:       true,
+		MaxThreadDepth:   20,
+		InlineImages:     true,
+		Dithering:        true,
+		GraphicsProtocol: "sixel",
+	})
+
+	if !m.wanderLust {
+		t.Error("wanderLust should be seeded from SharedConfigMsg even after a prior SetSettings call")
+	}
+	if m.maxThreadDepth != 20 {
+		t.Errorf("maxThreadDepth = %d, want 20", m.maxThreadDepth)
+	}
+	if !m.inlineImages {
+		t.Error("inlineImages should be seeded from SharedConfigMsg even after a prior SetSettings call")
+	}
+	if !m.dithering {
+		t.Error("dithering should be seeded from SharedConfigMsg even after a prior SetSettings call")
+	}
+	if m.graphicsProtocol != "sixel" {
+		t.Errorf("graphicsProtocol = %q, want sixel", m.graphicsProtocol)
+	}
+}
+
 // --- Setter Tests ---
 
 func TestSettings_SetSettings_SetsOriginal(t *testing.T) {


### PR DESCRIPTION
## Release v0.8.6.2

Incremental TUI release on top of v0.8.6.1.

## Changes

- fix: seed Settings display prefs (wander mode, thread depth, inline images, dithering, timezone, image viewer, graphics protocol, dither sharpness, layout) independently of the server-settings guard. A second, independent bug from the one fixed in v0.8.6.1: SettingsModel's local preference cache was gated by a guard tied to the server-side settings baseline, which tripped early and left preference fields at zero values that then got saved back to disk on the next settings change.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...`, `govulncheck ./...` — all clean
- `go test ./...` — all packages pass
- New regression test: `TestSettings_SharedConfigMsg_SeedsPrefsAfterSetSettings`
