### PR TITLE
feat: add ctrl+j song-attach modal for cIRC

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -192,6 +192,7 @@ cIRC/C-Mail messages can now carry `imageUrl`, `gifUrl` (`/gif <url>`), `audioAt
 | `gifUrl`, `audioAttachment`, `style`, chained styles | Render/decode in message view; `style: "art"` needs base64 decode | **Done** — wire/model fields across all four message shapes, attachment badges reusing `renderAttachments`, and a middle-fidelity style pipeline (ANSI attributes for blink/quiet/rainbow, Unicode substitution for l33t/cursive/flip, ASCII-safe jitter for glitch, `tea.Tick`-driven slow/wave/glitch animation, select-to-reveal spoiler in cIRC only — see `internal/ui/screens/chatstyle.go`) |
 | `/mute` family + `mutedUsersByRoom` | Client-side message filtering by muted user | **Done** — cIRC only (C-Mail 400s per API spec); see `docs/37-circ-mute.md` |
 | Empty `content` with attachment-only messages | Message rendering must not assume non-empty `content` | **Done** — covered by the same change; `messageDisplayBody` skips duplicate URL text and empty bodies render without assuming non-empty `content` |
+| `/song` composer UI | A guided way to build the `/song <url> \| <artist> \| <title> [\| <genre>]` command instead of hand-typing it | **Done** — `ctrl+j` Song Prompt modal in cIRC (supporter-gated client-side ahead of the server's 403), artist/title auto-filled via YouTube's public oEmbed endpoint (`internal/youtube`); see `docs/49-song-attach.md`. C-Mail not covered (out of this feature's scope, though the API accepts `/song` there too) |
 
 ### cIRC idle presence (new in v0.8.1)
 

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -697,6 +697,17 @@ Fetches and displays images in the terminal using native graphics protocols (Kit
 
 ---
 
+### `internal/youtube`
+
+Lightweight, unauthenticated helpers for YouTube video links — no `internal/api` dependency (this talks to `youtube.com`, not cyberspace.online). Backs the Song Prompt modal's auto-fill (`docs/49-song-attach.md`).
+
+| Identifier | Kind | Purpose |
+|---|---|---|
+| `ExtractVideoID(rawURL string) (id string, ok bool)` | func | Recognizes `youtube.com/watch?v=`, `youtu.be/<id>`, `youtube.com/shorts/<id>`, `youtube.com/embed/<id>` (`www.`/`m.` host prefixes accepted). Client-side validation ahead of a fetch or submit — the server itself 400s a non-YouTube `/song` link |
+| `FetchMetadata(ctx, rawURL) (title, author string, err error)` | func | GETs YouTube's public oEmbed endpoint, no API key. `author_name` (the channel) stands in for "artist" — oEmbed has no artist/genre field, so genre is always left for the user to fill in manually. Own `http.Client` (8s timeout) and User-Agent, mirroring `internal/ui/imgview/fetch.go`'s pattern for third-party fetches |
+
+---
+
 ## Configuration File
 
 Location: `~/.cyber-tui.json`  
@@ -918,6 +929,37 @@ fields.
 | `ctrl+s` | Submit (validates the slug field first; invalid slug refocuses it with an inline error) |
 | `esc` | Cancel |
 
+### Icon Picker
+
+`Ctrl+]` (`internal/ui/screens/iconpicker.go`) opens a modal over any focused
+compose input: tabs between icon sets, a live search box, and a scrollable
+list. Two tabs — Emoji and Kaomoji.
+
+| Key | Action |
+|---|---|
+| `tab` / `shift+tab` | Switch icon set |
+| `↑`/`↓`, `pgup`/`pgdn` | Move selection |
+| (typing) | Filter the active set by name |
+| `enter` | Insert the selected icon and close the picker |
+| `ctrl+n` | Insert the selected icon and leave the picker open, for inserting several in a row |
+| `esc` | Close without inserting |
+
+### Song Prompt
+
+`ctrl+j` (`internal/ui/screens/songprompt.go`) opens a modal over CIRC's
+composer (supporter accounts only — see the CIRC table below) for attaching
+a YouTube track: URL, Artist, Title, Genre. Artist/Title auto-fill
+best-effort from the URL via `internal/youtube`'s oEmbed lookup; Genre is
+always manual (oEmbed has no genre field). See `docs/49-song-attach.md`.
+
+| Key | Action |
+|---|---|
+| `tab` / `shift+tab` | Cycle fields: url → artist → title → genre |
+| `enter` on url | Validate the URL and fetch artist/title metadata, advancing focus to artist |
+| `enter` on artist/title | Advance focus (same as tab) |
+| `enter` on genre, or `ctrl+s` | Submit — hands the built `/song ...` command to the composer (still requires `enter` there to send) |
+| `esc` | Cancel without inserting anything |
+
 ### Notifications
 
 | Key | Action |
@@ -978,6 +1020,7 @@ fields.
 | `enter` | Send message (when input non-empty) |
 | `esc` | Return to list mode — or, if this room was opened via a `chat_mention` notification, leave Chatrooms entirely and return to that origin screen |
 | `ctrl+o` | Open URLs/images found across the loaded room history (plain `o` is captured by the compose input) |
+| `ctrl+j` | Open the Song Prompt modal to attach a YouTube track (supporter accounts only — a non-supporter gets a local `*** song attachments require supporter status` notice instead) |
 | all other | Forwarded to compose input |
 
 ### Search
@@ -1070,7 +1113,7 @@ Release tags follow semver: `git tag -a v0.1.0 -m "v0.1.0"`. The `--version` fla
 | **Settings — deferred fields** | `iconTheme`, `imagePixelSize`, `followedTopics`, `mutedTopics` are read from the API but intentionally excluded from PATCH until the server-side feature is finalized. `mutedUsersByRoom` is also read but excluded from PATCH for a different reason — it's server-managed via `/mute` slash commands only (see `docs/37-circ-mute.md`), never client-patched |
 | **Journal write operations** | Fully operational. `PATCH /v1/notes/:id` was fixed server-side in API v0.4. |
 | **Post/reply deletion** | Wired and working — `d` key in Feed (own posts) and Post Detail (own posts and replies) |
-| **Attachments** | Images render inline (Feed, Post Detail, Search, Topics, Guilds post lists, C-Mail, cIRC, Profile — gated by the InlineImages setting; see `docs/45-inline-images-everywhere.md`) and open in a fullscreen modal (`o`) via `internal/ui/imgview` (Kitty/iTerm2/Sixel, falling back to the OS browser when no protocol is detected or the Image Viewer setting is "browser"). YouTube audio attachments are still not supported |
+| **Attachments** | Images render inline (Feed, Post Detail, Search, Topics, Guilds post lists, C-Mail, cIRC, Profile — gated by the InlineImages setting; see `docs/45-inline-images-everywhere.md`) and open in a fullscreen modal (`o`) via `internal/ui/imgview` (Kitty/iTerm2/Sixel, falling back to the OS browser when no protocol is detected or the Image Viewer setting is "browser"). YouTube audio attachments can be composed in cIRC via the `ctrl+j` Song Prompt modal (`docs/49-song-attach.md`, supporter accounts only) — not yet available in C-Mail or for blog posts (the API only accepts them via chat's `/song` command, not the posts endpoints) |
 | **Badge icons — supporter only, posts/replies not covered** | A real inline supporter badge icon renders next to usernames on Profile and the C-Mail detail header (`docs/48-badge-icons.md`). Two things it does NOT cover: (1) Feed/Post Detail/Search/Topics/Bookmarks — post/reply API payloads carry no author badge data at all, only `authorId`/`authorUsername`; would need a per-author `GET /v1/users/:username` fetch-and-cache subsystem or the API adding these fields directly. (2) Guild badges (Guilds list icon, Profile's guild badge) — attempted and reverted, since `Guild.Icon`/`GuildIcon` values are confirmed live to be Unicode/CLDR emoji character names or an unidentified `dinkie-icons:` set, not the Lucide/Phosphor scheme `SupporterIcon` uses. See `docs/00-api-backlog.md`. |
 | **iTerm2/Sixel inline-image repaint workarounds** | First real-terminal testing of the feature (native macOS iTerm2, this was previously only eyeballed on Kitty) found several rendering bugs whose fixes lean on genuine workarounds rather than clean solutions — an inert dirty-marker byte to force Bubble Tea's per-line diff to reissue a line, and explicit on-screen-rectangle tracking to erase stale image pixels (iTerm2/Sixel have no placement/compositing concept like Kitty's). A residual single-line flash on a selection change touching a visible image was evaluated and accepted rather than fixed. See `docs/plan-inline-images-improvements.md` §8 for what each workaround depends on and when to revisit it. On Windows specifically, Sixel detection via `imgview.ProbeSixel`'s DA1 query has been observed to never receive a response from WezTerm — `DetectProtocol()`'s env-var check (`TERM_PROGRAM=WezTerm` → iTerm2 protocol) is the reliable path there instead |
 | **Inline/fullscreen images on Windows: known, accepted limitation** | Do not reliably render — a fragment appears in the wrong screen position instead. This is a Windows/ConPTY problem, not a WezTerm one: WezTerm supports the iTerm2 protocol per its own docs, and the same escape sequence renders correctly on real iTerm2 (macOS, no ConPTY involved) and in isolated replay outside Bubble Tea. Root cause: `injectInlineImages` batches each image's cursor-position (CUP) escape with the image OSC sequence into one write, and Bubble Tea's renderer (`standard_renderer.go`, vendored) always appends its own trailing cursor-position CSI after all frame content in the same syscall write — ConPTY (Windows' only pty layer, unavoidable for a native Win32 console app) is known to reorder an OSC relative to a CSI that follows it in the same write (`microsoft/terminal#17314`). Every graphics protocol this app supports has turned up a confirmed or documented Windows-specific problem during this investigation, not just iTerm2 — Kitty is unimplemented on WezTerm's Windows build entirely (`wezterm/wezterm#5757`), and Sixel is documented broken there too (`wezterm/wezterm#5758`). The workaround is Settings → Image Viewer → `browser`, which routes `o` through the OS browser instead (fully functional) and simply skips inline thumbnails; the app previously surfaced a one-time post-login notice pointing at this on Windows but it was removed as too noisy — the limitation is unchanged, just no longer announced on every login. Not fixable within cyber-tui without bypassing Bubble Tea's renderer for image writes entirely — judged not worth the architectural risk for a Windows-only ConPTY bug; not planned, and deliberately not auto-disabled (kept fully user-controlled via the existing toggle). See `docs/plan-inline-images-improvements.md` §9 for the full investigation. The unrelated fixes found along the way (WezTerm's own scroll-on-last-line bug, and images not being downscaled to their display size before encoding) are kept — both genuinely correct regardless of this outcome |

--- a/docs/49-song-attach.md
+++ b/docs/49-song-attach.md
@@ -1,0 +1,111 @@
+# 49 — /song attach modal (cIRC)
+
+## Purpose
+cyberspace.online lets a cIRC message attach a YouTube track to a room's
+jukebox via `/song <youtube url> | <artist> | <title> [| <genre>]`
+(supporter-only; see `docs/00-latest-api-reference.md`). Typing that whole
+pipe-delimited command by hand is tedious and error-prone. `ctrl+j`, while a
+cIRC room's composer is focused, opens a modal with four fields — URL,
+Artist, Title, Genre — where Artist and Title auto-fill (best-effort) from
+the pasted URL, and every field stays editable before it's sent.
+
+## Auto-fill: YouTube oEmbed (`internal/youtube`)
+`internal/youtube` is a new, network-capable-but-network-free-until-called
+package, independent of `internal/api` (this hits `youtube.com`, not
+cyberspace.online):
+- `ExtractVideoID(rawURL) (id string, ok bool)` — recognizes
+  `youtube.com/watch?v=`, `youtu.be/<id>`, `youtube.com/shorts/<id>`, and
+  `youtube.com/embed/<id>` (`www.`/`m.` host prefixes accepted). Used for
+  instant client-side validation before a fetch or submit — the server
+  itself 400s a non-YouTube `/song` link, this just avoids the round trip.
+- `FetchMetadata(ctx, rawURL) (title, author string, err error)` — GETs
+  YouTube's public oEmbed endpoint (`https://www.youtube.com/oembed?...`),
+  no API key required. `author_name` (the channel) is the best available
+  stand-in for "artist" — oEmbed has no separate artist or genre field, so
+  genre is always left for the user to fill in by hand. Own `http.Client`
+  (8s timeout) and User-Agent, mirroring `internal/ui/imgview/fetch.go`'s
+  pattern for third-party fetches.
+
+## The modal (`internal/ui/screens/songprompt.go`)
+`SongPromptModel` is a 4-field form (url/artist/title/genre `textinput`s),
+structurally closest to `PostComposePanel`'s tab-cycling `focus` enum, but
+simpler — no textarea, no toggles. It never talks to the network itself;
+`App` drives the async fetch, same split as the inline-image pipeline.
+
+- **Tab / Shift+Tab** cycle the four fields, wrapping.
+- **Enter on the URL field**: client-side validates via `ExtractVideoID`
+  (invalid → inline warning, focus stays put); if valid, `App` starts the
+  oEmbed fetch and focus moves to Artist immediately — fields populate in
+  place when the fetch resolves (`SongPromptModel.ApplyMetadata`), or a
+  "couldn't auto-fill — enter artist/title manually" note appears on error
+  (`FetchFailed`) without blocking anything.
+- **Enter on Artist/Title**: behaves like Tab (advance focus).
+- **Enter on Genre (last field), or ctrl+s from any field**: attempt
+  submit — requires a valid URL plus non-empty Artist and Title (Genre is
+  optional, matching the server's own `/song` syntax). On success the built
+  `/song ...` string is handed to the cIRC composer via the existing
+  `screens.SetComposeValueMsg` — the same mechanism `ctrl+g`'s GIF-attach
+  flow already uses (`applyAttachURL`) — so the user sees the exact command
+  in the input box and still presses Enter there to actually send it.
+- **Esc**: cancel, discard everything.
+
+## Wiring (`internal/ui/app.go`)
+- `ctrl+j` is scoped to cIRC only: `a.active == screenChatrooms &&
+  a.activeScreenHasFocusedInput()`. Non-supporters are rejected locally —
+  `a.chatrooms.AppendSystemMessage(roomID, "*** song attachments require
+  supporter status")` — instead of opening a modal whose submit would just
+  hit the server's 403; this mirrors the existing local rejection of an
+  unrecognized slash command.
+- The async fetch follows the `inlineImageFetchedMsg` /
+  `fetchInlineImageCmd` pattern exactly: `songMetadataFetchedMsg` +
+  `fetchSongMetadataCmd`, intercepted early in `Update` via
+  `handleSongMetadataFetched` (spliced in next to
+  `handleInlineImageFetched`). A result arriving after the modal was
+  cancelled is dropped rather than reopening or mutating a fresh prompt.
+- `handleSongPromptKey` mirrors `handleIconPickerKey`/
+  `handleAttachURLPromptKey`'s split: it intercepts esc/tab/shift-tab/
+  ctrl+s/enter itself, forwarding everything else into
+  `SongPromptModel.Update`.
+
+## Layout
+`renderSongPrompt(a App) string` (a one-line `a.songPrompt.View()`) was
+added to the `modalRenderer` interface and both `TabsLayout`/`MillerLayout`
+implementations, plus a `songPromptOpen` case in `compositeOverlays` —
+same shape as every other simple modal (icon picker, attach-URL prompt).
+The `ctrl+j` shortcut is listed in the help modal's global section in both
+layouts, next to `ctrl+g`.
+
+## Scope: cIRC only
+`/song` is technically accepted server-side in C-Mail too
+(`baseSlashCommands` in `chatrooms.go`), but this modal only triggers from
+cIRC, matching what was asked for. Extending it to C-Mail later is a small
+follow-up — the modal and fetch pipeline are screen-agnostic; only the
+`ctrl+j` case's `a.active == screenChatrooms` check would need to also
+allow `screenCMail`.
+
+## Verification
+- `go test ./...`, `go vet ./...`, `staticcheck ./...` — no warnings.
+- `internal/youtube/oembed_test.go`: `ExtractVideoID` across `watch?v=`,
+  `youtu.be/`, `/shorts/`, `/embed/`, `www.`/`m.` hosts, and non-YouTube/
+  malformed input; `FetchMetadata` against an `httptest.Server` for the
+  success, non-200, malformed-JSON, and missing-title paths.
+- `internal/ui/screens/songprompt_test.go`: `Open` resets/focuses, Tab/
+  Shift+Tab cycling and wrapping, typing routes to the focused field only,
+  `BuildCommand` validation (full, genre omitted, missing artist/title,
+  invalid/empty URL), `ApplyMetadata`/`FetchFailed`/`SetLoading`, and the
+  keystroke-clears-status behavior.
+- `internal/ui/app_test.go`: `ctrl+j` opens the modal for a supporter with
+  cIRC's composer focused, rejects locally (system message, no modal) for a
+  non-supporter, and is unconsumed outside cIRC (`setupCMailDetail`); esc
+  closes without submitting; Enter on a valid/invalid URL fetches-and-
+  advances vs. warns-in-place; `submitSongPrompt` closes and emits the
+  correct `SetComposeValueMsg` on valid fields, stays open with a warning
+  when a required field is missing; `handleSongMetadataFetched` applies a
+  result to an open prompt and drops one for a closed (cancelled) prompt.
+- Manual: run the TUI, open a cIRC room, `ctrl+j` on a supporter account —
+  paste a real YouTube URL, confirm artist/title populate, edit a field,
+  submit, confirm the composer shows the correct `/song` string, send it,
+  confirm the message renders with the audio attachment. Also check:
+  `ctrl+j` as a non-supporter (local rejection message, no modal), a
+  non-YouTube URL (client-side warning), and a private/unfetchable video
+  (manual-entry fallback still lets the message send).

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ragnar/cyber-tui/internal/ui/urlutil"
 	"github.com/ragnar/cyber-tui/internal/update"
 	"github.com/ragnar/cyber-tui/internal/version"
+	"github.com/ragnar/cyber-tui/internal/youtube"
 )
 
 type screen int
@@ -111,10 +112,10 @@ type App struct {
 	// tab — separate from ProfileModel's apprenticeships, which get
 	// overwritten when viewing another user's profile.
 	ownApprenticeSlugs []string
-	active      screen
-	focus       focusTarget
-	width       int
-	height      int
+	active             screen
+	focus              focusTarget
+	width              int
+	height             int
 
 	// autoEmail and autoPassword are set from the config file.
 	// When both are non-empty, Init fires loginCmd immediately.
@@ -191,6 +192,13 @@ type App struct {
 	// wherever InsertIconMsg would land — see applyAttachURL.
 	attachURLPromptOpen bool
 	attachURLPrompt     screens.PathPromptModel
+
+	// songPrompt state — open with ctrl+j from a focused cIRC composer
+	// (supporter accounts only). Submit hands off a built "/song ..."
+	// command via SetComposeValueMsg, the same mechanism ctrl+g's GIF
+	// attach uses — see applyAttachURL and submitSongPrompt.
+	songPromptOpen bool
+	songPrompt     screens.SongPromptModel
 
 	// imageCarousel state — populated when an image is opened from a picker
 	// containing more than one image, letting left/right cycle between them
@@ -605,6 +613,7 @@ func NewApp(client api.Client) App {
 		pathPrompt:         screens.NewPathPromptModel(),
 		iconPicker:         screens.NewIconPickerModel(),
 		attachURLPrompt:    screens.NewPathPromptModel(),
+		songPrompt:         screens.NewSongPromptModel(),
 		bookmarkedPostIDs:  make(map[string]struct{}),
 		bookmarkedReplyIDs: make(map[string]struct{}),
 		postBookmarkIDs:    make(map[string]string),
@@ -869,6 +878,9 @@ func (a App) updateInner(msg tea.Msg) (App, tea.Cmd) {
 	if a2, cmd, ok := a.handleInlineImageFetched(msg); ok {
 		return a2, cmd
 	}
+	if a2, cmd, ok := a.handleSongMetadataFetched(msg); ok {
+		return a2, cmd
+	}
 	if a2, cmd, ok := a.handleErr(msg); ok {
 		return a2, cmd
 	}
@@ -974,6 +986,10 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 		model, cmd := a.handleAttachURLPromptKey(m)
 		return model.(App), cmd, true
 	}
+	if a.songPromptOpen {
+		model, cmd := a.handleSongPromptKey(m)
+		return model.(App), cmd, true
+	}
 	// When a screen has a focused text input, let it consume all keys.
 	// ctrl+c is kept as a hard escape hatch; a handful of other global
 	// shortcuts get a ctrl-prefixed twin that reaches through too, since
@@ -1006,7 +1022,7 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 				(a.active == screenCMail && a.cmail.ComposeEmpty()))
 		switch {
 		case m.String() == "ctrl+o", m.String() == "ctrl+q", m.String() == "ctrl+t",
-			m.String() == "ctrl+]", m.String() == "ctrl+g", m.String() == "ctrl+left", m.String() == "ctrl+right", bareArrowEscapesEmptyCompose:
+			m.String() == "ctrl+]", m.String() == "ctrl+g", m.String() == "ctrl+j", m.String() == "ctrl+left", m.String() == "ctrl+right", bareArrowEscapesEmptyCompose:
 			// fall through to the global switch below
 		default:
 			return a, nil, false // fall through to delegateUpdate
@@ -1066,6 +1082,17 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 			a.attachURLPromptOpen = true
 			var cmd tea.Cmd
 			a.attachURLPrompt, cmd = a.attachURLPrompt.Open("attach image/gif url", "")
+			return a, cmd, true
+		}
+	case "ctrl+j":
+		if a.active == screenChatrooms && a.activeScreenHasFocusedInput() {
+			if !a.currentUser.IsSupporter {
+				a.chatrooms = a.chatrooms.AppendSystemMessage(a.chatrooms.ActiveRoomSlug(), "*** song attachments require supporter status")
+				return a, nil, true
+			}
+			a.songPromptOpen = true
+			var cmd tea.Cmd
+			a.songPrompt, cmd = a.songPrompt.Open()
 			return a, cmd, true
 		}
 	case "v":
@@ -4016,11 +4043,12 @@ func (a App) handleURLPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // handleIconPickerKey processes keyboard input while the icon picker overlay
-// is open. Esc and enter are handled here directly (mirrors
-// handleURLPickerKey); enter emits an InsertIconMsg that falls through to
-// delegateScreenUpdate and lands on whichever screen is currently active.
-// Every other key (tab/shift+tab/up/down/search typing) is forwarded to
-// IconPickerModel.Update.
+// is open. Esc, enter, and ctrl+n are handled here directly (mirrors
+// handleURLPickerKey); enter and ctrl+n both emit an InsertIconMsg that
+// falls through to delegateScreenUpdate and lands on whichever screen is
+// currently active — enter also closes the picker, ctrl+n leaves it open so
+// several icons can be inserted in a row. Every other key (tab/shift+tab/
+// up/down/search typing) is forwarded to IconPickerModel.Update.
 func (a App) handleIconPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
@@ -4032,6 +4060,14 @@ func (a App) handleIconPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		a.iconPickerOpen = false
+		return a, func() tea.Msg { return screens.InsertIconMsg{Icon: glyph} }
+	case "ctrl+n":
+		// Same as enter, but leaves the picker open so several icons can be
+		// inserted in a row without reopening it each time.
+		glyph, ok := a.iconPicker.Selected()
+		if !ok {
+			return a, nil
+		}
 		return a, func() tea.Msg { return screens.InsertIconMsg{Icon: glyph} }
 	}
 	var cmd tea.Cmd
@@ -4097,6 +4133,101 @@ func (a App) applyAttachURL(url string) (App, tea.Cmd) {
 		return a.notify(notifyWarn, "replies don't support image attachments — there's no attachments field in the reply API")
 	}
 	return a, func() tea.Msg { return screens.InsertIconMsg{Icon: "![](" + url + ")"} }
+}
+
+// handleSongPromptKey processes keyboard input while the ctrl+j song-attach
+// prompt is open. Esc/tab/shift+tab/ctrl+s are handled directly here; Enter's
+// behavior depends on which field has focus (mirrors the modal's own field
+// order): on the url field it validates and kicks off the async oEmbed
+// fetch (see fetchSongMetadataCmd), on artist/title it just advances focus
+// like tab, and on genre (the last field) it submits, same as ctrl+s. Every
+// other key is forwarded to SongPromptModel.Update.
+func (a App) handleSongPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		a.songPromptOpen = false
+		return a, nil
+	case "tab", "shift+tab":
+		var cmd tea.Cmd
+		a.songPrompt, cmd = a.songPrompt.Update(msg)
+		return a, cmd
+	case "ctrl+s":
+		return a.submitSongPrompt()
+	case "enter":
+		if a.songPrompt.OnURLField() {
+			url := a.songPrompt.URLValue()
+			if _, ok := youtube.ExtractVideoID(url); !ok {
+				a.songPrompt = a.songPrompt.SetWarning("not a recognized YouTube URL")
+				return a, nil
+			}
+			var advanceCmd tea.Cmd
+			a.songPrompt, advanceCmd = a.songPrompt.NextField()
+			a.songPrompt = a.songPrompt.SetLoading(true)
+			return a, tea.Batch(advanceCmd, a.fetchSongMetadataCmd(url))
+		}
+		if !a.songPrompt.OnLastField() {
+			var cmd tea.Cmd
+			a.songPrompt, cmd = a.songPrompt.NextField()
+			return a, cmd
+		}
+		return a.submitSongPrompt()
+	}
+	var cmd tea.Cmd
+	a.songPrompt, cmd = a.songPrompt.Update(msg)
+	return a, cmd
+}
+
+// submitSongPrompt validates the song prompt's fields and, if valid, closes
+// the modal and hands the built "/song ..." command to the chatrooms
+// composer via SetComposeValueMsg — the same handoff applyAttachURL uses
+// for ctrl+g's "/gif <url>". The user still presses Enter in the composer
+// itself to actually send it.
+func (a App) submitSongPrompt() (App, tea.Cmd) {
+	cmd, ok := a.songPrompt.BuildCommand()
+	if !ok {
+		a.songPrompt = a.songPrompt.SetWarning("enter a YouTube URL, artist, and title")
+		return a, nil
+	}
+	a.songPromptOpen = false
+	return a, func() tea.Msg { return screens.SetComposeValueMsg{Value: cmd} }
+}
+
+// songMetadataFetchedMsg reports the result of one fetchSongMetadataCmd.
+type songMetadataFetchedMsg struct {
+	title  string
+	artist string
+	err    error
+}
+
+// fetchSongMetadataCmd looks up rawURL's title/channel via YouTube's public
+// oEmbed endpoint (internal/youtube) — best-effort autofill, never blocking
+// submission (see SongPromptModel.FetchFailed).
+func (a App) fetchSongMetadataCmd(rawURL string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		title, artist, err := youtube.FetchMetadata(ctx, rawURL)
+		return songMetadataFetchedMsg{title: title, artist: artist, err: err}
+	}
+}
+
+// handleSongMetadataFetched applies a resolved songMetadataFetchedMsg to the
+// still-open song prompt. If the prompt was closed (cancelled) before the
+// fetch resolved, the result is simply dropped.
+func (a App) handleSongMetadataFetched(msg tea.Msg) (App, tea.Cmd, bool) {
+	m, ok := msg.(songMetadataFetchedMsg)
+	if !ok {
+		return a, nil, false
+	}
+	if !a.songPromptOpen {
+		return a, nil, true
+	}
+	if m.err != nil {
+		a.songPrompt = a.songPrompt.FetchFailed()
+	} else {
+		a.songPrompt = a.songPrompt.ApplyMetadata(m.title, m.artist)
+	}
+	return a, nil, true
 }
 
 // --- commands ---
@@ -4340,13 +4471,13 @@ type settingsSavedMsg struct {
 	feedManualRefreshOnly   bool
 	typingIndicatorsEnabled bool
 	maxThreadDepth          int
-	timezone         string
-	imageViewer      string
-	graphicsProtocol string
-	inlineImages     bool
-	dithering        bool
-	ditherSharpness  string
-	layoutName       string
+	timezone                string
+	imageViewer             string
+	graphicsProtocol        string
+	inlineImages            bool
+	dithering               bool
+	ditherSharpness         string
+	layoutName              string
 }
 type wanderTickMsg struct{ gen int }
 type wanderDoneMsg struct{ at time.Time } // zero At means no update was made

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/ragnar/cyber-tui/internal/api"
 	"github.com/ragnar/cyber-tui/internal/config"
 	"github.com/ragnar/cyber-tui/internal/model"
@@ -1876,7 +1877,7 @@ func TestHandleSettings_ManualToAutoRestartsFeedPoll(t *testing.T) {
 
 	a, cmd, ok := a.handleSettings(screens.SaveSettingsMsg{
 		FeedManualRefreshOnly: false,
-		ImageViewer:            "terminal",
+		ImageViewer:           "terminal",
 	})
 	if !ok || cmd == nil {
 		t.Fatal("expected handleSettings to handle SaveSettingsMsg with a non-nil cmd")
@@ -2872,6 +2873,255 @@ func TestHandleKeys_CtrlG_OpensAttachURLPrompt_WhenInputFocused(t *testing.T) {
 	}
 	if !a2.attachURLPromptOpen {
 		t.Error("expected attachURLPromptOpen = true after ctrl+g")
+	}
+}
+
+// --- ctrl+j / song prompt ---
+
+func TestHandleKeys_CtrlJ_OpensSongPrompt_WhenSupporterAndChatroomsFocused(t *testing.T) {
+	a := setupChatroomsDetailWithURL(loggedInApp())
+	a.currentUser = model.User{IsSupporter: true}
+	if !a.chatrooms.InputFocused() {
+		t.Fatal("setup: expected chatrooms input focused in detail mode")
+	}
+
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if !consumed {
+		t.Fatal("expected ctrl+j to be consumed while cIRC's compose field is focused")
+	}
+	if !a2.songPromptOpen {
+		t.Error("expected songPromptOpen = true after ctrl+j for a supporter")
+	}
+}
+
+// TestHandleKeys_CtrlJ_NonSupporter_RejectsLocally_DoesNotOpenModal guards
+// the client-side supporter gate: /song is 403 server-side for a
+// non-supporter, so ctrl+j should reject instantly with a local system
+// message instead of opening a modal whose submit would just fail later.
+func TestHandleKeys_CtrlJ_NonSupporter_RejectsLocally_DoesNotOpenModal(t *testing.T) {
+	a := setupChatroomsDetailWithURL(loggedInApp())
+	a.currentUser = model.User{IsSupporter: false}
+
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if !consumed {
+		t.Fatal("expected ctrl+j to be consumed even when rejected locally")
+	}
+	if a2.songPromptOpen {
+		t.Error("expected songPromptOpen to stay false for a non-supporter")
+	}
+	if !strings.Contains(ansi.Strip(a2.chatrooms.View()), "supporter status") {
+		t.Error("expected a local system message explaining the supporter requirement")
+	}
+}
+
+// TestHandleKeys_CtrlJ_NotConsumed_OutsideChatrooms guards the scoping to
+// cIRC only — /song is technically accepted server-side in C-Mail too
+// (baseSlashCommands), but this modal is cIRC-only per the feature's scope.
+func TestHandleKeys_CtrlJ_NotConsumed_OutsideChatrooms(t *testing.T) {
+	a := setupCMailDetail(loggedInApp())
+	a.currentUser = model.User{IsSupporter: true}
+
+	_, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if consumed {
+		t.Error("expected ctrl+j to be unconsumed (and not open the song prompt) outside cIRC")
+	}
+}
+
+// TestHandleSongPromptKey_Esc_ClosesWithoutSubmitting guards cancellation.
+func TestHandleSongPromptKey_Esc_ClosesWithoutSubmitting(t *testing.T) {
+	a := loggedInApp()
+	a.songPromptOpen = true
+	a.songPrompt, _ = a.songPrompt.Open()
+
+	model, cmd := a.handleSongPromptKey(tea.KeyMsg{Type: tea.KeyEsc})
+	a2 := model.(App)
+	if a2.songPromptOpen {
+		t.Error("expected songPromptOpen = false after esc")
+	}
+	if cmd != nil {
+		t.Error("expected esc to return no cmd")
+	}
+}
+
+// TestHandleSongPromptKey_EnterOnURL_ValidURL_FetchesAndAdvancesFocus guards
+// the url-field Enter behavior: a valid YouTube URL should trigger the
+// metadata fetch and move focus to artist, not submit.
+func TestHandleSongPromptKey_EnterOnURL_ValidURL_FetchesAndAdvancesFocus(t *testing.T) {
+	a := loggedInApp()
+	a.songPromptOpen = true
+	a.songPrompt, _ = a.songPrompt.Open()
+	for _, r := range "https://youtu.be/dQw4w9WgXcQ" {
+		a.songPrompt, _ = a.songPrompt.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	model, cmd := a.handleSongPromptKey(tea.KeyMsg{Type: tea.KeyEnter})
+	a2 := model.(App)
+	if a2.songPrompt.OnURLField() {
+		t.Error("expected enter on a valid url to advance focus off the url field")
+	}
+	if !a2.songPromptOpen {
+		t.Error("expected the prompt to stay open while the fetch is in flight")
+	}
+	if cmd == nil {
+		t.Fatal("expected enter on a valid url to return a cmd (the metadata fetch)")
+	}
+}
+
+// TestHandleSongPromptKey_EnterOnURL_InvalidURL_ShowsWarning guards the
+// client-side validation short-circuit — no fetch, no focus change.
+func TestHandleSongPromptKey_EnterOnURL_InvalidURL_ShowsWarning(t *testing.T) {
+	a := loggedInApp()
+	a.songPromptOpen = true
+	a.songPrompt, _ = a.songPrompt.Open()
+	for _, r := range "not a youtube url" {
+		a.songPrompt, _ = a.songPrompt.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	model, _ := a.handleSongPromptKey(tea.KeyMsg{Type: tea.KeyEnter})
+	a2 := model.(App)
+	if !a2.songPrompt.OnURLField() {
+		t.Error("expected focus to stay on the url field after an invalid url")
+	}
+}
+
+// TestSubmitSongPrompt_ValidFields_ClosesAndSetsComposeValue guards the
+// submit handoff mirroring applyAttachURL's ctrl+g GIF handoff.
+func TestSubmitSongPrompt_ValidFields_ClosesAndSetsComposeValue(t *testing.T) {
+	a := loggedInApp()
+	a.songPromptOpen = true
+	a.songPrompt, _ = a.songPrompt.Open()
+	fillSongPrompt(&a, "https://youtu.be/dQw4w9WgXcQ", "Rick Astley", "Never Gonna Give You Up", "")
+
+	a2, cmd := a.submitSongPrompt()
+	if a2.songPromptOpen {
+		t.Error("expected songPromptOpen = false after a valid submit")
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd emitting SetComposeValueMsg")
+	}
+	msg, ok := cmd().(screens.SetComposeValueMsg)
+	if !ok {
+		t.Fatalf("cmd() = %T, want screens.SetComposeValueMsg", cmd())
+	}
+	want := "/song https://youtu.be/dQw4w9WgXcQ | Rick Astley | Never Gonna Give You Up"
+	if msg.Value != want {
+		t.Errorf("SetComposeValueMsg.Value = %q, want %q", msg.Value, want)
+	}
+}
+
+// TestSubmitSongPrompt_MissingTitle_StaysOpenWithWarning guards that an
+// incomplete submit never hands a malformed /song command to the composer.
+func TestSubmitSongPrompt_MissingTitle_StaysOpenWithWarning(t *testing.T) {
+	a := loggedInApp()
+	a.songPromptOpen = true
+	a.songPrompt, _ = a.songPrompt.Open()
+	fillSongPrompt(&a, "https://youtu.be/dQw4w9WgXcQ", "Rick Astley", "", "")
+
+	a2, cmd := a.submitSongPrompt()
+	if !a2.songPromptOpen {
+		t.Error("expected the prompt to stay open when a required field is missing")
+	}
+	if cmd != nil {
+		t.Error("expected no cmd when submit is rejected")
+	}
+}
+
+// TestHandleSongMetadataFetched_Success_AppliesToOpenPrompt guards the async
+// fetch result being applied while the modal is still open.
+func TestHandleSongMetadataFetched_Success_AppliesToOpenPrompt(t *testing.T) {
+	a := loggedInApp()
+	a.songPromptOpen = true
+	a.songPrompt, _ = a.songPrompt.Open()
+	a.songPrompt = a.songPrompt.SetLoading(true)
+
+	a2, _, ok := a.handleSongMetadataFetched(songMetadataFetchedMsg{title: "Never Gonna Give You Up", artist: "Rick Astley"})
+	if !ok {
+		t.Fatal("expected handleSongMetadataFetched to claim its own message type")
+	}
+	if a2.songPrompt.TitleValue() != "Never Gonna Give You Up" || a2.songPrompt.ArtistValue() != "Rick Astley" {
+		t.Errorf("got title=%q artist=%q, want the fetched values", a2.songPrompt.TitleValue(), a2.songPrompt.ArtistValue())
+	}
+}
+
+// TestHandleSongMetadataFetched_PromptClosed_Dropped guards against a stale
+// fetch (from a cancelled prompt) reopening or mutating a fresh one.
+func TestHandleSongMetadataFetched_PromptClosed_Dropped(t *testing.T) {
+	a := loggedInApp()
+	a.songPromptOpen = false
+
+	a2, cmd, ok := a.handleSongMetadataFetched(songMetadataFetchedMsg{title: "t", artist: "a"})
+	if !ok {
+		t.Fatal("expected handleSongMetadataFetched to claim its own message type even when dropped")
+	}
+	if cmd != nil {
+		t.Error("expected no cmd for a dropped fetch result")
+	}
+	if a2.songPromptOpen {
+		t.Error("expected songPromptOpen to remain false")
+	}
+}
+
+// fillSongPrompt types url/artist/title/genre into a.songPrompt's four
+// fields in order, tabbing between them.
+func fillSongPrompt(a *App, url, artist, title, genre string) {
+	type_ := func(s string) {
+		for _, r := range s {
+			a.songPrompt, _ = a.songPrompt.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		}
+	}
+	type_(url)
+	a.songPrompt, _ = a.songPrompt.NextField()
+	type_(artist)
+	a.songPrompt, _ = a.songPrompt.NextField()
+	type_(title)
+	a.songPrompt, _ = a.songPrompt.NextField()
+	type_(genre)
+}
+
+// --- ctrl+n / icon picker insert-and-stay ---
+
+// TestHandleIconPickerKey_CtrlN_InsertsWithoutClosing guards the whole point
+// of ctrl+n: unlike enter, it must leave iconPickerOpen true so several
+// icons can be picked in a row.
+func TestHandleIconPickerKey_CtrlN_InsertsWithoutClosing(t *testing.T) {
+	a := loggedInApp()
+	a.iconPickerOpen = true
+	a.iconPicker, _ = a.iconPicker.Open()
+
+	model, cmd := a.handleIconPickerKey(tea.KeyMsg{Type: tea.KeyCtrlN})
+	a2 := model.(App)
+	if !a2.iconPickerOpen {
+		t.Error("expected iconPickerOpen to remain true after ctrl+n")
+	}
+	if cmd == nil {
+		t.Fatal("expected ctrl+n to return a cmd emitting InsertIconMsg")
+	}
+	msg, ok := cmd().(screens.InsertIconMsg)
+	if !ok {
+		t.Fatalf("expected InsertIconMsg, got %T", cmd())
+	}
+	if msg.Icon == "" {
+		t.Error("expected a non-empty icon glyph")
+	}
+}
+
+// TestHandleIconPickerKey_Enter_ClosesPicker guards the contrast with
+// ctrl+n above — enter still closes the picker as before.
+func TestHandleIconPickerKey_Enter_ClosesPicker(t *testing.T) {
+	a := loggedInApp()
+	a.iconPickerOpen = true
+	a.iconPicker, _ = a.iconPicker.Open()
+
+	model, cmd := a.handleIconPickerKey(tea.KeyMsg{Type: tea.KeyEnter})
+	a2 := model.(App)
+	if a2.iconPickerOpen {
+		t.Error("expected iconPickerOpen to be false after enter")
+	}
+	if cmd == nil {
+		t.Fatal("expected enter to return a cmd emitting InsertIconMsg")
+	}
+	if _, ok := cmd().(screens.InsertIconMsg); !ok {
+		t.Fatalf("expected InsertIconMsg, got %T", cmd())
 	}
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -67,6 +67,7 @@ type modalRenderer interface {
 	renderURLPicker(a App) string
 	renderIconPicker(a App) string
 	renderAttachURLPrompt(a App) string
+	renderSongPrompt(a App) string
 	renderImageModal(a App) string
 	// InlineImageSlots returns the active screen's visible inline-image
 	// slots plus this layout's screen origin (rowOrigin, colOrigin) for
@@ -98,6 +99,8 @@ func compositeOverlays(l modalRenderer, a App, base string) string {
 		return overlayCenter(base, l.renderIconPicker(a), a.width, a.height)
 	case a.attachURLPromptOpen:
 		return overlayCenter(base, l.renderAttachURLPrompt(a), a.width, a.height)
+	case a.songPromptOpen:
+		return overlayCenter(base, l.renderSongPrompt(a), a.width, a.height)
 	}
 	slots, rowOrigin, colOrigin, _ := l.InlineImageSlots(a)
 	if a.imageModalOpen {

--- a/internal/ui/layout_miller.go
+++ b/internal/ui/layout_miller.go
@@ -594,6 +594,7 @@ func (l MillerLayout) renderHelpModal(a App) string {
 		row("o", "open url"),
 		row("ctrl+]", "icon picker"),
 		row("ctrl+g", "attach image/gif"),
+		row("ctrl+j", "attach song (circ, supporter)"),
 		row("q", "quit"),
 	)
 	globalSection := lipgloss.JoinVertical(lipgloss.Left, globalRows...)
@@ -631,6 +632,10 @@ func (l MillerLayout) renderURLPicker(a App) string {
 
 func (l MillerLayout) renderIconPicker(a App) string {
 	return a.iconPicker.View()
+}
+
+func (l MillerLayout) renderSongPrompt(a App) string {
+	return a.songPrompt.View()
 }
 
 func (l MillerLayout) renderImageModal(a App) string {

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -488,6 +488,7 @@ func (l TabsLayout) renderHelpModal(a App) string {
 		row("o", "open url"),
 		row("ctrl+]", "icon picker"),
 		row("ctrl+g", "attach image/gif"),
+		row("ctrl+j", "attach song (circ, supporter)"),
 		row("q", "quit"),
 	)
 	globalSection := lipgloss.JoinVertical(lipgloss.Left, globalRows...)
@@ -628,6 +629,10 @@ func (l TabsLayout) renderURLPicker(a App) string {
 
 func (l TabsLayout) renderIconPicker(a App) string {
 	return a.iconPicker.View()
+}
+
+func (l TabsLayout) renderSongPrompt(a App) string {
+	return a.songPrompt.View()
 }
 
 // renderImageModal returns the bordered text-only shell for the image overlay.

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -574,6 +574,7 @@ func (f fakeModalRenderer) renderHelpModal(a App) string       { return "" }
 func (f fakeModalRenderer) renderURLPicker(a App) string       { return "" }
 func (f fakeModalRenderer) renderIconPicker(a App) string      { return "" }
 func (f fakeModalRenderer) renderAttachURLPrompt(a App) string { return "" }
+func (f fakeModalRenderer) renderSongPrompt(a App) string      { return "" }
 func (f fakeModalRenderer) renderImageModal(a App) string      { return "" }
 func (f fakeModalRenderer) InlineImageSlots(a App) ([]screens.InlineImageSlot, int, int, string) {
 	return f.slots, f.rowOrigin, f.colOrigin, ""

--- a/internal/ui/screens/songprompt.go
+++ b/internal/ui/screens/songprompt.go
@@ -1,0 +1,216 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/ragnar/cyber-tui/internal/ui/theme"
+	"github.com/ragnar/cyber-tui/internal/youtube"
+)
+
+// songField identifies which input has focus inside a SongPromptModel.
+type songField int
+
+const (
+	songFieldURL songField = iota
+	songFieldArtist
+	songFieldTitle
+	songFieldGenre
+	songFieldCount
+)
+
+// SongPromptModel is the ctrl+j "attach song" modal for cIRC: a YouTube URL
+// plus artist/title/genre, the latter two auto-filled (best-effort, via
+// internal/youtube's oEmbed lookup — triggered by App, not this model, same
+// split as the inline-image fetch pipeline) but always editable before
+// submit. It never talks to the network itself, mirroring
+// IconPickerModel/PathPromptModel staying pure UI.
+type SongPromptModel struct {
+	urlInput    textinput.Model
+	artistInput textinput.Model
+	titleInput  textinput.Model
+	genreInput  textinput.Model
+	focus       songField
+	loading     bool   // set by App while a metadata fetch is in flight
+	status      string // validation warning or fetch-outcome note; cleared on the next keystroke
+}
+
+// NewSongPromptModel builds an empty song-attach prompt.
+func NewSongPromptModel() SongPromptModel {
+	newField := func(placeholder string) textinput.Model {
+		ti := textinput.New()
+		ti.Placeholder = placeholder
+		ti.Width = 40
+		return ti
+	}
+	return SongPromptModel{
+		urlInput:    newField("https://youtube.com/watch?v=..."),
+		artistInput: newField("artist"),
+		titleInput:  newField("title"),
+		genreInput:  newField("genre (optional)"),
+	}
+}
+
+// Open resets every field and focuses the URL input.
+func (m SongPromptModel) Open() (SongPromptModel, tea.Cmd) {
+	m.focus = songFieldURL
+	m.loading = false
+	m.status = ""
+	m.urlInput.SetValue("")
+	m.artistInput.SetValue("")
+	m.titleInput.SetValue("")
+	m.genreInput.SetValue("")
+	m.artistInput.Blur()
+	m.titleInput.Blur()
+	m.genreInput.Blur()
+	return m, m.urlInput.Focus()
+}
+
+func (m SongPromptModel) URLValue() string    { return strings.TrimSpace(m.urlInput.Value()) }
+func (m SongPromptModel) ArtistValue() string { return strings.TrimSpace(m.artistInput.Value()) }
+func (m SongPromptModel) TitleValue() string  { return strings.TrimSpace(m.titleInput.Value()) }
+func (m SongPromptModel) GenreValue() string  { return strings.TrimSpace(m.genreInput.Value()) }
+
+// OnURLField reports whether the URL field currently has focus — App uses
+// this to decide whether Enter should trigger a metadata fetch (URL field)
+// or just advance focus (every other field).
+func (m SongPromptModel) OnURLField() bool { return m.focus == songFieldURL }
+
+// OnLastField reports whether the last field (genre) has focus — App uses
+// this to decide whether Enter should submit.
+func (m SongPromptModel) OnLastField() bool { return m.focus == songFieldGenre }
+
+// SetWarning attaches a validation message shown below the fields until the
+// next keystroke — mirrors PathPromptModel.SetWarning.
+func (m SongPromptModel) SetWarning(text string) SongPromptModel {
+	m.status = text
+	return m
+}
+
+// SetLoading marks a metadata fetch as in flight (or done), showing a
+// "fetching…" line in place of any status message while true.
+func (m SongPromptModel) SetLoading(loading bool) SongPromptModel {
+	m.loading = loading
+	if loading {
+		m.status = ""
+	}
+	return m
+}
+
+// ApplyMetadata fills the artist/title fields from a successful fetch and
+// clears the loading state.
+func (m SongPromptModel) ApplyMetadata(title, artist string) SongPromptModel {
+	m.loading = false
+	m.titleInput.SetValue(title)
+	m.artistInput.SetValue(artist)
+	return m
+}
+
+// FetchFailed clears the loading state and leaves a note that auto-fill
+// didn't work — the user can still fill artist/title by hand.
+func (m SongPromptModel) FetchFailed() SongPromptModel {
+	m.loading = false
+	m.status = "couldn't auto-fill — enter artist/title manually"
+	return m
+}
+
+// BuildCommand validates the current field values and, if valid, returns the
+// "/song <url> | <artist> | <title> [| <genre>]" string ready to hand to the
+// composer. Genre is the only optional field, matching the server's own
+// /song syntax (see docs/00-latest-api-reference.md).
+func (m SongPromptModel) BuildCommand() (string, bool) {
+	url := m.URLValue()
+	artist := m.ArtistValue()
+	title := m.TitleValue()
+	if _, ok := youtube.ExtractVideoID(url); !ok {
+		return "", false
+	}
+	if artist == "" || title == "" {
+		return "", false
+	}
+	cmd := "/song " + url + " | " + artist + " | " + title
+	if genre := m.GenreValue(); genre != "" {
+		cmd += " | " + genre
+	}
+	return cmd, true
+}
+
+// NextField advances focus by one field, wrapping from genre back to url —
+// used for both Tab and an Enter that just moves on rather than submitting
+// or fetching.
+func (m SongPromptModel) NextField() (SongPromptModel, tea.Cmd) { return m.moveFocus(1) }
+
+func (m SongPromptModel) moveFocus(delta int) (SongPromptModel, tea.Cmd) {
+	switch m.focus {
+	case songFieldURL:
+		m.urlInput.Blur()
+	case songFieldArtist:
+		m.artistInput.Blur()
+	case songFieldTitle:
+		m.titleInput.Blur()
+	case songFieldGenre:
+		m.genreInput.Blur()
+	}
+	m.focus = songField((int(m.focus) + delta + int(songFieldCount)) % int(songFieldCount))
+	var cmd tea.Cmd
+	switch m.focus {
+	case songFieldURL:
+		cmd = m.urlInput.Focus()
+	case songFieldArtist:
+		cmd = m.artistInput.Focus()
+	case songFieldTitle:
+		cmd = m.titleInput.Focus()
+	case songFieldGenre:
+		cmd = m.genreInput.Focus()
+	}
+	return m, cmd
+}
+
+// Update handles every key except esc/enter/ctrl+s, which App intercepts
+// itself (see App.handleSongPromptKey) — mirrors IconPickerModel's split
+// between model-local keys and App-level dismissal/submission.
+func (m SongPromptModel) Update(msg tea.KeyMsg) (SongPromptModel, tea.Cmd) {
+	switch msg.String() {
+	case "tab":
+		return m.moveFocus(1)
+	case "shift+tab":
+		return m.moveFocus(-1)
+	}
+	m.status = ""
+	var cmd tea.Cmd
+	switch m.focus {
+	case songFieldURL:
+		m.urlInput, cmd = m.urlInput.Update(msg)
+	case songFieldArtist:
+		m.artistInput, cmd = m.artistInput.Update(msg)
+	case songFieldTitle:
+		m.titleInput, cmd = m.titleInput.Update(msg)
+	case songFieldGenre:
+		m.genreInput, cmd = m.genreInput.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m SongPromptModel) View() string {
+	title := theme.Title.Render("Attach Song")
+	label := func(s string) string { return theme.Subtle.Render(fmt.Sprintf("%-8s› ", s)) }
+
+	rows := []string{
+		title, "",
+		label("url") + m.urlInput.View(),
+		label("artist") + m.artistInput.View(),
+		label("title") + m.titleInput.View(),
+		label("genre") + m.genreInput.View(),
+	}
+	switch {
+	case m.loading:
+		rows = append(rows, "", theme.Subtle.Render("fetching metadata…"))
+	case m.status != "":
+		rows = append(rows, "", theme.Error.Render(m.status))
+	}
+	rows = append(rows, "", theme.Subtle.Render("tab next field   enter on url · fetch   enter on genre / ctrl+s · send   esc cancel"))
+	return theme.ActiveBorder.Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+}

--- a/internal/ui/screens/songprompt_test.go
+++ b/internal/ui/screens/songprompt_test.go
@@ -1,0 +1,159 @@
+package screens
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func typeInto(m SongPromptModel, s string) SongPromptModel {
+	for _, r := range s {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	return m
+}
+
+func TestSongPromptModel_Open_FocusesURLAndClearsFields(t *testing.T) {
+	m := NewSongPromptModel()
+	m = typeInto(m, "stale")
+	m, _ = m.Open()
+
+	if !m.OnURLField() {
+		t.Error("expected Open to focus the url field")
+	}
+	if m.URLValue() != "" || m.ArtistValue() != "" || m.TitleValue() != "" || m.GenreValue() != "" {
+		t.Errorf("expected all fields cleared after Open, got url=%q artist=%q title=%q genre=%q",
+			m.URLValue(), m.ArtistValue(), m.TitleValue(), m.GenreValue())
+	}
+}
+
+func TestSongPromptModel_Tab_CyclesThroughAllFieldsAndWraps(t *testing.T) {
+	m, _ := NewSongPromptModel().Open()
+	if !m.OnURLField() {
+		t.Fatal("setup: expected to start on url field")
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // -> artist
+	if m.OnURLField() || m.OnLastField() {
+		t.Errorf("after 1 tab: expected artist field, OnURLField=%v OnLastField=%v", m.OnURLField(), m.OnLastField())
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // -> title
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // -> genre
+	if !m.OnLastField() {
+		t.Fatal("after 3 tabs: expected genre (last) field")
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab}) // wraps -> url
+	if !m.OnURLField() {
+		t.Error("expected tab from the last field to wrap back to url")
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab}) // wraps backward -> genre
+	if !m.OnLastField() {
+		t.Error("expected shift+tab from url to wrap back to genre")
+	}
+}
+
+func TestSongPromptModel_Update_TypesIntoFocusedFieldOnly(t *testing.T) {
+	m, _ := NewSongPromptModel().Open()
+	m = typeInto(m, "https://youtu.be/dQw4w9WgXcQ")
+	if m.URLValue() != "https://youtu.be/dQw4w9WgXcQ" {
+		t.Fatalf("URLValue() = %q, want the typed url", m.URLValue())
+	}
+
+	m, _ = m.NextField()
+	m = typeInto(m, "Rick Astley")
+	if m.ArtistValue() != "Rick Astley" {
+		t.Errorf("ArtistValue() = %q, want %q", m.ArtistValue(), "Rick Astley")
+	}
+	if m.URLValue() != "https://youtu.be/dQw4w9WgXcQ" {
+		t.Errorf("typing into artist changed url field to %q", m.URLValue())
+	}
+}
+
+func TestSongPromptModel_BuildCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		artist  string
+		title   string
+		genre   string
+		wantCmd string
+		wantOK  bool
+	}{
+		{
+			name: "full", url: "https://youtu.be/dQw4w9WgXcQ", artist: "Rick Astley",
+			title: "Never Gonna Give You Up", genre: "pop",
+			wantCmd: "/song https://youtu.be/dQw4w9WgXcQ | Rick Astley | Never Gonna Give You Up | pop",
+			wantOK:  true,
+		},
+		{
+			name: "genre omitted when blank", url: "https://youtu.be/dQw4w9WgXcQ", artist: "Rick Astley",
+			title:   "Never Gonna Give You Up",
+			wantCmd: "/song https://youtu.be/dQw4w9WgXcQ | Rick Astley | Never Gonna Give You Up",
+			wantOK:  true,
+		},
+		{name: "missing artist", url: "https://youtu.be/dQw4w9WgXcQ", title: "Title", wantOK: false},
+		{name: "missing title", url: "https://youtu.be/dQw4w9WgXcQ", artist: "Artist", wantOK: false},
+		{name: "invalid url", url: "https://vimeo.com/12345", artist: "Artist", title: "Title", wantOK: false},
+		{name: "empty url", artist: "Artist", title: "Title", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := NewSongPromptModel().Open()
+			m = typeInto(m, tt.url)
+			m, _ = m.NextField()
+			m = typeInto(m, tt.artist)
+			m, _ = m.NextField()
+			m = typeInto(m, tt.title)
+			m, _ = m.NextField()
+			m = typeInto(m, tt.genre)
+
+			cmd, ok := m.BuildCommand()
+			if ok != tt.wantOK {
+				t.Fatalf("BuildCommand() ok = %v, want %v (cmd=%q)", ok, tt.wantOK, cmd)
+			}
+			if ok && cmd != tt.wantCmd {
+				t.Errorf("BuildCommand() = %q, want %q", cmd, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestSongPromptModel_ApplyMetadata_FillsArtistAndTitleAndClearsLoading(t *testing.T) {
+	m, _ := NewSongPromptModel().Open()
+	m = m.SetLoading(true)
+
+	m = m.ApplyMetadata("Never Gonna Give You Up", "Rick Astley")
+
+	if m.loading {
+		t.Error("expected ApplyMetadata to clear loading")
+	}
+	if m.TitleValue() != "Never Gonna Give You Up" || m.ArtistValue() != "Rick Astley" {
+		t.Errorf("got title=%q artist=%q, want the fetched values", m.TitleValue(), m.ArtistValue())
+	}
+}
+
+func TestSongPromptModel_FetchFailed_ClearsLoadingAndSetsNote(t *testing.T) {
+	m, _ := NewSongPromptModel().Open()
+	m = m.SetLoading(true)
+
+	m = m.FetchFailed()
+
+	if m.loading {
+		t.Error("expected FetchFailed to clear loading")
+	}
+	if m.status == "" {
+		t.Error("expected FetchFailed to leave a status note")
+	}
+}
+
+func TestSongPromptModel_Update_KeystrokeClearsStatus(t *testing.T) {
+	m, _ := NewSongPromptModel().Open()
+	m = m.SetWarning("not a recognized YouTube URL")
+
+	m = typeInto(m, "h")
+
+	if m.status != "" {
+		t.Errorf("expected a keystroke to clear the status message, got %q", m.status)
+	}
+}

--- a/internal/youtube/oembed.go
+++ b/internal/youtube/oembed.go
@@ -1,0 +1,105 @@
+// Package youtube provides lightweight, unauthenticated helpers for working
+// with YouTube video links — validating a URL and looking up its title/
+// channel via the public oEmbed endpoint. No API key involved or needed.
+package youtube
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ragnar/cyber-tui/internal/version"
+)
+
+// userAgent identifies cyber-tui to YouTube, mirroring
+// internal/ui/imgview's own dedicated User-Agent for third-party fetches.
+var userAgent = "cyber-tui/" + version.Version + " (+https://github.com/ArmadilloBrillo/cyber-tui)"
+
+// httpClient is dedicated to oEmbed lookups — a small JSON response, so a
+// much shorter timeout than imgview's 30s image fetches is plenty.
+var httpClient = &http.Client{Timeout: 8 * time.Second}
+
+// oembedEndpoint is the oEmbed base URL. A package var so tests can point it
+// at an httptest.Server instead of the real youtube.com.
+var oembedEndpoint = "https://www.youtube.com/oembed"
+
+// ExtractVideoID reports whether rawURL is a recognizable YouTube video link
+// (youtube.com/watch?v=, youtu.be/<id>, youtube.com/shorts/<id>,
+// youtube.com/embed/<id>) and, if so, its video ID. Used for client-side
+// validation before a fetch or submit — the server itself rejects a
+// non-YouTube /song link with a 400; this just gives faster feedback.
+func ExtractVideoID(rawURL string) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", false
+	}
+	host := strings.TrimPrefix(strings.TrimPrefix(strings.ToLower(u.Host), "www."), "m.")
+	switch host {
+	case "youtu.be":
+		id := strings.Trim(u.Path, "/")
+		return id, id != ""
+	case "youtube.com":
+		switch {
+		case u.Path == "/watch":
+			id := u.Query().Get("v")
+			return id, id != ""
+		case strings.HasPrefix(u.Path, "/shorts/"):
+			id := strings.TrimPrefix(u.Path, "/shorts/")
+			return id, id != ""
+		case strings.HasPrefix(u.Path, "/embed/"):
+			id := strings.TrimPrefix(u.Path, "/embed/")
+			return id, id != ""
+		}
+	}
+	return "", false
+}
+
+// oembedResponse is the subset of YouTube's public oEmbed response this
+// package uses.
+type oembedResponse struct {
+	Title      string `json:"title"`
+	AuthorName string `json:"author_name"`
+}
+
+// FetchMetadata asks YouTube's public oEmbed endpoint for rawURL's video
+// title and channel name — no API key required. The channel name
+// (author_name) is the best available stand-in for "artist": oEmbed has no
+// separate artist or genre field, so genre is always left for the caller to
+// fill in manually.
+func FetchMetadata(ctx context.Context, rawURL string) (title, author string, err error) {
+	if _, ok := ExtractVideoID(rawURL); !ok {
+		return "", "", fmt.Errorf("youtube: not a recognized YouTube URL")
+	}
+	endpoint := oembedEndpoint + "?format=json&url=" + url.QueryEscape(rawURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("youtube: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("youtube: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("youtube: oembed returned %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", "", fmt.Errorf("youtube: read body: %w", err)
+	}
+	var parsed oembedResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", "", fmt.Errorf("youtube: decode: %w", err)
+	}
+	if parsed.Title == "" {
+		return "", "", fmt.Errorf("youtube: oembed response missing title")
+	}
+	return parsed.Title, parsed.AuthorName, nil
+}

--- a/internal/youtube/oembed_test.go
+++ b/internal/youtube/oembed_test.go
@@ -1,0 +1,106 @@
+package youtube
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExtractVideoID(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		wantID string
+		wantOK bool
+	}{
+		{"watch url", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ", true},
+		{"watch url no www", "https://youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ", true},
+		{"watch url with extra params", "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s", "dQw4w9WgXcQ", true},
+		{"youtu.be short link", "https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ", true},
+		{"youtu.be trailing slash", "https://youtu.be/dQw4w9WgXcQ/", "dQw4w9WgXcQ", true},
+		{"shorts", "https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ", true},
+		{"embed", "https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ", true},
+		{"mobile host", "https://m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ", true},
+		{"missing v param", "https://www.youtube.com/watch", "", false},
+		{"non-youtube host", "https://vimeo.com/12345", "", false},
+		{"not a url", "not a url at all", "", false},
+		{"empty", "", "", false},
+		{"youtube homepage", "https://www.youtube.com/", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := ExtractVideoID(tt.rawURL)
+			if ok != tt.wantOK || id != tt.wantID {
+				t.Errorf("ExtractVideoID(%q) = (%q, %v), want (%q, %v)", tt.rawURL, id, ok, tt.wantID, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestFetchMetadata_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"title":"Never Gonna Give You Up","author_name":"Rick Astley"}`))
+	}))
+	defer srv.Close()
+	t.Cleanup(swapEndpoint(srv.URL))
+
+	title, author, err := FetchMetadata(context.Background(), "https://youtu.be/dQw4w9WgXcQ")
+	if err != nil {
+		t.Fatalf("FetchMetadata returned error: %v", err)
+	}
+	if title != "Never Gonna Give You Up" || author != "Rick Astley" {
+		t.Errorf("FetchMetadata = (%q, %q), want (%q, %q)", title, author, "Never Gonna Give You Up", "Rick Astley")
+	}
+}
+
+func TestFetchMetadata_NonYouTubeURL(t *testing.T) {
+	if _, _, err := FetchMetadata(context.Background(), "https://vimeo.com/12345"); err == nil {
+		t.Error("expected an error for a non-YouTube URL, got nil")
+	}
+}
+
+func TestFetchMetadata_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Cleanup(swapEndpoint(srv.URL))
+
+	if _, _, err := FetchMetadata(context.Background(), "https://youtu.be/dQw4w9WgXcQ"); err == nil {
+		t.Error("expected an error for a non-200 oembed response, got nil")
+	}
+}
+
+func TestFetchMetadata_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+	t.Cleanup(swapEndpoint(srv.URL))
+
+	if _, _, err := FetchMetadata(context.Background(), "https://youtu.be/dQw4w9WgXcQ"); err == nil {
+		t.Error("expected an error for a malformed oembed response, got nil")
+	}
+}
+
+func TestFetchMetadata_MissingTitle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"author_name":"Rick Astley"}`))
+	}))
+	defer srv.Close()
+	t.Cleanup(swapEndpoint(srv.URL))
+
+	if _, _, err := FetchMetadata(context.Background(), "https://youtu.be/dQw4w9WgXcQ"); err == nil {
+		t.Error("expected an error when the oembed response has no title, got nil")
+	}
+}
+
+// swapEndpoint points oembedEndpoint at url and returns a func that restores
+// the original value — pass directly to t.Cleanup.
+func swapEndpoint(url string) func() {
+	orig := oembedEndpoint
+	oembedEndpoint = url
+	return func() { oembedEndpoint = orig }
+}


### PR DESCRIPTION
## Summary
Adds a `ctrl+j` modal in cIRC that builds the `/song <url> | <artist> | <title> [| <genre>]` jukebox command interactively instead of requiring it to be hand-typed:

- Paste a YouTube URL; artist/title auto-fill best-effort via YouTube's public oEmbed endpoint (new `internal/youtube` package, no API key). Genre is always manual (oEmbed has no genre field).
- Every field stays editable before submit.
- Supporter-gated client-side (local `*** song attachments require supporter status` notice for non-supporters, avoiding a round trip to the server's 403).
- Submit hands the built command to the cIRC composer via the existing `SetComposeValueMsg` mechanism — the same handoff `ctrl+g`'s GIF-attach flow already uses — so the user still reviews the exact command and presses enter to send it.

Scoped to cIRC only per the request; `/song` is technically also accepted server-side in C-Mail, noted as a small follow-up in the docs if wanted later.

See `docs/49-song-attach.md` for full design details.

## Testing
- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean
- `go test ./...` — full suite passes
- New unit tests: `internal/youtube` (URL parsing across all recognized YouTube link shapes, oEmbed fetch success/error paths via `httptest`), `internal/ui/screens/songprompt_test.go` (field cycling, command building/validation, metadata apply/fail), `internal/ui/app_test.go` (ctrl+j gating — supporter/non-supporter/scoped-to-cIRC, submit handoff, async fetch result handling)
- Not done: live manual verification against a real terminal + supporter account + network — recommend testing that before considering this fully verified.

## Docs
- New `docs/49-song-attach.md`
- `docs/00-project-reference.md` — new `internal/youtube` package section, two Keyboard Shortcuts subsections (Song Prompt, cIRC's `ctrl+j` row), fixed a stale "YouTube audio attachments... not supported" line
- `docs/00-api-backlog.md` — new row noting the `/song` composer UI as done
