### PR TITLE
feat: check for a newer release on startup

### DIFF
--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -289,6 +289,14 @@ SSH mode is experimental and unauthenticated; startup warns accordingly. The SSH
 
 ---
 
+### `internal/update`
+
+#### `check.go`
+
+`Latest(ctx) (Release, error)` fetches GitHub's latest-release API and returns `{TagName, HTMLURL}`. Dedicated HTTP client (8s timeout, identifying User-Agent), independent of the cyberspace.online API client. Used once at startup to power the update-available banner — see `docs/47-update-check.md`.
+
+---
+
 ### `internal/ui`
 
 #### `app.go`

--- a/docs/37-threatcrush-scanning.md
+++ b/docs/37-threatcrush-scanning.md
@@ -93,6 +93,14 @@ A scan of this repo reports **seven** suppressions, not six: the Go example
 above is real text in a real file, so its own `threatcrush-disable-next-line`
 line suppresses the mock string it demonstrates.
 
+One more, added later — `sql-format-call` in `internal/ui/app.go` (the
+update-available notification's `fmt.Sprintf` call, `docs/47-update-check.md`):
+the rule pattern-matches *any* format-helper call building a string and
+labels it "SQL text produced by a format helper," with no actual SQL/database
+code anywhere in this repo to be near. Medium severity, so it never hit the
+`--fail-on critical,high` gate — suppressed anyway to keep the Security tab
+free of noise that would otherwise need re-explaining on every future scan.
+
 ## Running locally
 
 ```bash

--- a/docs/47-update-check.md
+++ b/docs/47-update-check.md
@@ -1,0 +1,37 @@
+# 47 — Startup update check
+
+## Purpose
+Let a user on a released binary know a newer version exists, without polling,
+without any config, and without ever blocking or interrupting startup.
+
+## Behaviour
+- Runs once, right after login succeeds (`afterLoginCmd`, `internal/ui/app.go`)
+  — batched alongside the other startup background checks (unread count,
+  wander mode). Not on a repeating schedule; a fresh check only happens on
+  the next app launch.
+- Gated on `version.Version != "dev"` (`internal/version`) — only released
+  builds check. A `go run`/untagged build (`Version == "dev"`) never makes
+  the network call at all.
+- `internal/update.Latest` fetches
+  `https://api.github.com/repos/ArmadilloBrillo/cyber-tui/releases/latest`
+  with a dedicated 8s-timeout HTTP client (never the authenticated
+  cyberspace.online API client) and compares the returned `tag_name` against
+  `version.Version` by plain string inequality — a release build's version
+  is always exactly the tag it was built from (see `.github/workflows/release.yml`
+  ldflags), so any difference means a newer tag was published.
+- If newer, the existing global banner (`App.notify`, `notifyWarn`) shows
+  once: `"update available: vX.Y.Z (you have vA.B.C) — <release URL>"`. It
+  auto-dismisses like every other notification (4s or next keypress) — no
+  persistent UI, no dismiss-forever state.
+- Every failure mode — network error, non-200, malformed JSON, already on
+  the latest tag — silently produces no message. The user is never shown an
+  error for this.
+- Skipped entirely for ephemeral (SSH-hosted) sessions, matching wander
+  mode's convention of never touching state for those sessions.
+
+## Non-goals
+No throttle/persistence (`LastUpdateCheck`, etc.) — deliberately dropped in
+favor of "just check on startup," since a fresh app launch is already a
+natural, infrequent cadence. No semver dependency — tags aren't strict
+semver (`v0.8.6.4`), and string inequality against the one authoritative
+"latest" tag is sufficient without ordering logic.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1715,6 +1715,7 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 
 	case updateAvailableMsg:
 		var cmd tea.Cmd
+		// threatcrush-disable-next-line sql-format-call  UI notification string, no SQL anywhere in this codebase
 		a, cmd = a.notify(notifyWarn, fmt.Sprintf("update available: %s (you have %s) — %s", msg.tag, version.Version, msg.url))
 		return a, cmd, true
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -26,6 +26,8 @@ import (
 	"github.com/ragnar/cyber-tui/internal/ui/screens"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 	"github.com/ragnar/cyber-tui/internal/ui/urlutil"
+	"github.com/ragnar/cyber-tui/internal/update"
+	"github.com/ragnar/cyber-tui/internal/version"
 )
 
 type screen int
@@ -1710,6 +1712,11 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 			})
 		}
 		return a, nil, true
+
+	case updateAvailableMsg:
+		var cmd tea.Cmd
+		a, cmd = a.notify(notifyWarn, fmt.Sprintf("update available: %s (you have %s) — %s", msg.tag, version.Version, msg.url))
+		return a, cmd, true
 	}
 	return a, nil, false
 }
@@ -4197,6 +4204,7 @@ func (a *App) afterLoginCmd() tea.Cmd {
 		a.scheduleWanderCmd(),
 		a.checkAndWanderCmd(),
 		a.scheduleLogoAnimCmd(),
+		a.checkForUpdateCmd(),
 	)
 }
 
@@ -4296,6 +4304,7 @@ type settingsSavedMsg struct {
 }
 type wanderTickMsg struct{ gen int }
 type wanderDoneMsg struct{ at time.Time } // zero At means no update was made
+type updateAvailableMsg struct{ tag, url string }
 type errMsg struct{ err error }
 
 // notifPostLoadErrMsg is the failure of opening a post from the Notifications
@@ -5822,6 +5831,25 @@ func (a *App) checkAndWanderCmd() tea.Cmd {
 			return wanderDoneMsg{}
 		}
 		return wanderDoneMsg{at: time.Now().UTC()}
+	}
+}
+
+// checkForUpdateCmd checks GitHub for a newer release once at startup, only
+// on an actual released build (version.Version != "dev"). All failures —
+// including "already on the latest release" — are silent; the user is only
+// notified when a strictly newer tag is found.
+func (a *App) checkForUpdateCmd() tea.Cmd {
+	if a.ephemeral || version.Version == "dev" {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		rel, err := update.Latest(ctx)
+		if err != nil || rel.TagName == "" || rel.TagName == version.Version {
+			return nil
+		}
+		return updateAvailableMsg{tag: rel.TagName, url: rel.HTMLURL}
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ragnar/cyber-tui/internal/ui/imgview"
 	"github.com/ragnar/cyber-tui/internal/ui/screens"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
+	"github.com/ragnar/cyber-tui/internal/version"
 )
 
 func keyMsg(key string) tea.KeyMsg {
@@ -5811,4 +5812,43 @@ func TestWithSavedPreferences_LoadsWithoutRefreshToken(t *testing.T) {
 	if a.timezone != "UTC+2" {
 		t.Errorf("timezone = %q, want UTC+2", a.timezone)
 	}
+}
+
+// --- checkForUpdateCmd / updateAvailableMsg ---
+
+func TestCheckForUpdateCmd_SkipsDevVersion(t *testing.T) {
+	// version.Version defaults to "dev" for a plain `go test` build, which is
+	// exactly the case this must skip — no ldflags override needed.
+	a := loggedInApp()
+	if cmd := a.checkForUpdateCmd(); cmd != nil {
+		t.Error("checkForUpdateCmd on a dev build: expected nil cmd, got non-nil")
+	}
+}
+
+func TestCheckForUpdateCmd_SkipsEphemeralSession(t *testing.T) {
+	old := version.Version
+	version.Version = "v1.0.0"
+	t.Cleanup(func() { version.Version = old })
+
+	a := loggedInApp()
+	a.ephemeral = true
+	if cmd := a.checkForUpdateCmd(); cmd != nil {
+		t.Error("checkForUpdateCmd on an ephemeral session: expected nil cmd, got non-nil")
+	}
+}
+
+func TestHandleSettings_UpdateAvailableMsgShowsBanner(t *testing.T) {
+	a := loggedInApp()
+
+	a, cmd, ok := a.handleSettings(updateAvailableMsg{tag: "v9.9.9", url: "https://example.com/releases/v9.9.9"})
+	if !ok {
+		t.Fatal("handleSettings did not claim updateAvailableMsg")
+	}
+	if a.notifyLevel != notifyWarn {
+		t.Errorf("notifyLevel = %v, want notifyWarn", a.notifyLevel)
+	}
+	if !strings.Contains(a.notifyText, "v9.9.9") {
+		t.Errorf("notifyText = %q, want it to mention v9.9.9", a.notifyText)
+	}
+	runCmd(t, cmd) // just confirm the expire-tick cmd doesn't panic
 }

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -1,0 +1,62 @@
+// Package update checks GitHub for a newer cyber-tui release.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ragnar/cyber-tui/internal/version"
+)
+
+// userAgent identifies cyber-tui to the GitHub API, matching the convention
+// used for image fetches (internal/ui/imgview/fetch.go) — Go's default UA is
+// discouraged by GitHub's API etiquette.
+var userAgent = "cyber-tui/" + version.Version + " (+https://github.com/ArmadilloBrillo/cyber-tui)"
+
+// httpClient is dedicated to update checks so this path never inherits
+// global mutations to http.DefaultClient.
+var httpClient = &http.Client{Timeout: 8 * time.Second}
+
+// latestReleaseURL is a var (not const) so tests can point it at an
+// httptest.Server instead of the real GitHub API.
+var latestReleaseURL = "https://api.github.com/repos/ArmadilloBrillo/cyber-tui/releases/latest"
+
+// maxResponseBytes caps how much of the response body is read, defending
+// against a misbehaving or malicious endpoint.
+const maxResponseBytes = 1 << 20
+
+// Release is the subset of GitHub's release JSON this package needs.
+type Release struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// Latest fetches the latest published release from GitHub.
+func Latest(ctx context.Context) (Release, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return Release{}, fmt.Errorf("update: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return Release{}, fmt.Errorf("update: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Release{}, fmt.Errorf("update: unexpected status %d", resp.StatusCode)
+	}
+
+	var rel Release
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&rel); err != nil {
+		return Release{}, fmt.Errorf("update: %w", err)
+	}
+	return rel, nil
+}

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -1,0 +1,51 @@
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func serve(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { latestReleaseURL = "https://api.github.com/repos/ArmadilloBrillo/cyber-tui/releases/latest" })
+	latestReleaseURL = srv.URL
+	return srv
+}
+
+func TestLatest_ParsesRelease(t *testing.T) {
+	serve(t, http.StatusOK, `{"tag_name":"v1.2.3","html_url":"https://example.com/releases/v1.2.3"}`)
+
+	rel, err := Latest(context.Background())
+	if err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+	if rel.TagName != "v1.2.3" {
+		t.Errorf("TagName = %q, want v1.2.3", rel.TagName)
+	}
+	if rel.HTMLURL != "https://example.com/releases/v1.2.3" {
+		t.Errorf("HTMLURL = %q, want https://example.com/releases/v1.2.3", rel.HTMLURL)
+	}
+}
+
+func TestLatest_NonOKStatus(t *testing.T) {
+	serve(t, http.StatusNotFound, `{"message":"Not Found"}`)
+
+	if _, err := Latest(context.Background()); err == nil {
+		t.Fatal("Latest: expected error for 404, got nil")
+	}
+}
+
+func TestLatest_MalformedJSON(t *testing.T) {
+	serve(t, http.StatusOK, `not json`)
+
+	if _, err := Latest(context.Background()); err == nil {
+		t.Fatal("Latest: expected error for malformed JSON, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
Adds a one-shot startup update check: once per app launch, after login, a released build checks GitHub's latest release and shows a dismissible banner if a newer tag exists.

## Behaviour
- Gated on `version.Version != "dev"` — only released builds check, never a `go run`/untagged build.
- New `internal/update` package: `Latest(ctx)` hits `https://api.github.com/repos/ArmadilloBrillo/cyber-tui/releases/latest` with a dedicated 8s-timeout HTTP client (not the authenticated cyberspace.online API client).
- Version comparison is a plain string inequality against the returned `tag_name` — no semver dependency needed, since a release build's version is always exactly its tag.
- Wired into `afterLoginCmd()` alongside the other startup background checks (unread count, wander mode).
- On a newer tag, shows the existing global banner (`notifyWarn`) once — auto-dismisses like every other notification.
- Silent on any failure (network error, non-200, malformed JSON) or when already on the latest tag. Skipped entirely for ephemeral (SSH-hosted) sessions.
- No schedule/throttle and no persisted config — deliberately dropped in favor of "just check on startup."

## Testing
- `go build ./...`, `go vet ./...`, `staticcheck ./...` all clean
- `go test ./...` passes, including new tests:
  - `internal/update`: `TestLatest_ParsesRelease`, `TestLatest_NonOKStatus`, `TestLatest_MalformedJSON`
  - `internal/ui`: `TestCheckForUpdateCmd_SkipsDevVersion`, `TestCheckForUpdateCmd_SkipsEphemeralSession`, `TestHandleSettings_UpdateAvailableMsgShowsBanner`

## Docs
- New `docs/47-update-check.md`
- `docs/00-project-reference.md` updated with the new package entry
