### PR TITLE
chore: log loaded display prefs behind cfg.Debug

### DIFF
--- a/cmd/cyber-tui/main.go
+++ b/cmd/cyber-tui/main.go
@@ -94,6 +94,12 @@ func main() {
 		} else {
 			defer logFile.Close()
 		}
+		// Dump the preference fields exactly as loaded from ~/.cyber-tui.json,
+		// before WithSavedPreferences applies them to the App — the earliest
+		// point that can distinguish a bad config file from a bug in applying
+		// an otherwise-good one.
+		log.Printf("config: loaded wanderLust=%v maxThreadDepth=%d inlineImages=%v dithering=%v graphicsProtocol=%q timezone=%q",
+			cfg.WanderLust, cfg.MaxThreadDepth, cfg.InlineImages, cfg.Dithering, cfg.GraphicsProtocol, cfg.Timezone)
 	}
 
 	// Local TUI mode


### PR DESCRIPTION
## What

Not a fix — a diagnostic. Logs the display-preference fields exactly as loaded from `~/.cyber-tui.json`, gated behind the existing `cfg.Debug` flag.

## Why

A fourth config-reset report came in on a build confirmed fresh past both the settings-prefs-stale-zero-seed fix (#139) and the guild apprentice-slug wiring fix (#141), describing actual runtime behavior being wrong, not just a display glitch. Static review of the full load path found nothing wrong:

- `WithSavedPreferences` is applied unconditionally in `main.go`, synchronously, before the program starts.
- `broadcastConfig()` fires synchronously in `afterLoginCmd()` on login success — not gated on any network round trip.
- The current `~/.cyber-tui.json` has correct values right now.

The bad-state evidence was gone by the time it was reported — the user had already reset the values in-app before I could inspect anything. Rather than guess at another blind fix, this adds hard-evidence logging so the next occurrence can be diagnosed from `cyber-tui-debug.log`.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test ./...` — all clean, no behavior change when `cfg.Debug` is false (default)
