### PR TITLE
fix: refresh own apprenticeships after join/leave/promote

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2242,7 +2242,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "✓ "+verb+" #"+msg.name)
-		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
+		return a, tea.Batch(notifyCmd, a.loadGuildsCmd(""), a.loadUserGuildsCmd(a.currentUser.Username)), true
 
 	case guildLeftMsg:
 		a.guilds = a.guilds.BackToGuildList()
@@ -2255,7 +2255,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "✓ Left #"+msg.name)
-		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
+		return a, tea.Batch(notifyCmd, a.loadGuildsCmd(""), a.loadUserGuildsCmd(a.currentUser.Username)), true
 
 	case guildPromotedMsg:
 		detail := a.guilds.GuildDetail()
@@ -2268,7 +2268,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.guilds = a.guilds.SetOwnGuildSlug(msg.slug)
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "✓ #"+msg.name+" is now your guild badge")
-		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
+		return a, tea.Batch(notifyCmd, a.loadGuildsCmd(""), a.loadUserGuildsCmd(a.currentUser.Username)), true
 	}
 	return a, nil, false
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -5274,6 +5274,68 @@ func TestHandleGuilds_OwnGuildInjectMsg_AddsGuildToList(t *testing.T) {
 	}
 }
 
+// userGuildsStubClient overrides GetUserGuilds to simulate the server already
+// reflecting a just-joined apprenticeship, for testing that the Guilds tab
+// refreshes ownApprenticeSlugs after a join/leave/promote instead of relying
+// on the stale list loaded at login.
+type userGuildsStubClient struct {
+	*api.MockClient
+	guilds []model.GuildMembership
+}
+
+func (c *userGuildsStubClient) GetUserGuilds(username string) ([]model.GuildMembership, error) {
+	return c.guilds, nil
+}
+
+// TestHandleGuilds_GuildJoinedAsApprentice_RefreshesOwnApprenticeSlugs is the
+// regression test for a real bug: apprenticing to a guild mid-session never
+// refreshed a.ownApprenticeSlugs (only login and profile edits did, via
+// loadUserGuildsCmd), so the Guilds tab kept sorting/badging by the stale
+// apprenticeship list from login and the new apprenticeship never appeared.
+func TestHandleGuilds_GuildJoinedAsApprentice_RefreshesOwnApprenticeSlugs(t *testing.T) {
+	client := &userGuildsStubClient{
+		MockClient: api.NewMockClient(),
+		guilds: []model.GuildMembership{
+			{Slug: "night-owls", Role: "member"},
+			{Slug: "deep-divers", Role: "apprentice"},
+		},
+	}
+	a := NewApp(client)
+	a.active = screenGuilds
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.guilds = a.guilds.SetGuildDetail(model.Guild{ID: "g2", Slug: "deep-divers", Name: "Deep Divers"})
+
+	a2, cmd, handled := a.handleGuilds(guildJoinedMsg{slug: "deep-divers", name: "Deep Divers", role: "apprentice"})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildJoinedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected guildJoinedMsg to trigger a cmd batch")
+	}
+
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected guildJoinedMsg to dispatch a tea.Batch, got %T", cmd())
+	}
+	var refreshMsg *userGuildsLoadedMsg
+	for _, c := range batch {
+		if msg, ok := c().(userGuildsLoadedMsg); ok {
+			refreshMsg = &msg
+		}
+	}
+	if refreshMsg == nil {
+		t.Fatal("expected guildJoinedMsg's cmd batch to include a userGuilds refresh")
+	}
+
+	a3, _, handled := a2.handleProfile(*refreshMsg)
+	if !handled {
+		t.Fatal("expected userGuildsLoadedMsg to be handled")
+	}
+	if !slices.Contains(a3.ownApprenticeSlugs, "deep-divers") {
+		t.Errorf("ownApprenticeSlugs = %v, want it to contain the just-joined deep-divers", a3.ownApprenticeSlugs)
+	}
+}
+
 // TestHandleProfile_OwnProfileLoad_FetchesApprenticeships is the regression
 // test for a real bug: navigating to your own profile via the tab bar goes
 // through loadProfileCmd/profileLoadedMsg (activateScreen in layout.go), a


### PR DESCRIPTION
## Summary
- `a.ownApprenticeSlugs` (used to sort/badge the Guilds tab) was only populated by `loadUserGuildsCmd`, which runs at login and after profile edits
- Joining, leaving, or promoting a guild mid-session never re-fetched it, so a newly-apprenticed guild wouldn't show up in the Guilds tab until the app was restarted (or the profile screen was revisited)
- All three `handleGuilds` handlers (`guildJoinedMsg`, `guildLeftMsg`, `guildPromotedMsg`) now also dispatch `loadUserGuildsCmd`, reusing the existing refresh path instead of hand-patching the slug list in three places

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race ./internal/...` — all pass
- [x] New `TestHandleGuilds_GuildJoinedAsApprentice_RefreshesOwnApprenticeSlugs` reproduces the reported bug
- [x] Verified the test is meaningful: reverted the fix and reran — failed as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)