### PR TITLE
fix: drop out-of-order settings saves instead of persisting them

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -545,6 +545,15 @@ type App struct {
 	notifyLevel notifyLevel
 	notifyGen   int
 
+	// settingsSaveSeq is bumped on every SaveSettingsMsg dispatch. Its value
+	// is stamped onto the resulting settingsSavedMsg so an out-of-order
+	// completion — e.g. an earlier save still waiting on the UpdateSettings
+	// network round-trip while a later save (dispatched from a second ctrl+s
+	// before the first returned) finishes and persists first — is dropped
+	// instead of clobbering the newer values, in memory and on disk, with
+	// its own stale snapshot.
+	settingsSaveSeq int
+
 	// sessionGen is bumped in handleUnauthorized on session expiry, so the
 	// self-rescheduling poll/wander/logo-idle tea.Tick chains started by
 	// afterLoginCmd (each stamped with the gen they were scheduled under)
@@ -1558,27 +1567,28 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		dt := msg.Dithering
 		ds := msg.DitherSharpness
 		ln := msg.LayoutName
+		a.settingsSaveSeq++
+		seq := a.settingsSaveSeq
 		return a, func() tea.Msg {
 			if msg.RemoteChanged {
 				if err := a.client.UpdateSettings(s); err != nil {
 					return actionErrMsg{err}
 				}
 			}
-			a.saveConfig(func(cfg *config.Config) {
-				cfg.WanderLust = wl
-				cfg.MaxThreadDepth = td
-				cfg.Timezone = tz
-				cfg.ImageViewer = iv
-				cfg.GraphicsProtocol = gp
-				cfg.InlineImages = ii
-				cfg.Dithering = dt
-				cfg.DitherSharpness = ds
-				cfg.Layout = ln
-			})
-			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, graphicsProtocol: gp, inlineImages: ii, dithering: dt, ditherSharpness: ds, layoutName: ln}
+			return settingsSavedMsg{seq: seq, settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, graphicsProtocol: gp, inlineImages: ii, dithering: dt, ditherSharpness: ds, layoutName: ln}
 		}, true
 
 	case settingsSavedMsg:
+		// A second ctrl+s can be dispatched (and land) before an earlier
+		// save's UpdateSettings network round-trip finishes. If that earlier
+		// save were still allowed to persist once it does complete, it would
+		// silently overwrite the newer values — in memory and in
+		// ~/.cyber-tui.json — with its own stale snapshot. Only the
+		// most-recently-dispatched save (the current seq) is applied; any
+		// other completion is dropped.
+		if msg.seq != a.settingsSaveSeq {
+			return a, nil, true
+		}
 		a.settings = msg.settings
 		a.wanderLust = msg.wanderLust
 		a.maxThreadDepth = msg.maxThreadDepth
@@ -1615,8 +1625,23 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.refreshViewports()
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "settings saved")
+		wl, td, tz, iv, gp, ii, dt, ds, ln := msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.graphicsProtocol, msg.inlineImages, msg.dithering, msg.ditherSharpness, msg.layoutName
+		saveCmd := func() tea.Msg {
+			a.saveConfig(func(cfg *config.Config) {
+				cfg.WanderLust = wl
+				cfg.MaxThreadDepth = td
+				cfg.Timezone = tz
+				cfg.ImageViewer = iv
+				cfg.GraphicsProtocol = gp
+				cfg.InlineImages = ii
+				cfg.Dithering = dt
+				cfg.DitherSharpness = ds
+				cfg.Layout = ln
+			})
+			return nil
+		}
 		if min := a.layout.NeedsCompactAutoFill(a.height); min > 0 {
-			cmds := []tea.Cmd{notifyCmd}
+			cmds := []tea.Cmd{notifyCmd, saveCmd}
 			if cursor := a.feed.NextCursor(); cursor != "" && a.feed.PostCount() < min {
 				cmds = append(cmds, a.loadFeedPageCmd(cursor))
 			}
@@ -1632,7 +1657,7 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 			}
 			return a, tea.Batch(cmds...), true
 		}
-		return a, notifyCmd, true
+		return a, tea.Batch(notifyCmd, saveCmd), true
 
 	case wanderTickMsg:
 		if msg.gen != a.sessionGen {
@@ -4188,6 +4213,7 @@ type replyEditedMsg struct {
 }
 type settingsLoadedMsg struct{ settings model.Settings }
 type settingsSavedMsg struct {
+	seq              int
 	settings         model.Settings
 	wanderLust       bool
 	maxThreadDepth   int

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -29,6 +29,22 @@ func keyMsg(key string) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
 }
 
+// runCmd executes cmd the way the real bubbletea runtime would: a
+// tea.BatchMsg result is a bundle of not-yet-run cmds, not an executed one,
+// so it must be recursed into rather than just called once.
+func runCmd(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			runCmd(t, c)
+		}
+	}
+}
+
 func newTestApp() App {
 	return NewApp(api.NewMockClient())
 }
@@ -5187,7 +5203,7 @@ func TestHandleSettings_SavingUnrelatedSettingPreservesProbedProtocol(t *testing
 	a.graphicsProtocol = imgview.ProtocolSixel
 	a.graphicsProtocolName = "" // auto — the only way DetectProtocol() ever gets consulted
 
-	_, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
+	a, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
 		GraphicsProtocol: "", // unchanged
 		Dithering:        true,
 		ImageViewer:      "terminal",
@@ -5210,6 +5226,98 @@ func TestHandleSettings_SavingUnrelatedSettingPreservesProbedProtocol(t *testing
 	}
 }
 
+// TestHandleSettings_OutOfOrderSaveDoesNotClobberNewer reproduces a real
+// corruption: ctrl+s dispatches a save whose cmd may call the (network) API
+// before persisting to disk. Pressing ctrl+s again before that first save's
+// cmd returns dispatches a second save; if the two ever complete out of
+// order, the first (now-stale) one landing last must not overwrite the
+// second (newer) one's values in memory or in ~/.cyber-tui.json — this is
+// exactly how wander mode, timezone, thread depth, dithering, and the
+// graphics protocol override (observed flipping a deliberately-set "sixel"
+// back to an earlier "kitty") were seen reverting to their pre-edit values
+// after a restart.
+func TestHandleSettings_OutOfOrderSaveDoesNotClobberNewer(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.graphicsProtocolName = "kitty"
+
+	var cmd1 tea.Cmd
+	var ok bool
+	a, cmd1, ok = a.handleSettings(screens.SaveSettingsMsg{
+		WanderLust:       true,
+		Timezone:         "UTC+2",
+		ImageViewer:      "terminal",
+		GraphicsProtocol: "kitty", // unchanged from the pre-save value
+	})
+	if !ok || cmd1 == nil {
+		t.Fatal("expected first SaveSettingsMsg to be handled")
+	}
+
+	var cmd2 tea.Cmd
+	a, cmd2, ok = a.handleSettings(screens.SaveSettingsMsg{
+		WanderLust:       true,
+		Timezone:         "UTC+5:30",
+		MaxThreadDepth:   7,
+		ImageViewer:      "terminal",
+		GraphicsProtocol: "sixel", // the user's real, later edit
+	})
+	if !ok || cmd2 == nil {
+		t.Fatal("expected second SaveSettingsMsg to be handled")
+	}
+
+	// Second (newer) save completes first.
+	saved2 := cmd2().(settingsSavedMsg)
+	var diskCmd2 tea.Cmd
+	a, diskCmd2, ok = a.handleSettings(saved2)
+	if !ok {
+		t.Fatal("expected settingsSavedMsg to be handled")
+	}
+	if diskCmd2 == nil {
+		t.Fatal("expected the newer settingsSavedMsg to dispatch a disk-write cmd")
+	}
+	runCmd(t, diskCmd2)
+
+	// First (now-stale) save completes afterward.
+	saved1 := cmd1().(settingsSavedMsg)
+	a, cmd, ok := a.handleSettings(saved1)
+	if !ok {
+		t.Fatal("expected stale settingsSavedMsg to still report handled=true")
+	}
+	if cmd != nil {
+		t.Error("stale settingsSavedMsg must not dispatch a disk-write cmd")
+	}
+	if a.timezone != "UTC+5:30" {
+		t.Errorf("timezone = %q after stale save applied, want UTC+5:30 (the newer value) to survive", a.timezone)
+	}
+	if a.maxThreadDepth != 7 {
+		t.Errorf("maxThreadDepth = %d after stale save applied, want 7 (the newer value) to survive", a.maxThreadDepth)
+	}
+	if a.graphicsProtocolName != "sixel" {
+		t.Errorf("graphicsProtocolName = %q after stale save applied, want sixel (the newer value) to survive", a.graphicsProtocolName)
+	}
+	if a.graphicsProtocol != imgview.ProtocolSixel {
+		t.Errorf("graphicsProtocol = %v after stale save applied, want ProtocolSixel", a.graphicsProtocol)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.Timezone != "UTC+5:30" {
+		t.Errorf("saved config timezone = %q, want UTC+5:30 — the stale first save must not overwrite the newer value on disk", cfg.Timezone)
+	}
+	if cfg.MaxThreadDepth != 7 {
+		t.Errorf("saved config maxThreadDepth = %d, want 7", cfg.MaxThreadDepth)
+	}
+	if cfg.GraphicsProtocol != "sixel" {
+		t.Errorf("saved config graphicsProtocol = %q, want sixel", cfg.GraphicsProtocol)
+	}
+}
+
 // TestHandleSettings_ChangingGraphicsProtocolOverrideReResolves confirms the
 // override still takes effect when the user actually changes it — the fix
 // for the regression above only skips re-resolution when the override is
@@ -5219,7 +5327,7 @@ func TestHandleSettings_ChangingGraphicsProtocolOverrideReResolves(t *testing.T)
 	a.graphicsProtocol = imgview.ProtocolSixel
 	a.graphicsProtocolName = ""
 
-	_, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
+	a, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
 		GraphicsProtocol: "kitty", // changed
 		ImageViewer:      "terminal",
 	})


### PR DESCRIPTION
﻿## What

Ctrl+S on the Settings screen dispatches a save whose cmd may call `UpdateSettings` over the network before writing `~/.cyber-tui.json`. Pressing ctrl+s again before that first save's cmd returns dispatches a second save; the two cmds run concurrently with no ordering guarantee. If they complete out of order, the first (now-stale) one landing last silently overwrote the second (newer) one's values -- in memory and on disk.

This is the actual mechanism behind the repeated config-reset reports: wander mode, timezone, thread depth, dithering, dither sharpness, inline images, and the graphics-protocol override all reverting to earlier values after a restart. Not a stale-zero-seed bug (already fixed by #139), and not a guild-wiring issue (#141) -- a genuine save-ordering race.

## Fix

- Added `settingsSaveSeq` on `App`, bumped on every `SaveSettingsMsg` dispatch and stamped onto the resulting `settingsSavedMsg` -- same pattern as the existing `sessionGen`/`notifyGen` staleness guards.
- Moved the disk write out of the (possibly network-delayed) save cmd and into the `settingsSavedMsg` handler, which runs on the single serial Update loop. It only persists when `msg.seq` still matches the current `settingsSaveSeq` -- so the most-recently-*dispatched* save always wins, regardless of which cmd's network round-trip finishes first. Stale completions are dropped before touching memory or disk.

Supersedes #143 (diagnostic logging only, opened after a static review of the load path came up empty) with the actual root-cause fix. Closing that PR in favor of this one.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test ./...` -- all clean.
- Added `TestHandleSettings_OutOfOrderSaveDoesNotClobberNewer`, reproducing two saves completing out of order (including a graphics-protocol override reverting from a real edit, sixel, back to an earlier value, kitty) and asserting both in-memory state and the on-disk config retain the newer save.
- Fixed two existing tests that discarded the mutated `App` between chained `handleSettings` calls, which masked this same class of bug.
