### PR TITLE
fix: serialize saveConfig to prevent concurrent saves clobbering each other

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -674,12 +674,21 @@ func (a App) WithEphemeralSession() App {
 	return a
 }
 
+// saveConfigMu serializes saveConfig's load-mutate-write cycle across the
+// several tea.Cmd goroutines that can call it concurrently (settings save,
+// density toggle, theme save, login, ...). Without it, two overlapping calls
+// each read the same stale snapshot and the last write wins, silently
+// discarding whichever fields the other call touched.
+var saveConfigMu sync.Mutex
+
 // saveConfig loads the persisted config, applies mutate, and writes it back. It
 // is a no-op for ephemeral (SSH-hosted) sessions.
 func (a *App) saveConfig(mutate func(cfg *config.Config)) {
 	if a.ephemeral {
 		return
 	}
+	saveConfigMu.Lock()
+	defer saveConfigMu.Unlock()
 	cfg, err := config.Load()
 	if err != nil {
 		return

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -5315,6 +5316,68 @@ func TestHandleSettings_OutOfOrderSaveDoesNotClobberNewer(t *testing.T) {
 	}
 	if cfg.GraphicsProtocol != "sixel" {
 		t.Errorf("saved config graphicsProtocol = %q, want sixel", cfg.GraphicsProtocol)
+	}
+}
+
+// TestSaveConfig_ConcurrentCallsDoNotClobberEachOther reproduces the general
+// lost-update race saveConfig is exposed to: unlike the ctrl+s-vs-ctrl+s case
+// above, this races saveConfig itself (as called from unrelated triggers like
+// the density toggle, theme save, and login) directly against each other.
+// Each call does its own load-mutate-write of the whole config file with no
+// synchronization beyond saveConfigMu; if that lock were missing, whichever
+// goroutine's write lands last would silently discard the other's field.
+func TestSaveConfig_ConcurrentCallsDoNotClobberEachOther(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	a := loggedInApp()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			a.saveConfig(func(cfg *config.Config) {
+				cfg.Density = fmt.Sprintf("density-%d", i)
+			})
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		a.saveConfig(func(cfg *config.Config) {
+			cfg.Theme = "custom"
+			cfg.CustomPalette = &theme.Palette{Accent: "#ff00ff"}
+		})
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		a.saveConfig(func(cfg *config.Config) {
+			cfg.Timezone = "UTC+5:30"
+		})
+	}()
+	close(start)
+	wg.Wait()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.Theme != "custom" || cfg.CustomPalette == nil || cfg.CustomPalette.Accent != "#ff00ff" {
+		t.Errorf("theme save was clobbered by a concurrent save: Theme=%q CustomPalette=%v", cfg.Theme, cfg.CustomPalette)
+	}
+	if cfg.Timezone != "UTC+5:30" {
+		t.Errorf("timezone save was clobbered by a concurrent save: Timezone=%q", cfg.Timezone)
+	}
+	if !strings.HasPrefix(cfg.Density, "density-") {
+		t.Errorf("density save was clobbered by a concurrent save: Density=%q", cfg.Density)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `e64d701` fixed the settings-vs-settings double-save race, but the other `saveConfig` call sites (density toggle, theme editor/picker, login, token-login, wander-tick, logout) still did an unsynchronized load-mutate-write of the whole config file
- Any two of those firing close together could silently drop whichever fields the losing call touched, matching the "only certain settings get wiped" reports
- Added a package-level mutex (`saveConfigMu`) that serializes the whole `saveConfig` critical section across every caller

Full investigation notes: no exit-time config write exists (Bubble Tea intercepts quit/SIGINT/SIGTERM before `App.Update` runs), and no leftover "reset config" code exists (a `config.Clear()` helper was never wired to any caller and was cleanly removed as dead code in `4d1675a`).

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race ./internal/...` — all pass
- [x] New `TestSaveConfig_ConcurrentCallsDoNotClobberEachOther` races density/theme/timezone saves concurrently and asserts none are lost
- [x] Verified the test is meaningful: temporarily removed the mutex and reran — failed reliably (5/5), including one run that produced corrupted JSON on disk from concurrent unsynchronized writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)