### PR TITLE
fix: float apprentice guilds missing from page 1 into the guild list

### DIFF
--- a/docs/29-guilds.md
+++ b/docs/29-guilds.md
@@ -18,7 +18,7 @@ feed | notifications | journal | bookmarks | guilds | topics | profile | setting
 
 ### Guild list (default view)
 
-Displays all guilds that have at least one member, in the order the API returns them (member count, most populated first), except the logged-in user's own guilds are floated to the top: their badge guild first, then any guilds they're apprenticed to (ordered by member count), then the rest of the list unchanged. Each row shows:
+Displays all guilds that have at least one member, in the order the API returns them (member count, most populated first), except the logged-in user's own guilds are floated to the top: their badge guild first, then any guilds they're apprenticed to (ordered by member count), then the rest of the list unchanged. If the badge guild or an apprenticed guild isn't present on the first page returned by the API, it's fetched individually (`GET /v1/guilds/:slug`) and injected into the list so it still floats to the top instead of waiting for pagination to reach it. Each row shows:
 
 - Guild icon (emoji; plain-text icon names from the API fall back to `◆`, or to `★`/`☆` for the user's badge guild / an apprenticed guild)
 - Guild name (highlighted when selected)
@@ -102,7 +102,7 @@ After a successful post the thread list reloads.
 - `internal/api/client.go` — wire types and HTTP implementations
 - `internal/ui/screens/guilds.go` — `GuildsModel` (three-view screen + embedded `PostComposePanel`); `sortGuildsForDisplay` floats the user's badge guild then apprenticeships (by member count) to the top of the list; `SetOwnGuildSlug`/`SetOwnApprenticeSlugs` re-sort on membership changes
 - `internal/ui/screens/profile.go` — apprenticeships row on the Info tab (`SetApprenticeships`)
-- `internal/ui/app.go` — `screenGuilds` enum, `handleGuilds`, load/create/promote commands, menu wiring; `ownApprenticeSlugs` (from the logged-in user's own `GetUserGuilds`, distinct from whichever profile `ProfileModel` currently has apprenticeships loaded for) feeds the Guilds tab ordering via `SharedConfigMsg.OwnApprenticeSlugs`
+- `internal/ui/app.go` — `screenGuilds` enum, `handleGuilds`, load/create/promote commands, menu wiring; `ownApprenticeSlugs` (from the logged-in user's own `GetUserGuilds`, distinct from whichever profile `ProfileModel` currently has apprenticeships loaded for) feeds the Guilds tab ordering via `SharedConfigMsg.OwnApprenticeSlugs`. On `guildsLoadedMsg`, any of the badge guild or apprentice slugs missing from the freshly loaded page is fetched individually via `loadOwnGuildIntoListCmd`/`ownGuildInjectMsg` (batched with `tea.Batch`, one fetch per missing slug) and injected into `GuildsModel` with `InjectGuild`/`HasGuild`.
 
 ## Known limitations / out of scope
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2072,6 +2072,26 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 
 	case guildsLoadedMsg:
 		a.guilds = a.guilds.SetGuilds(msg.guilds, msg.cursor)
+		var missing []string
+		if slug := a.currentUser.GuildSlug; slug != "" && !a.guilds.HasGuild(slug) {
+			missing = append(missing, slug)
+		}
+		for _, slug := range a.ownApprenticeSlugs {
+			if slug != "" && !a.guilds.HasGuild(slug) {
+				missing = append(missing, slug)
+			}
+		}
+		if len(missing) == 0 {
+			return a, nil, true
+		}
+		cmds := make([]tea.Cmd, len(missing))
+		for i, slug := range missing {
+			cmds[i] = a.loadOwnGuildIntoListCmd(slug)
+		}
+		return a, tea.Batch(cmds...), true
+
+	case ownGuildInjectMsg:
+		a.guilds = a.guilds.InjectGuild(msg.guild)
 		return a, nil, true
 
 	case screens.LoadMoreGuildsMsg:
@@ -4419,6 +4439,7 @@ type guildsLoadedMsg struct {
 	guilds []model.Guild
 	cursor string
 }
+type ownGuildInjectMsg struct{ guild model.Guild }
 type guildsPageMsg struct {
 	guilds []model.Guild
 	cursor string
@@ -5397,6 +5418,22 @@ func (a *App) loadGuildDetailCmd(slug string) tea.Cmd {
 			return actionErrMsg{err}
 		}
 		return guildDetailLoadedMsg{guild: g}
+	}
+}
+
+// loadOwnGuildIntoListCmd fetches a single guild (the user's badge guild or
+// one of their apprenticeships) directly when the paginated,
+// most-populated-first guild list didn't include it on the first page —
+// otherwise sortGuildsForDisplay has nothing to float to the top. Failure is
+// silent: the list still works, it just won't show that guild pinned until
+// pagination reaches it.
+func (a *App) loadOwnGuildIntoListCmd(slug string) tea.Cmd {
+	return func() tea.Msg {
+		g, err := a.client.GetGuild(slug)
+		if err != nil {
+			return nil
+		}
+		return ownGuildInjectMsg{guild: g}
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -5099,6 +5099,164 @@ func TestHandleGuilds_GuildPromoted_SwapsBadge(t *testing.T) {
 	}
 }
 
+// guildFetchingClient returns a canned per-slug guild from GetGuild, or a
+// fixed error if err is set — simulates the off-first-page fetch in
+// loadOwnGuildIntoListCmd.
+type guildFetchingClient struct {
+	*api.MockClient
+	guilds map[string]model.Guild
+	err    error
+}
+
+func (c *guildFetchingClient) GetGuild(slug string) (model.Guild, error) {
+	if c.err != nil {
+		return model.Guild{}, c.err
+	}
+	return c.guilds[slug], nil
+}
+
+func TestHandleGuilds_GuildsLoaded_BadgeGuildMissing_FetchesIt(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.client = &guildFetchingClient{
+		MockClient: api.NewMockClient(),
+		guilds:     map[string]model.Guild{"night-owls": {Slug: "night-owls", Name: "Night Owls"}},
+	}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{{Slug: "deep-divers", Name: "Deep Divers"}}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch cmd for the missing badge guild")
+	}
+	msgs := resolveMsgs(cmd)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 resolved msg, got %d", len(msgs))
+	}
+	inj, ok := msgs[0].(ownGuildInjectMsg)
+	if !ok {
+		t.Fatalf("expected ownGuildInjectMsg, got %T", msgs[0])
+	}
+	if inj.guild.Slug != "night-owls" {
+		t.Errorf("injected slug = %q, want night-owls", inj.guild.Slug)
+	}
+}
+
+func TestHandleGuilds_GuildsLoaded_ApprenticeGuildMissing_FetchesIt(t *testing.T) {
+	a := loggedInApp()
+	a.ownApprenticeSlugs = []string{"deep-divers"}
+	a.client = &guildFetchingClient{
+		MockClient: api.NewMockClient(),
+		guilds:     map[string]model.Guild{"deep-divers": {Slug: "deep-divers", Name: "Deep Divers"}},
+	}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{{Slug: "night-owls", Name: "Night Owls"}}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch cmd for the missing apprentice guild")
+	}
+	msgs := resolveMsgs(cmd)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 resolved msg, got %d", len(msgs))
+	}
+	inj, ok := msgs[0].(ownGuildInjectMsg)
+	if !ok {
+		t.Fatalf("expected ownGuildInjectMsg, got %T", msgs[0])
+	}
+	if inj.guild.Slug != "deep-divers" {
+		t.Errorf("injected slug = %q, want deep-divers", inj.guild.Slug)
+	}
+}
+
+func TestHandleGuilds_GuildsLoaded_BadgeAndApprenticesMissing_FetchesAll(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.ownApprenticeSlugs = []string{"deep-divers", "sprawl-runners"}
+	a.client = &guildFetchingClient{
+		MockClient: api.NewMockClient(),
+		guilds: map[string]model.Guild{
+			"night-owls":     {Slug: "night-owls", Name: "Night Owls"},
+			"deep-divers":    {Slug: "deep-divers", Name: "Deep Divers"},
+			"sprawl-runners": {Slug: "sprawl-runners", Name: "Sprawl Runners"},
+		},
+	}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{{Slug: "chiba-city", Name: "Chiba City"}}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected fetch cmds for the three missing guilds")
+	}
+	msgs := resolveMsgs(cmd)
+	if len(msgs) != 3 {
+		t.Fatalf("expected exactly 3 resolved msgs, got %d", len(msgs))
+	}
+	got := map[string]bool{}
+	for _, m := range msgs {
+		inj, ok := m.(ownGuildInjectMsg)
+		if !ok {
+			t.Fatalf("expected ownGuildInjectMsg, got %T", m)
+		}
+		got[inj.guild.Slug] = true
+	}
+	for _, want := range []string{"night-owls", "deep-divers", "sprawl-runners"} {
+		if !got[want] {
+			t.Errorf("expected an injection for %q, got %v", want, got)
+		}
+	}
+}
+
+func TestHandleGuilds_GuildsLoaded_AllPresent_NoFetch(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.ownApprenticeSlugs = []string{"deep-divers"}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{
+		{Slug: "night-owls", Name: "Night Owls"},
+		{Slug: "deep-divers", Name: "Deep Divers"},
+	}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd != nil {
+		t.Error("expected no fetch cmd when badge and apprentice guilds are already present")
+	}
+}
+
+func TestHandleGuilds_GuildsLoaded_FetchFails_Silent(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.client = &guildFetchingClient{MockClient: api.NewMockClient(), err: errors.New("boom")}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{{Slug: "deep-divers", Name: "Deep Divers"}}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch cmd even though it will fail")
+	}
+	msgs := resolveMsgs(cmd)
+	if len(msgs) != 1 || msgs[0] != nil {
+		t.Errorf("expected a single nil msg on fetch failure, got %v", msgs)
+	}
+}
+
+func TestHandleGuilds_OwnGuildInjectMsg_AddsGuildToList(t *testing.T) {
+	a := loggedInApp()
+
+	a2, _, handled := a.handleGuilds(ownGuildInjectMsg{guild: model.Guild{Slug: "deep-divers", Name: "Deep Divers"}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle ownGuildInjectMsg")
+	}
+	if !a2.guilds.HasGuild("deep-divers") {
+		t.Error("expected deep-divers to be present in the guild list after injection")
+	}
+}
+
 // TestHandleProfile_OwnProfileLoad_FetchesApprenticeships is the regression
 // test for a real bug: navigating to your own profile via the tab bar goes
 // through loadProfileCmd/profileLoadedMsg (activateScreen in layout.go), a

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -387,6 +387,31 @@ func sortGuildsForDisplay(guilds []model.Guild, ownSlug string, apprenticeSlugs 
 	return sorted
 }
 
+// HasGuild reports whether slug is present in the currently loaded guild list.
+func (m GuildsModel) HasGuild(slug string) bool {
+	for _, g := range m.guilds {
+		if g.Slug == slug {
+			return true
+		}
+	}
+	return false
+}
+
+// InjectGuild adds a guild fetched out-of-band (e.g. the user's own guild,
+// which the paginated, most-populated-first list may not reach for a while)
+// so sortGuildsForDisplay can float it to the top even though normal
+// pagination hasn't loaded it yet. No-op if already present.
+func (m GuildsModel) InjectGuild(g model.Guild) GuildsModel {
+	if m.HasGuild(g.Slug) {
+		return m
+	}
+	m.guilds = sortGuildsForDisplay(append(m.guilds, g), m.ownGuildSlug, m.ownApprenticeSlugs)
+	if m.ready {
+		m = m.refreshContent()
+	}
+	return m
+}
+
 // isOwnGuild reports whether slug is the logged-in user's badge guild.
 func (m GuildsModel) isOwnGuild(slug string) bool {
 	return m.ownGuildSlug != "" && slug == m.ownGuildSlug

--- a/internal/ui/screens/guilds_test.go
+++ b/internal/ui/screens/guilds_test.go
@@ -146,6 +146,52 @@ func TestGuildsModel_SetGuilds_ApprenticesOrderedByMemberCount(t *testing.T) {
 	}
 }
 
+func TestGuildsModel_HasGuild_TrueForLoadedSlug(t *testing.T) {
+	m := screens.NewGuildsModel().SetGuilds(sampleGuilds(), "")
+	if !m.HasGuild("alpha") {
+		t.Error("expected HasGuild(\"alpha\") to be true after SetGuilds")
+	}
+}
+
+func TestGuildsModel_HasGuild_FalseForMissingSlug(t *testing.T) {
+	m := screens.NewGuildsModel().SetGuilds(sampleGuilds(), "")
+	if m.HasGuild("zzz") {
+		t.Error("expected HasGuild(\"zzz\") to be false")
+	}
+}
+
+func TestGuildsModel_InjectGuild_FloatsToTop(t *testing.T) {
+	t.Helper()
+	m := guildViewWithSize(screens.NewGuildsModel())
+	m = m.SetOwnGuildSlug("epsilon")
+	m = m.SetGuilds(orderedGuilds(), "") // epsilon is not present on this page
+
+	m = m.InjectGuild(model.Guild{ID: "g5", Name: "Epsilon", Slug: "epsilon", MemberCount: 20})
+
+	view := m.View()
+	epsilonPos := strings.Index(view, "Epsilon")
+	alphaPos := strings.Index(view, "Alpha")
+	if epsilonPos == -1 || alphaPos == -1 {
+		t.Fatal("expected both Epsilon and Alpha present in view")
+	}
+	if epsilonPos > alphaPos {
+		t.Errorf("Epsilon (own guild, injected) should render before Alpha")
+	}
+}
+
+func TestGuildsModel_InjectGuild_NoopIfAlreadyPresent(t *testing.T) {
+	t.Helper()
+	m := guildViewWithSize(screens.NewGuildsModel())
+	m = m.SetGuilds(sampleGuilds(), "") // already contains slug "beta" / name "Beta"
+
+	m = m.InjectGuild(model.Guild{ID: "g99", Name: "Beta-duplicate", Slug: "beta"})
+
+	view := m.View()
+	if strings.Contains(view, "Beta-duplicate") {
+		t.Error("expected InjectGuild to no-op when the slug is already present, not add a duplicate row")
+	}
+}
+
 func TestGuildsModel_RenderGuildItem_ShowsMembershipIcons(t *testing.T) {
 	t.Helper()
 	m := guildViewWithSize(screens.NewGuildsModel())


### PR DESCRIPTION
﻿## What

The Guilds tab floats the user's badge guild and apprenticed guilds (`sortGuildsForDisplay`) to the top of the paginated, most-populated-first guild list -- but that only works if those guilds are actually present in whatever page has loaded. An in-progress, previously-uncommitted fix already closed this gap for the single badge guild (`HasGuild`/`InjectGuild` in `guilds.go`; `guildsLoadedMsg`/`ownGuildInjectMsg`/`loadOwnGuildIntoListCmd` in `app.go`), but left apprenticed guilds (`ownApprenticeSlugs`, up to 5) with the identical problem: if one isn't on page 1, it silently won't show pinned until pagination happens to reach it.

## Fix

Widen the `guildsLoadedMsg` missing-slug check to cover the badge guild AND every apprentice slug, firing one `loadOwnGuildIntoListCmd` fetch per missing slug via `tea.Batch`. `HasGuild`/`InjectGuild`/`loadOwnGuildIntoListCmd`/`ownGuildInjectMsg` needed no changes -- they were already slug-agnostic, only the single call site was badge-only. Reworded `loadOwnGuildIntoListCmd`'s doc comment to match (no rename).

## Deliberately not fixing

A related staleness gap: `ownGuildInjectMsg` carries no request-correlation token, so a stale in-flight fetch could in theory land after a fresher `SetGuilds` reload (reachable via join/leave/promote, which always re-triggers `loadGuildsCmd`). Traced through `sortGuildsForDisplay` and the render path: rank and the star icons are computed live from current `ownGuildSlug`/`ownApprenticeSlugs` at sort/render time, never stored per-row, so this can only ever produce one harmless extra unranked row that self-heals on the next `SetGuilds` -- never a false badge or false ranking. Reaching the window at all requires leaving/rejoining/promoting across a different guild inside one `GetGuild` round-trip. Not worth plumbing a correlation ID through the message for a cosmetic, self-healing, near-unreachable case.

## Testing

- `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test ./...` -- all clean.
- Added coverage that was completely absent for this mechanism:
  - `guilds_test.go`: `HasGuild`/`InjectGuild` unit tests (present/missing slug, float-to-top, no-op on duplicate).
  - `app_test.go`: `handleGuilds` tests for the widened `guildsLoadedMsg` check (badge missing, apprentice missing, both missing fetches all, all-present skips the fetch, `GetGuild` failure stays silent) plus a direct test of the previously-untested `ownGuildInjectMsg` wiring.
- `docs/29-guilds.md`'s guild list and Implementation sections now describe the injection behavior for both badge and apprentice guilds.
