### PR TITLE
fix: restore app.go wiring for guild apprentice-slug ordering

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -104,6 +104,11 @@ type App struct {
 	client      api.Client
 	tokens      model.Tokens
 	currentUser model.User
+	// ownApprenticeSlugs are the logged-in user's apprenticed guild slugs
+	// (from GetUserGuilds on their own username), used to order the Guilds
+	// tab — separate from ProfileModel's apprenticeships, which get
+	// overwritten when viewing another user's profile.
+	ownApprenticeSlugs []string
 	active      screen
 	focus       focusTarget
 	width       int
@@ -857,7 +862,7 @@ func (a App) updateAll(msg tea.Msg) App {
 // Call this whenever loc, relaxed, or dimensions change outside of a
 // WindowSizeMsg (e.g. after login, timezone change, or density toggle).
 func (a *App) broadcastConfig() {
-	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), Dithering: a.dithering, DitherSharpness: a.ditherSharpness, OwnGuildSlug: a.currentUser.GuildSlug, LayoutName: a.layoutName}
+	msg := screens.SharedConfigMsg{Width: a.layout.ContentWidth(a.width), Height: a.height, Loc: a.loc, Relaxed: a.relaxed, Settings: a.settings, WanderLust: a.wanderLust, MaxThreadDepth: a.maxThreadDepth, Timezone: a.timezone, ImageViewer: a.imageViewer, GraphicsProtocol: a.graphicsProtocolName, InlineImages: a.inlineImages, InlineImagesEnabled: a.canInlineImages(), Dithering: a.dithering, DitherSharpness: a.ditherSharpness, OwnGuildSlug: a.currentUser.GuildSlug, OwnApprenticeSlugs: a.ownApprenticeSlugs, LayoutName: a.layoutName}
 	*a = a.updateAll(msg)
 }
 
@@ -1432,6 +1437,10 @@ func (a App) handleProfile(msg tea.Msg) (App, tea.Cmd, bool) {
 		return a, a.loadUserGuildsCmd(msg.user.Username), true
 
 	case userGuildsLoadedMsg:
+		if msg.username == a.currentUser.Username {
+			a.ownApprenticeSlugs = apprenticeSlugsFrom(msg.guilds)
+			a.guilds = a.guilds.SetOwnApprenticeSlugs(a.ownApprenticeSlugs)
+		}
 		if msg.username != a.profile.Username() {
 			return a, nil, true // stale response from a since-abandoned profile switch
 		}
@@ -4567,6 +4576,18 @@ func (a *App) loadUserProfileCmd(username string) tea.Cmd {
 type userGuildsLoadedMsg struct {
 	username string
 	guilds   []model.GuildMembership
+}
+
+// apprenticeSlugsFrom extracts the apprentice-role guild slugs from a user's
+// GetUserGuilds result, used to order the Guilds tab.
+func apprenticeSlugsFrom(memberships []model.GuildMembership) []string {
+	var slugs []string
+	for _, gm := range memberships {
+		if gm.Role == "apprentice" {
+			slugs = append(slugs, gm.Slug)
+		}
+	}
+	return slugs
 }
 
 func (a *App) loadUserGuildsCmd(username string) tea.Cmd {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -5148,6 +5148,30 @@ func TestHandleGuilds_UserGuildsLoaded_GuardsOnUsernameMatch(t *testing.T) {
 	}
 }
 
+// TestHandleProfile_OwnGuildsLoaded_FeedsApprenticeSlugsToGuildsScreen is the
+// regression test for a real bug: this app.go wiring (ownApprenticeSlugs
+// field, its broadcastConfig plumbing, and apprenticeSlugsFrom) was dropped
+// entirely during an unrelated branch cleanup, leaving guilds.go's sort/icon
+// logic wired up but never fed real data — apprentice guilds silently never
+// floated to the top or got the ☆ icon, with no build failure to catch it.
+func TestHandleProfile_OwnGuildsLoaded_FeedsApprenticeSlugsToGuildsScreen(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case"}
+	a.profile = a.profile.SetUser(model.User{Username: "case"})
+	memberships := []model.GuildMembership{
+		{Slug: "deep-divers", Role: "apprentice"},
+		{Slug: "chrome-syndicate", Role: "member"},
+	}
+
+	a2, _, handled := a.handleProfile(userGuildsLoadedMsg{username: "case", guilds: memberships})
+	if !handled {
+		t.Fatal("expected handleProfile to handle userGuildsLoadedMsg")
+	}
+	if got := a2.ownApprenticeSlugs; len(got) != 1 || got[0] != "deep-divers" {
+		t.Errorf("ownApprenticeSlugs = %v, want [deep-divers]", got)
+	}
+}
+
 // TestHandleSettings_SavingUnrelatedSettingPreservesProbedProtocol is a
 // regression test: a.graphicsProtocol can be ProtocolSixel here only because
 // the startup DA1 probe (imgview.ProbeSixel) found it — that probe can't


### PR DESCRIPTION
## Problem

Guild membership sorting/icons (PR #137, `feat/guilds-membership-sort`) don't work on dev builds: guilds aren't ordered by membership, and apprenticeship isn't indicated with the ☆ icon.

## Root cause

PR #137 shipped `guilds.go`/`messages.go` with the sort/icon logic and `SharedConfigMsg.OwnApprenticeSlugs`, but the `app.go` side of the wiring — `App.ownApprenticeSlugs`, `apprenticeSlugsFrom`, the `userGuildsLoadedMsg` handler that populates it, and threading it through `broadcastConfig()` — never made it into that branch.

This happened because an unrelated interdependent uncommitted diff (this project's `app.go` had both the settings-prefs-reset fix and the guild-sort wiring mixed into one uncommitted diff) got split across two PR branches (#136 and #137) during cleanup after a CI failure, and the app.go hunks were only removed from #136, never re-added to #137.

Net effect: the own-guild badge (★) kept working (pre-existing code), but apprenticed guilds never got ordering or the ☆ icon — `ownApprenticeSlugs` was always `nil`.

## Fix

Restore `App.ownApprenticeSlugs`, `apprenticeSlugsFrom`, the `userGuildsLoadedMsg` handler that populates it and calls `guilds.SetOwnApprenticeSlugs`, and thread it through `broadcastConfig()` via `SharedConfigMsg.OwnApprenticeSlugs`.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean
- `go test ./...` — all pass
- New regression test: `TestHandleProfile_OwnGuildsLoaded_FeedsApprenticeSlugsToGuildsScreen`
