### PR TITLE
fix: stop icon picker from resetting selection on ignored keys

### DIFF
--- a/internal/ui/screens/iconpicker.go
+++ b/internal/ui/screens/iconpicker.go
@@ -223,9 +223,17 @@ func (m IconPickerModel) Update(msg tea.KeyMsg) (IconPickerModel, tea.Cmd) {
 	if km, ok := filterAmbiguousKeyMsg(msg); ok {
 		msg = km
 	}
+	before := m.query.Value()
 	var cmd tea.Cmd
 	m.query, cmd = m.query.Update(msg)
-	m = m.refiltered()
+	if m.query.Value() != before {
+		// Only re-filter (which resets selection/scroll to the top) when the
+		// query actually changed. Otherwise any key this switch and the
+		// textinput both ignore — e.g. a modifier combo a given terminal
+		// doesn't encode the way this app expects — would silently yank the
+		// selection back to row 0 despite nothing about the list changing.
+		m = m.refiltered()
+	}
 	return m, cmd
 }
 
@@ -271,7 +279,7 @@ func (m IconPickerModel) View() string {
 		lines = append(lines, theme.Subtle.Render("  no matches"))
 	}
 
-	hint := theme.Subtle.Render("↑↓ select   tab switch   enter insert   esc close")
+	hint := theme.Subtle.Render("↑↓ select   tab switch   enter insert   ctrl+n insert & stay   esc close")
 
 	body := lipgloss.JoinVertical(lipgloss.Left,
 		title,

--- a/internal/ui/screens/iconpicker_test.go
+++ b/internal/ui/screens/iconpicker_test.go
@@ -1,0 +1,31 @@
+package screens
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestIconPickerModel_Update_UnrecognizedKey_DoesNotResetSelection guards a
+// bug: refiltered() unconditionally resets selection/scroll to the top, so
+// forwarding every key the switch doesn't recognize straight into
+// refiltered() — even one the query textinput itself ignores and that
+// leaves the query text unchanged — silently yanked the selection back to
+// row 0. Seen in practice: a terminal that doesn't encode ctrl+n the way
+// this app expects fell through to this path on every ctrl+n press.
+func TestIconPickerModel_Update_UnrecognizedKey_DoesNotResetSelection(t *testing.T) {
+	m := NewIconPickerModel()
+	m = m.moveSelection(2)
+	selected := m.selected
+	if selected == 0 {
+		t.Fatal("setup: expected moveSelection(2) to move off row 0")
+	}
+
+	// ctrl+w is bound to word-delete in textinput's default keymap, but on
+	// an empty query it's a no-op — value before and after are both "".
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlW})
+
+	if m.selected != selected {
+		t.Errorf("selected = %d after a query-unchanged key, want unchanged %d", m.selected, selected)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes a bug in the icon picker (`ctrl+]`): `Update()` unconditionally called `refiltered()` after every keypress, which resets selection/scroll to the top row. That's correct when the search query text actually changed, but wrong otherwise — a key both the picker's own switch and the query `textinput` ignore (e.g. a modifier combo a given terminal doesn't encode the way this app expects) still fell through to that call and silently yanked the selection back to row 0 despite nothing about the list changing. Seen in practice: a terminal that doesn't encode ctrl+n the way this app expects hit this on every ctrl+n press.

Fix: only call `refiltered()` when the query value actually changed.

Also updates the picker's own hint line to mention the existing `ctrl+n` insert-and-stay shortcut, which it never listed.

## Testing
- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean
- `go test ./...` — full suite passes
- New test: `TestIconPickerModel_Update_UnrecognizedKey_DoesNotResetSelection` — guards the exact regression (a query-unchanged key must leave the selection alone)
