### PR TITLE
Release v0.8.6.4

### DIFF
--- a/docs/29-guilds.md
+++ b/docs/29-guilds.md
@@ -18,7 +18,7 @@ feed | notifications | journal | bookmarks | guilds | topics | profile | setting
 
 ### Guild list (default view)
 
-Displays all guilds that have at least one member, in the order the API returns them (member count, most populated first), except the logged-in user's own guilds are floated to the top: their badge guild first, then any guilds they're apprenticed to (ordered by member count), then the rest of the list unchanged. Each row shows:
+Displays all guilds that have at least one member, in the order the API returns them (member count, most populated first), except the logged-in user's own guilds are floated to the top: their badge guild first, then any guilds they're apprenticed to (ordered by member count), then the rest of the list unchanged. If the badge guild or an apprenticed guild isn't present on the first page returned by the API, it's fetched individually (`GET /v1/guilds/:slug`) and injected into the list so it still floats to the top instead of waiting for pagination to reach it. Each row shows:
 
 - Guild icon (emoji; plain-text icon names from the API fall back to `◆`, or to `★`/`☆` for the user's badge guild / an apprenticed guild)
 - Guild name (highlighted when selected)
@@ -102,7 +102,7 @@ After a successful post the thread list reloads.
 - `internal/api/client.go` — wire types and HTTP implementations
 - `internal/ui/screens/guilds.go` — `GuildsModel` (three-view screen + embedded `PostComposePanel`); `sortGuildsForDisplay` floats the user's badge guild then apprenticeships (by member count) to the top of the list; `SetOwnGuildSlug`/`SetOwnApprenticeSlugs` re-sort on membership changes
 - `internal/ui/screens/profile.go` — apprenticeships row on the Info tab (`SetApprenticeships`)
-- `internal/ui/app.go` — `screenGuilds` enum, `handleGuilds`, load/create/promote commands, menu wiring; `ownApprenticeSlugs` (from the logged-in user's own `GetUserGuilds`, distinct from whichever profile `ProfileModel` currently has apprenticeships loaded for) feeds the Guilds tab ordering via `SharedConfigMsg.OwnApprenticeSlugs`
+- `internal/ui/app.go` — `screenGuilds` enum, `handleGuilds`, load/create/promote commands, menu wiring; `ownApprenticeSlugs` (from the logged-in user's own `GetUserGuilds`, distinct from whichever profile `ProfileModel` currently has apprenticeships loaded for) feeds the Guilds tab ordering via `SharedConfigMsg.OwnApprenticeSlugs`. On `guildsLoadedMsg`, any of the badge guild or apprentice slugs missing from the freshly loaded page is fetched individually via `loadOwnGuildIntoListCmd`/`ownGuildInjectMsg` (batched with `tea.Batch`, one fetch per missing slug) and injected into `GuildsModel` with `InjectGuild`/`HasGuild`.
 
 ## Known limitations / out of scope
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -545,6 +545,15 @@ type App struct {
 	notifyLevel notifyLevel
 	notifyGen   int
 
+	// settingsSaveSeq is bumped on every SaveSettingsMsg dispatch. Its value
+	// is stamped onto the resulting settingsSavedMsg so an out-of-order
+	// completion — e.g. an earlier save still waiting on the UpdateSettings
+	// network round-trip while a later save (dispatched from a second ctrl+s
+	// before the first returned) finishes and persists first — is dropped
+	// instead of clobbering the newer values, in memory and on disk, with
+	// its own stale snapshot.
+	settingsSaveSeq int
+
 	// sessionGen is bumped in handleUnauthorized on session expiry, so the
 	// self-rescheduling poll/wander/logo-idle tea.Tick chains started by
 	// afterLoginCmd (each stamped with the gen they were scheduled under)
@@ -1558,27 +1567,28 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		dt := msg.Dithering
 		ds := msg.DitherSharpness
 		ln := msg.LayoutName
+		a.settingsSaveSeq++
+		seq := a.settingsSaveSeq
 		return a, func() tea.Msg {
 			if msg.RemoteChanged {
 				if err := a.client.UpdateSettings(s); err != nil {
 					return actionErrMsg{err}
 				}
 			}
-			a.saveConfig(func(cfg *config.Config) {
-				cfg.WanderLust = wl
-				cfg.MaxThreadDepth = td
-				cfg.Timezone = tz
-				cfg.ImageViewer = iv
-				cfg.GraphicsProtocol = gp
-				cfg.InlineImages = ii
-				cfg.Dithering = dt
-				cfg.DitherSharpness = ds
-				cfg.Layout = ln
-			})
-			return settingsSavedMsg{settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, graphicsProtocol: gp, inlineImages: ii, dithering: dt, ditherSharpness: ds, layoutName: ln}
+			return settingsSavedMsg{seq: seq, settings: s, wanderLust: wl, maxThreadDepth: td, timezone: tz, imageViewer: iv, graphicsProtocol: gp, inlineImages: ii, dithering: dt, ditherSharpness: ds, layoutName: ln}
 		}, true
 
 	case settingsSavedMsg:
+		// A second ctrl+s can be dispatched (and land) before an earlier
+		// save's UpdateSettings network round-trip finishes. If that earlier
+		// save were still allowed to persist once it does complete, it would
+		// silently overwrite the newer values — in memory and in
+		// ~/.cyber-tui.json — with its own stale snapshot. Only the
+		// most-recently-dispatched save (the current seq) is applied; any
+		// other completion is dropped.
+		if msg.seq != a.settingsSaveSeq {
+			return a, nil, true
+		}
 		a.settings = msg.settings
 		a.wanderLust = msg.wanderLust
 		a.maxThreadDepth = msg.maxThreadDepth
@@ -1615,8 +1625,23 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.refreshViewports()
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "settings saved")
+		wl, td, tz, iv, gp, ii, dt, ds, ln := msg.wanderLust, msg.maxThreadDepth, msg.timezone, msg.imageViewer, msg.graphicsProtocol, msg.inlineImages, msg.dithering, msg.ditherSharpness, msg.layoutName
+		saveCmd := func() tea.Msg {
+			a.saveConfig(func(cfg *config.Config) {
+				cfg.WanderLust = wl
+				cfg.MaxThreadDepth = td
+				cfg.Timezone = tz
+				cfg.ImageViewer = iv
+				cfg.GraphicsProtocol = gp
+				cfg.InlineImages = ii
+				cfg.Dithering = dt
+				cfg.DitherSharpness = ds
+				cfg.Layout = ln
+			})
+			return nil
+		}
 		if min := a.layout.NeedsCompactAutoFill(a.height); min > 0 {
-			cmds := []tea.Cmd{notifyCmd}
+			cmds := []tea.Cmd{notifyCmd, saveCmd}
 			if cursor := a.feed.NextCursor(); cursor != "" && a.feed.PostCount() < min {
 				cmds = append(cmds, a.loadFeedPageCmd(cursor))
 			}
@@ -1632,7 +1657,7 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 			}
 			return a, tea.Batch(cmds...), true
 		}
-		return a, notifyCmd, true
+		return a, tea.Batch(notifyCmd, saveCmd), true
 
 	case wanderTickMsg:
 		if msg.gen != a.sessionGen {
@@ -4188,6 +4213,7 @@ type replyEditedMsg struct {
 }
 type settingsLoadedMsg struct{ settings model.Settings }
 type settingsSavedMsg struct {
+	seq              int
 	settings         model.Settings
 	wanderLust       bool
 	maxThreadDepth   int

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2072,6 +2072,26 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 
 	case guildsLoadedMsg:
 		a.guilds = a.guilds.SetGuilds(msg.guilds, msg.cursor)
+		var missing []string
+		if slug := a.currentUser.GuildSlug; slug != "" && !a.guilds.HasGuild(slug) {
+			missing = append(missing, slug)
+		}
+		for _, slug := range a.ownApprenticeSlugs {
+			if slug != "" && !a.guilds.HasGuild(slug) {
+				missing = append(missing, slug)
+			}
+		}
+		if len(missing) == 0 {
+			return a, nil, true
+		}
+		cmds := make([]tea.Cmd, len(missing))
+		for i, slug := range missing {
+			cmds[i] = a.loadOwnGuildIntoListCmd(slug)
+		}
+		return a, tea.Batch(cmds...), true
+
+	case ownGuildInjectMsg:
+		a.guilds = a.guilds.InjectGuild(msg.guild)
 		return a, nil, true
 
 	case screens.LoadMoreGuildsMsg:
@@ -4419,6 +4439,7 @@ type guildsLoadedMsg struct {
 	guilds []model.Guild
 	cursor string
 }
+type ownGuildInjectMsg struct{ guild model.Guild }
 type guildsPageMsg struct {
 	guilds []model.Guild
 	cursor string
@@ -5397,6 +5418,22 @@ func (a *App) loadGuildDetailCmd(slug string) tea.Cmd {
 			return actionErrMsg{err}
 		}
 		return guildDetailLoadedMsg{guild: g}
+	}
+}
+
+// loadOwnGuildIntoListCmd fetches a single guild (the user's badge guild or
+// one of their apprenticeships) directly when the paginated,
+// most-populated-first guild list didn't include it on the first page —
+// otherwise sortGuildsForDisplay has nothing to float to the top. Failure is
+// silent: the list still works, it just won't show that guild pinned until
+// pagination reaches it.
+func (a *App) loadOwnGuildIntoListCmd(slug string) tea.Cmd {
+	return func() tea.Msg {
+		g, err := a.client.GetGuild(slug)
+		if err != nil {
+			return nil
+		}
+		return ownGuildInjectMsg{guild: g}
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -674,12 +674,21 @@ func (a App) WithEphemeralSession() App {
 	return a
 }
 
+// saveConfigMu serializes saveConfig's load-mutate-write cycle across the
+// several tea.Cmd goroutines that can call it concurrently (settings save,
+// density toggle, theme save, login, ...). Without it, two overlapping calls
+// each read the same stale snapshot and the last write wins, silently
+// discarding whichever fields the other call touched.
+var saveConfigMu sync.Mutex
+
 // saveConfig loads the persisted config, applies mutate, and writes it back. It
 // is a no-op for ephemeral (SSH-hosted) sessions.
 func (a *App) saveConfig(mutate func(cfg *config.Config)) {
 	if a.ephemeral {
 		return
 	}
+	saveConfigMu.Lock()
+	defer saveConfigMu.Unlock()
 	cfg, err := config.Load()
 	if err != nil {
 		return

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2242,7 +2242,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "✓ "+verb+" #"+msg.name)
-		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
+		return a, tea.Batch(notifyCmd, a.loadGuildsCmd(""), a.loadUserGuildsCmd(a.currentUser.Username)), true
 
 	case guildLeftMsg:
 		a.guilds = a.guilds.BackToGuildList()
@@ -2255,7 +2255,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "✓ Left #"+msg.name)
-		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
+		return a, tea.Batch(notifyCmd, a.loadGuildsCmd(""), a.loadUserGuildsCmd(a.currentUser.Username)), true
 
 	case guildPromotedMsg:
 		detail := a.guilds.GuildDetail()
@@ -2268,7 +2268,7 @@ func (a App) handleGuilds(msg tea.Msg) (App, tea.Cmd, bool) {
 		a.guilds = a.guilds.SetOwnGuildSlug(msg.slug)
 		var notifyCmd tea.Cmd
 		a, notifyCmd = a.notify(notifyInfo, "✓ #"+msg.name+" is now your guild badge")
-		return a, tea.Batch(notifyCmd, a.loadGuildsCmd("")), true
+		return a, tea.Batch(notifyCmd, a.loadGuildsCmd(""), a.loadUserGuildsCmd(a.currentUser.Username)), true
 	}
 	return a, nil, false
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -29,6 +29,22 @@ func keyMsg(key string) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
 }
 
+// runCmd executes cmd the way the real bubbletea runtime would: a
+// tea.BatchMsg result is a bundle of not-yet-run cmds, not an executed one,
+// so it must be recursed into rather than just called once.
+func runCmd(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			runCmd(t, c)
+		}
+	}
+}
+
 func newTestApp() App {
 	return NewApp(api.NewMockClient())
 }
@@ -5187,7 +5203,7 @@ func TestHandleSettings_SavingUnrelatedSettingPreservesProbedProtocol(t *testing
 	a.graphicsProtocol = imgview.ProtocolSixel
 	a.graphicsProtocolName = "" // auto — the only way DetectProtocol() ever gets consulted
 
-	_, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
+	a, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
 		GraphicsProtocol: "", // unchanged
 		Dithering:        true,
 		ImageViewer:      "terminal",
@@ -5210,6 +5226,98 @@ func TestHandleSettings_SavingUnrelatedSettingPreservesProbedProtocol(t *testing
 	}
 }
 
+// TestHandleSettings_OutOfOrderSaveDoesNotClobberNewer reproduces a real
+// corruption: ctrl+s dispatches a save whose cmd may call the (network) API
+// before persisting to disk. Pressing ctrl+s again before that first save's
+// cmd returns dispatches a second save; if the two ever complete out of
+// order, the first (now-stale) one landing last must not overwrite the
+// second (newer) one's values in memory or in ~/.cyber-tui.json — this is
+// exactly how wander mode, timezone, thread depth, dithering, and the
+// graphics protocol override (observed flipping a deliberately-set "sixel"
+// back to an earlier "kitty") were seen reverting to their pre-edit values
+// after a restart.
+func TestHandleSettings_OutOfOrderSaveDoesNotClobberNewer(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	a := loggedInApp()
+	a.graphicsProtocol = imgview.ProtocolKitty
+	a.graphicsProtocolName = "kitty"
+
+	var cmd1 tea.Cmd
+	var ok bool
+	a, cmd1, ok = a.handleSettings(screens.SaveSettingsMsg{
+		WanderLust:       true,
+		Timezone:         "UTC+2",
+		ImageViewer:      "terminal",
+		GraphicsProtocol: "kitty", // unchanged from the pre-save value
+	})
+	if !ok || cmd1 == nil {
+		t.Fatal("expected first SaveSettingsMsg to be handled")
+	}
+
+	var cmd2 tea.Cmd
+	a, cmd2, ok = a.handleSettings(screens.SaveSettingsMsg{
+		WanderLust:       true,
+		Timezone:         "UTC+5:30",
+		MaxThreadDepth:   7,
+		ImageViewer:      "terminal",
+		GraphicsProtocol: "sixel", // the user's real, later edit
+	})
+	if !ok || cmd2 == nil {
+		t.Fatal("expected second SaveSettingsMsg to be handled")
+	}
+
+	// Second (newer) save completes first.
+	saved2 := cmd2().(settingsSavedMsg)
+	var diskCmd2 tea.Cmd
+	a, diskCmd2, ok = a.handleSettings(saved2)
+	if !ok {
+		t.Fatal("expected settingsSavedMsg to be handled")
+	}
+	if diskCmd2 == nil {
+		t.Fatal("expected the newer settingsSavedMsg to dispatch a disk-write cmd")
+	}
+	runCmd(t, diskCmd2)
+
+	// First (now-stale) save completes afterward.
+	saved1 := cmd1().(settingsSavedMsg)
+	a, cmd, ok := a.handleSettings(saved1)
+	if !ok {
+		t.Fatal("expected stale settingsSavedMsg to still report handled=true")
+	}
+	if cmd != nil {
+		t.Error("stale settingsSavedMsg must not dispatch a disk-write cmd")
+	}
+	if a.timezone != "UTC+5:30" {
+		t.Errorf("timezone = %q after stale save applied, want UTC+5:30 (the newer value) to survive", a.timezone)
+	}
+	if a.maxThreadDepth != 7 {
+		t.Errorf("maxThreadDepth = %d after stale save applied, want 7 (the newer value) to survive", a.maxThreadDepth)
+	}
+	if a.graphicsProtocolName != "sixel" {
+		t.Errorf("graphicsProtocolName = %q after stale save applied, want sixel (the newer value) to survive", a.graphicsProtocolName)
+	}
+	if a.graphicsProtocol != imgview.ProtocolSixel {
+		t.Errorf("graphicsProtocol = %v after stale save applied, want ProtocolSixel", a.graphicsProtocol)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.Timezone != "UTC+5:30" {
+		t.Errorf("saved config timezone = %q, want UTC+5:30 — the stale first save must not overwrite the newer value on disk", cfg.Timezone)
+	}
+	if cfg.MaxThreadDepth != 7 {
+		t.Errorf("saved config maxThreadDepth = %d, want 7", cfg.MaxThreadDepth)
+	}
+	if cfg.GraphicsProtocol != "sixel" {
+		t.Errorf("saved config graphicsProtocol = %q, want sixel", cfg.GraphicsProtocol)
+	}
+}
+
 // TestHandleSettings_ChangingGraphicsProtocolOverrideReResolves confirms the
 // override still takes effect when the user actually changes it — the fix
 // for the regression above only skips re-resolution when the override is
@@ -5219,7 +5327,7 @@ func TestHandleSettings_ChangingGraphicsProtocolOverrideReResolves(t *testing.T)
 	a.graphicsProtocol = imgview.ProtocolSixel
 	a.graphicsProtocolName = ""
 
-	_, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
+	a, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
 		GraphicsProtocol: "kitty", // changed
 		ImageViewer:      "terminal",
 	})

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -5274,6 +5274,68 @@ func TestHandleGuilds_OwnGuildInjectMsg_AddsGuildToList(t *testing.T) {
 	}
 }
 
+// userGuildsStubClient overrides GetUserGuilds to simulate the server already
+// reflecting a just-joined apprenticeship, for testing that the Guilds tab
+// refreshes ownApprenticeSlugs after a join/leave/promote instead of relying
+// on the stale list loaded at login.
+type userGuildsStubClient struct {
+	*api.MockClient
+	guilds []model.GuildMembership
+}
+
+func (c *userGuildsStubClient) GetUserGuilds(username string) ([]model.GuildMembership, error) {
+	return c.guilds, nil
+}
+
+// TestHandleGuilds_GuildJoinedAsApprentice_RefreshesOwnApprenticeSlugs is the
+// regression test for a real bug: apprenticing to a guild mid-session never
+// refreshed a.ownApprenticeSlugs (only login and profile edits did, via
+// loadUserGuildsCmd), so the Guilds tab kept sorting/badging by the stale
+// apprenticeship list from login and the new apprenticeship never appeared.
+func TestHandleGuilds_GuildJoinedAsApprentice_RefreshesOwnApprenticeSlugs(t *testing.T) {
+	client := &userGuildsStubClient{
+		MockClient: api.NewMockClient(),
+		guilds: []model.GuildMembership{
+			{Slug: "night-owls", Role: "member"},
+			{Slug: "deep-divers", Role: "apprentice"},
+		},
+	}
+	a := NewApp(client)
+	a.active = screenGuilds
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.guilds = a.guilds.SetGuildDetail(model.Guild{ID: "g2", Slug: "deep-divers", Name: "Deep Divers"})
+
+	a2, cmd, handled := a.handleGuilds(guildJoinedMsg{slug: "deep-divers", name: "Deep Divers", role: "apprentice"})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildJoinedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected guildJoinedMsg to trigger a cmd batch")
+	}
+
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected guildJoinedMsg to dispatch a tea.Batch, got %T", cmd())
+	}
+	var refreshMsg *userGuildsLoadedMsg
+	for _, c := range batch {
+		if msg, ok := c().(userGuildsLoadedMsg); ok {
+			refreshMsg = &msg
+		}
+	}
+	if refreshMsg == nil {
+		t.Fatal("expected guildJoinedMsg's cmd batch to include a userGuilds refresh")
+	}
+
+	a3, _, handled := a2.handleProfile(*refreshMsg)
+	if !handled {
+		t.Fatal("expected userGuildsLoadedMsg to be handled")
+	}
+	if !slices.Contains(a3.ownApprenticeSlugs, "deep-divers") {
+		t.Errorf("ownApprenticeSlugs = %v, want it to contain the just-joined deep-divers", a3.ownApprenticeSlugs)
+	}
+}
+
 // TestHandleProfile_OwnProfileLoad_FetchesApprenticeships is the regression
 // test for a real bug: navigating to your own profile via the tab bar goes
 // through loadProfileCmd/profileLoadedMsg (activateScreen in layout.go), a

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -5099,6 +5099,164 @@ func TestHandleGuilds_GuildPromoted_SwapsBadge(t *testing.T) {
 	}
 }
 
+// guildFetchingClient returns a canned per-slug guild from GetGuild, or a
+// fixed error if err is set — simulates the off-first-page fetch in
+// loadOwnGuildIntoListCmd.
+type guildFetchingClient struct {
+	*api.MockClient
+	guilds map[string]model.Guild
+	err    error
+}
+
+func (c *guildFetchingClient) GetGuild(slug string) (model.Guild, error) {
+	if c.err != nil {
+		return model.Guild{}, c.err
+	}
+	return c.guilds[slug], nil
+}
+
+func TestHandleGuilds_GuildsLoaded_BadgeGuildMissing_FetchesIt(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.client = &guildFetchingClient{
+		MockClient: api.NewMockClient(),
+		guilds:     map[string]model.Guild{"night-owls": {Slug: "night-owls", Name: "Night Owls"}},
+	}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{{Slug: "deep-divers", Name: "Deep Divers"}}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch cmd for the missing badge guild")
+	}
+	msgs := resolveMsgs(cmd)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 resolved msg, got %d", len(msgs))
+	}
+	inj, ok := msgs[0].(ownGuildInjectMsg)
+	if !ok {
+		t.Fatalf("expected ownGuildInjectMsg, got %T", msgs[0])
+	}
+	if inj.guild.Slug != "night-owls" {
+		t.Errorf("injected slug = %q, want night-owls", inj.guild.Slug)
+	}
+}
+
+func TestHandleGuilds_GuildsLoaded_ApprenticeGuildMissing_FetchesIt(t *testing.T) {
+	a := loggedInApp()
+	a.ownApprenticeSlugs = []string{"deep-divers"}
+	a.client = &guildFetchingClient{
+		MockClient: api.NewMockClient(),
+		guilds:     map[string]model.Guild{"deep-divers": {Slug: "deep-divers", Name: "Deep Divers"}},
+	}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{{Slug: "night-owls", Name: "Night Owls"}}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch cmd for the missing apprentice guild")
+	}
+	msgs := resolveMsgs(cmd)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 resolved msg, got %d", len(msgs))
+	}
+	inj, ok := msgs[0].(ownGuildInjectMsg)
+	if !ok {
+		t.Fatalf("expected ownGuildInjectMsg, got %T", msgs[0])
+	}
+	if inj.guild.Slug != "deep-divers" {
+		t.Errorf("injected slug = %q, want deep-divers", inj.guild.Slug)
+	}
+}
+
+func TestHandleGuilds_GuildsLoaded_BadgeAndApprenticesMissing_FetchesAll(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.ownApprenticeSlugs = []string{"deep-divers", "sprawl-runners"}
+	a.client = &guildFetchingClient{
+		MockClient: api.NewMockClient(),
+		guilds: map[string]model.Guild{
+			"night-owls":     {Slug: "night-owls", Name: "Night Owls"},
+			"deep-divers":    {Slug: "deep-divers", Name: "Deep Divers"},
+			"sprawl-runners": {Slug: "sprawl-runners", Name: "Sprawl Runners"},
+		},
+	}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{{Slug: "chiba-city", Name: "Chiba City"}}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected fetch cmds for the three missing guilds")
+	}
+	msgs := resolveMsgs(cmd)
+	if len(msgs) != 3 {
+		t.Fatalf("expected exactly 3 resolved msgs, got %d", len(msgs))
+	}
+	got := map[string]bool{}
+	for _, m := range msgs {
+		inj, ok := m.(ownGuildInjectMsg)
+		if !ok {
+			t.Fatalf("expected ownGuildInjectMsg, got %T", m)
+		}
+		got[inj.guild.Slug] = true
+	}
+	for _, want := range []string{"night-owls", "deep-divers", "sprawl-runners"} {
+		if !got[want] {
+			t.Errorf("expected an injection for %q, got %v", want, got)
+		}
+	}
+}
+
+func TestHandleGuilds_GuildsLoaded_AllPresent_NoFetch(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.ownApprenticeSlugs = []string{"deep-divers"}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{
+		{Slug: "night-owls", Name: "Night Owls"},
+		{Slug: "deep-divers", Name: "Deep Divers"},
+	}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd != nil {
+		t.Error("expected no fetch cmd when badge and apprentice guilds are already present")
+	}
+}
+
+func TestHandleGuilds_GuildsLoaded_FetchFails_Silent(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{Username: "case", GuildSlug: "night-owls"}
+	a.client = &guildFetchingClient{MockClient: api.NewMockClient(), err: errors.New("boom")}
+
+	_, cmd, handled := a.handleGuilds(guildsLoadedMsg{guilds: []model.Guild{{Slug: "deep-divers", Name: "Deep Divers"}}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle guildsLoadedMsg")
+	}
+	if cmd == nil {
+		t.Fatal("expected a fetch cmd even though it will fail")
+	}
+	msgs := resolveMsgs(cmd)
+	if len(msgs) != 1 || msgs[0] != nil {
+		t.Errorf("expected a single nil msg on fetch failure, got %v", msgs)
+	}
+}
+
+func TestHandleGuilds_OwnGuildInjectMsg_AddsGuildToList(t *testing.T) {
+	a := loggedInApp()
+
+	a2, _, handled := a.handleGuilds(ownGuildInjectMsg{guild: model.Guild{Slug: "deep-divers", Name: "Deep Divers"}})
+	if !handled {
+		t.Fatal("expected handleGuilds to handle ownGuildInjectMsg")
+	}
+	if !a2.guilds.HasGuild("deep-divers") {
+		t.Error("expected deep-divers to be present in the guild list after injection")
+	}
+}
+
 // TestHandleProfile_OwnProfileLoad_FetchesApprenticeships is the regression
 // test for a real bug: navigating to your own profile via the tab bar goes
 // through loadProfileCmd/profileLoadedMsg (activateScreen in layout.go), a

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -5315,6 +5316,68 @@ func TestHandleSettings_OutOfOrderSaveDoesNotClobberNewer(t *testing.T) {
 	}
 	if cfg.GraphicsProtocol != "sixel" {
 		t.Errorf("saved config graphicsProtocol = %q, want sixel", cfg.GraphicsProtocol)
+	}
+}
+
+// TestSaveConfig_ConcurrentCallsDoNotClobberEachOther reproduces the general
+// lost-update race saveConfig is exposed to: unlike the ctrl+s-vs-ctrl+s case
+// above, this races saveConfig itself (as called from unrelated triggers like
+// the density toggle, theme save, and login) directly against each other.
+// Each call does its own load-mutate-write of the whole config file with no
+// synchronization beyond saveConfigMu; if that lock were missing, whichever
+// goroutine's write lands last would silently discard the other's field.
+func TestSaveConfig_ConcurrentCallsDoNotClobberEachOther(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+
+	a := loggedInApp()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			a.saveConfig(func(cfg *config.Config) {
+				cfg.Density = fmt.Sprintf("density-%d", i)
+			})
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		a.saveConfig(func(cfg *config.Config) {
+			cfg.Theme = "custom"
+			cfg.CustomPalette = &theme.Palette{Accent: "#ff00ff"}
+		})
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		a.saveConfig(func(cfg *config.Config) {
+			cfg.Timezone = "UTC+5:30"
+		})
+	}()
+	close(start)
+	wg.Wait()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.Theme != "custom" || cfg.CustomPalette == nil || cfg.CustomPalette.Accent != "#ff00ff" {
+		t.Errorf("theme save was clobbered by a concurrent save: Theme=%q CustomPalette=%v", cfg.Theme, cfg.CustomPalette)
+	}
+	if cfg.Timezone != "UTC+5:30" {
+		t.Errorf("timezone save was clobbered by a concurrent save: Timezone=%q", cfg.Timezone)
+	}
+	if !strings.HasPrefix(cfg.Density, "density-") {
+		t.Errorf("density save was clobbered by a concurrent save: Density=%q", cfg.Density)
 	}
 }
 

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -387,6 +387,31 @@ func sortGuildsForDisplay(guilds []model.Guild, ownSlug string, apprenticeSlugs 
 	return sorted
 }
 
+// HasGuild reports whether slug is present in the currently loaded guild list.
+func (m GuildsModel) HasGuild(slug string) bool {
+	for _, g := range m.guilds {
+		if g.Slug == slug {
+			return true
+		}
+	}
+	return false
+}
+
+// InjectGuild adds a guild fetched out-of-band (e.g. the user's own guild,
+// which the paginated, most-populated-first list may not reach for a while)
+// so sortGuildsForDisplay can float it to the top even though normal
+// pagination hasn't loaded it yet. No-op if already present.
+func (m GuildsModel) InjectGuild(g model.Guild) GuildsModel {
+	if m.HasGuild(g.Slug) {
+		return m
+	}
+	m.guilds = sortGuildsForDisplay(append(m.guilds, g), m.ownGuildSlug, m.ownApprenticeSlugs)
+	if m.ready {
+		m = m.refreshContent()
+	}
+	return m
+}
+
 // isOwnGuild reports whether slug is the logged-in user's badge guild.
 func (m GuildsModel) isOwnGuild(slug string) bool {
 	return m.ownGuildSlug != "" && slug == m.ownGuildSlug

--- a/internal/ui/screens/guilds_test.go
+++ b/internal/ui/screens/guilds_test.go
@@ -146,6 +146,52 @@ func TestGuildsModel_SetGuilds_ApprenticesOrderedByMemberCount(t *testing.T) {
 	}
 }
 
+func TestGuildsModel_HasGuild_TrueForLoadedSlug(t *testing.T) {
+	m := screens.NewGuildsModel().SetGuilds(sampleGuilds(), "")
+	if !m.HasGuild("alpha") {
+		t.Error("expected HasGuild(\"alpha\") to be true after SetGuilds")
+	}
+}
+
+func TestGuildsModel_HasGuild_FalseForMissingSlug(t *testing.T) {
+	m := screens.NewGuildsModel().SetGuilds(sampleGuilds(), "")
+	if m.HasGuild("zzz") {
+		t.Error("expected HasGuild(\"zzz\") to be false")
+	}
+}
+
+func TestGuildsModel_InjectGuild_FloatsToTop(t *testing.T) {
+	t.Helper()
+	m := guildViewWithSize(screens.NewGuildsModel())
+	m = m.SetOwnGuildSlug("epsilon")
+	m = m.SetGuilds(orderedGuilds(), "") // epsilon is not present on this page
+
+	m = m.InjectGuild(model.Guild{ID: "g5", Name: "Epsilon", Slug: "epsilon", MemberCount: 20})
+
+	view := m.View()
+	epsilonPos := strings.Index(view, "Epsilon")
+	alphaPos := strings.Index(view, "Alpha")
+	if epsilonPos == -1 || alphaPos == -1 {
+		t.Fatal("expected both Epsilon and Alpha present in view")
+	}
+	if epsilonPos > alphaPos {
+		t.Errorf("Epsilon (own guild, injected) should render before Alpha")
+	}
+}
+
+func TestGuildsModel_InjectGuild_NoopIfAlreadyPresent(t *testing.T) {
+	t.Helper()
+	m := guildViewWithSize(screens.NewGuildsModel())
+	m = m.SetGuilds(sampleGuilds(), "") // already contains slug "beta" / name "Beta"
+
+	m = m.InjectGuild(model.Guild{ID: "g99", Name: "Beta-duplicate", Slug: "beta"})
+
+	view := m.View()
+	if strings.Contains(view, "Beta-duplicate") {
+		t.Error("expected InjectGuild to no-op when the slug is already present, not add a duplicate row")
+	}
+}
+
 func TestGuildsModel_RenderGuildItem_ShowsMembershipIcons(t *testing.T) {
 	t.Helper()
 	m := guildViewWithSize(screens.NewGuildsModel())


### PR DESCRIPTION
## Release v0.8.6.4

Incremental TUI release on top of v0.8.6.3.

## Changes

- fix: drop out-of-order settings saves instead of persisting them. A second ctrl+s before the first save's network round-trip returned could let the stale save land last and overwrite the newer one, in memory and on disk. A `settingsSaveSeq` counter now drops stale completions.
- fix: float apprentice guilds missing from page 1 into the guild list. The Guilds tab only floats the user's badge/apprenticed guilds to the top of the already-loaded page; a low-membership guild sitting deep in the paginated, most-populated-first list would never load. Missing own guilds are now fetched individually and injected.
- fix: serialize saveConfig to prevent concurrent saves clobbering each other. Beyond the settings-vs-settings race fixed above, five other independent triggers (density toggle, theme editor/picker, login, token-login, wander-tick) each did an unsynchronized load-mutate-write of the whole config file. A mutex now serializes the whole critical section across every caller.
- fix: refresh own apprenticeships after join/leave/promote. `ownApprenticeSlugs` was only refreshed at login and after profile edits, so a guild joined/left/promoted mid-session wouldn't update the Guilds tab's sort order until the app restarted.

## Testing

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./...` — all packages pass
- Each fix carries its own regression test; all four were confirmed meaningful by temporarily reverting and observing the test fail