### PR TITLE
feat: native reply attachments, extend song-attach to posts/replies (feature 50)

### DIFF
--- a/cmd/apifetch/main.go
+++ b/cmd/apifetch/main.go
@@ -15,6 +15,7 @@ const defaultBaseURL = "https://api.cyberspace.online"
 func main() {
 	method := flag.String("method", "GET", "HTTP method")
 	body := flag.String("body", "", "request body (JSON string)")
+	bodyFile := flag.String("body-file", "", "request body (path to JSON file; avoids shell quoting issues)")
 	baseURL := flag.String("base-url", "", "override API base URL")
 	flag.Parse()
 
@@ -49,7 +50,14 @@ func main() {
 	}
 
 	var bodyBytes []byte
-	if *body != "" {
+	if *bodyFile != "" {
+		b, err := os.ReadFile(*bodyFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: read body file: %v\n", err)
+			os.Exit(1)
+		}
+		bodyBytes = b
+	} else if *body != "" {
 		bodyBytes = []byte(*body)
 	}
 

--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -65,6 +65,38 @@ Ordered roughly by implementation effort / priority.
 | `POST /v1/posts` — optional `slug` field (v0.7) | Custom slug (`a-z0-9-`, max 60 chars); server generates one if omitted. Compose panel (`PostComposePanel`) now includes a slug field with inline validation; empty slug is silently omitted from the wire. Same applies to `POST /v1/guilds/:slug/posts`. | **Done** — v0.7 alignment |
 | Post/reply objects — no author badge fields | Confirmed (docs + live) that a post/reply carries only `authorId`/`authorUsername` — no `authorIsSupporter`/`authorSupporterIcon`/`authorGuildIcon`. Badge icons (feature 48, `docs/48-badge-icons.md`) render on Profile/C-Mail, where the full author `model.User` is already available, but can't extend to Feed/Post Detail/Search/Topics/Bookmarks without either a per-author `GET /v1/users/:username` fetch-and-cache layer or the API adding these fields directly to post/reply payloads. | Feature request to API maintainer — not blocking |
 
+### Attachments — shape & validation, posts and replies (confirmed live, 2026-08-27)
+
+`docs.md`'s prose never documents the `attachments` object shape, and never mentions `attachments` at all under Replies (only under Posts, and only as "replaces the existing attachments" on `PATCH`). `GET /types.d.ts` (published since v0.8.4, previously logged below as "not applicable to this Go client" and never actually pulled for content until now) fills the gap:
+
+```typescript
+export interface Attachment {
+  type: 'audio' | 'image'
+  src: string
+  origin?: 'youtube'
+  artist?: string
+  title?: string
+  genre?: string
+  width?: number
+  height?: number
+}
+```
+
+Matches `wireAttachment` (`internal/api/client.go:76-83`) field-for-field — that shape was reverse-engineered correctly by this client via live testing before this type file was ever checked.
+
+Live-tested via `apifetch` against throwaway posts/replies (all created, tested, deleted within the same session):
+
+| Finding | Confirmed behavior |
+|---|---|
+| **Replies accept `attachments`** | `POST /v1/replies` with an `attachments` array succeeds and `GET` echoes it back intact, despite zero mention in `docs.md`'s Replies section. `internal/ui/app.go`'s `applyAttachURL` (line ~4132) currently hard-rejects `ctrl+g` image attach on Post Detail's reply compose with *"replies don't support image attachments — there's no attachments field in the reply API"* — that message is now known to be factually wrong; the API supports it, only the client doesn't wire it up. |
+| **640px cap is real, inclusive, per-dimension** | `width`/`height` > 640 → `400`: `"Image width must be an integer between 1 and 640px"` / `"Image height must be an integer between 1 and 640px"` (checked independently, own message each). Exactly `640` is accepted. Confirmed identical on both `PATCH /v1/posts/:id` and `POST /v1/replies` (create). |
+| **`width`/`height` are required for `type: "image"`, despite the `?` in `/types.d.ts`** | Omitting either field entirely (not just setting it small) produces the same `400` as an out-of-range value. The type file's optionality marker is inaccurate — both dimensions are mandatory on the wire for a `type: "image"` attachment. |
+| **`width`/`height` are ignored (and unchecked) for `type: "audio"`** | A `type: "audio"` attachment (`{src, origin: "youtube", artist, title, genre}`) with **no** `width`/`height` keys at all was accepted and stored cleanly — the 640px dimension validation is `type`-conditional, image-only. Also confirmed live in the same test: `hasAudioAttachment: true` and `audioAttachmentGenre` (both undocumented in `docs.md`, present in `/types.d.ts`) round-tripped correctly on `GET`. |
+| **The 640px check is metadata-only — the server never fetches the image** | Sent `width: 10, height: 10` with `src` pointing at a real 2000×2000 image → accepted with no error, and `GET` echoed the lied-about `10x10` dimensions next to the real (much larger) URL. The cap is honesty-based: a client that declares small dimensions bypasses it entirely, since nothing server-side verifies the claim against the actual file. **As of 2026-08-27, `resolveAttachment` (`internal/ui/app.go`) deliberately exploits this** — see the `⚠ EXPERIMENTAL` section of `docs/50-post-reply-attachments.md` — always declaring `640x640` regardless of the real image, at the user's explicit request, rather than the honest fetch-and-report behavior this row originally described. |
+| **`type` union is `'audio' \| 'image'` only — no `'gif'`** | `attachmentTypeForURL` (`internal/ui/app.go:5137`) currently sends the literal string `"gif"` as an attachment's `type` for post/reply attachments with a `.gif`-extension URL. Not spot-checked against the live server (no test posted a `.gif` URL as a post/reply attachment this session) — worth confirming whether the server accepts `"gif"` as an undocumented extension of the union or silently coerces/rejects it. |
+| **`hasImageAttachment`/`hasAudioAttachment` are computed for posts, not replies** | Confirmed live 2026-08-27: a post with a real `attachments` entry returns `hasImageAttachment: true` (or `hasAudioAttachment: true`) automatically — never sent by the client, so it's server-derived at write time. A reply with an identical `attachments` entry returns *neither* flag, and explicitly sending `hasImageAttachment: true` in the `POST /v1/replies` body is silently ignored (not present in the response either — confirmed the field isn't just omitted-when-false, it's genuinely absent). `/types.d.ts` declares both flags on `Reply` too, so this looks like the derivation step was simply never wired up for the reply write path. **Likely explains a live report**: an image attached to a reply via `ctrl+g` (feature 50) was stored correctly (`attachments` populated, confirmed via `apifetch`) but did not render on the website — if the site's reply view keys off `hasImageAttachment` rather than checking `attachments` directly, it would never fire for a reply. Unconfirmed whether that's the actual website mechanism; the flag gap itself is confirmed. |
+| **Reply permalink shows `undefined` in place of username** | Observed 2026-08-27 on a reply detail URL (`https://cyberspace.online/undefined/<post-slug>?reply=<id>`) — the reply's own `authorUsername` was populated correctly server-side (confirmed via `apifetch`), so this looks like a website-side link-building bug (a JS template picking up a missing value at render time) rather than anything server- or cyber-tui-side. Not investigated further — cyber-tui has no website code to inspect. |
+
 ### Guilds (new in v0.4)
 
 Guilds are member groups with their own forum of threads. A user can belong to one guild at a time. `Guild` model type added; read-only browsing implemented in feature 29.
@@ -193,7 +225,7 @@ cIRC/C-Mail messages can now carry `imageUrl`, `gifUrl` (`/gif <url>`), `audioAt
 | `gifUrl`, `audioAttachment`, `style`, chained styles | Render/decode in message view; `style: "art"` needs base64 decode | **Done** — wire/model fields across all four message shapes, attachment badges reusing `renderAttachments`, and a middle-fidelity style pipeline (ANSI attributes for blink/quiet/rainbow, Unicode substitution for l33t/cursive/flip, ASCII-safe jitter for glitch, `tea.Tick`-driven slow/wave/glitch animation, select-to-reveal spoiler in cIRC only — see `internal/ui/screens/chatstyle.go`) |
 | `/mute` family + `mutedUsersByRoom` | Client-side message filtering by muted user | **Done** — cIRC only (C-Mail 400s per API spec); see `docs/37-circ-mute.md` |
 | Empty `content` with attachment-only messages | Message rendering must not assume non-empty `content` | **Done** — covered by the same change; `messageDisplayBody` skips duplicate URL text and empty bodies render without assuming non-empty `content` |
-| `/song` composer UI | A guided way to build the `/song <url> \| <artist> \| <title> [\| <genre>]` command instead of hand-typing it | **Done** — `ctrl+j` Song Prompt modal in cIRC (supporter-gated client-side ahead of the server's 403), artist/title auto-filled via YouTube's public oEmbed endpoint (`internal/youtube`); see `docs/49-song-attach.md`. C-Mail not covered (out of this feature's scope, though the API accepts `/song` there too) |
+| `/song` composer UI | A guided way to build the `/song <url> \| <artist> \| <title> [\| <genre>]` command instead of hand-typing it | **Done** — `ctrl+j` Song Prompt modal in cIRC (supporter-gated client-side ahead of the server's 403), artist/title auto-filled via YouTube's public oEmbed endpoint (`internal/youtube`); see `docs/49-song-attach.md`. Extended to Feed/Post Detail's native audio attachment (feature 50, `docs/50-post-reply-attachments.md`). C-Mail's own composer still not covered (out of scope, though the API accepts `/song` there too) |
 
 ### cIRC idle presence (new in v0.8.1)
 
@@ -205,7 +237,7 @@ cIRC/C-Mail messages can now carry `imageUrl`, `gifUrl` (`/gif <url>`), `audioAt
 
 ### TypeScript definitions (new in v0.8.4)
 
-`/types.d.ts` now publishes TypeScript types for every documented response shape. Not applicable to this Go client — noted for reference only.
+`/types.d.ts` now publishes TypeScript types for every documented response shape. Not consumed programmatically by this Go client, but proved genuinely useful as a documentation source on 2026-08-27: `docs.md`'s prose never spells out the `attachments` object shape or mentions it on Replies at all, while `/types.d.ts`'s `Attachment`/`Entry`/`Reply` interfaces filled both gaps (and turned up two fields — `hasImageAttachment`/`hasAudioAttachment`/`audioAttachmentGenre` — not yet modeled client-side; see the Attachments section above). Worth checking again whenever a field's real shape is undocumented in prose.
 
 ### Auth (new in v0.8)
 
@@ -254,6 +286,7 @@ Notes:
 | Endpoint | Method | Description | Priority |
 |---|---|---|---|
 | `/v1/posts/:postId/replies` | GET | Cursor-paginated replies (oldest-first by reply ID) | Deferred — replies are rendered as a tree grouped by `parentReplyId`; paginated loads arrive interleaved across parent/child, requiring tree re-parenting and a full re-render on each page. Cost outweighs benefit at current network scale. |
+| `POST /v1/replies` — `attachments` field | Live-confirmed 2026-08-27 (see Attachments section above): replies accept an `attachments` array identically to posts, undocumented in `docs.md` but present in `/types.d.ts` and functional. `ctrl+g` (image/gif) and `ctrl+j` (audio/song) both now attach natively on the reply compose box — feature 50, `docs/50-post-reply-attachments.md`. | **Done** — feature 50 |
 
 ### Follows
 

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -946,18 +946,19 @@ list. Two tabs — Emoji and Kaomoji.
 
 ### Song Prompt
 
-`ctrl+j` (`internal/ui/screens/songprompt.go`) opens a modal over CIRC's
-composer (supporter accounts only — see the CIRC table below) for attaching
-a YouTube track: URL, Artist, Title, Genre. Artist/Title auto-fill
-best-effort from the URL via `internal/youtube`'s oEmbed lookup; Genre is
-always manual (oEmbed has no genre field). See `docs/49-song-attach.md`.
+`ctrl+j` (`internal/ui/screens/songprompt.go`) opens a modal (supporter
+accounts only) for attaching a YouTube track: URL, Artist, Title, Genre.
+Artist/Title auto-fill best-effort from the URL via `internal/youtube`'s
+oEmbed lookup; Genre is always manual (oEmbed has no genre field). Opens from
+CIRC's composer, Feed's new-post panel, and Post Detail's edit panel/reply
+compose (`docs/49-song-attach.md`, `docs/50-post-reply-attachments.md`).
 
 | Key | Action |
 |---|---|
 | `tab` / `shift+tab` | Cycle fields: url → artist → title → genre |
 | `enter` on url | Validate the URL and fetch artist/title metadata, advancing focus to artist |
 | `enter` on artist/title | Advance focus (same as tab) |
-| `enter` on genre, or `ctrl+s` | Submit — hands the built `/song ...` command to the composer (still requires `enter` there to send) |
+| `enter` on genre, or `ctrl+s` | Submit — in CIRC/C-Mail, hands the built `/song ...` command to the composer (still requires `enter` there to send); on a post/reply target, sets a native audio attachment directly |
 | `esc` | Cancel without inserting anything |
 
 ### Notifications

--- a/docs/50-post-reply-attachments.md
+++ b/docs/50-post-reply-attachments.md
@@ -1,0 +1,156 @@
+# 50 — Post/reply attachments: image on replies, audio (song) everywhere
+
+## Purpose
+
+Two gaps closed together, both discovered via live `apifetch` testing against
+the API (see `docs/00-api-backlog.md`'s "Attachments — shape & validation"
+section for the full research):
+
+1. **Replies never supported any attachment**, blocked by an outdated
+   client-side assumption. Live-tested 2026-08-27: `POST /v1/replies` accepts
+   an `attachments` array identically to posts — `docs.md` just never
+   mentions it for replies. `ctrl+g` (image/gif URL) now works on the reply
+   compose box the same way it already did on Feed's new-post panel and Post
+   Detail's edit panel.
+2. **The `ctrl+j` song-attach modal (`docs/49-song-attach.md`) was cIRC-only.**
+   Live-tested 2026-08-27: posts and replies both accept a `type: "audio"`
+   attachment (`{src, origin: "youtube", artist, title, genre}`) with no
+   `width`/`height` required — unlike an image attachment, which the API
+   requires both dimensions for (1–640px inclusive, checked independently).
+   `ctrl+j` now also opens from Feed's new-post panel, Post Detail's edit
+   panel, and Post Detail's reply compose box.
+
+## Attachment shape (confirmed live)
+
+```typescript
+export interface Attachment {
+  type: 'audio' | 'image'
+  src: string
+  origin?: 'youtube'   // audio only
+  artist?: string      // audio only
+  title?: string       // audio only
+  genre?: string       // audio only
+  width?: number       // image only, required despite the "?"
+  height?: number      // image only, required despite the "?"
+}
+```
+
+`CreatePost`/`EditPost`/`CreateReply` each accept **at most one** native
+attachment — the wire request supports an array, but every screen's compose
+UI offers exactly one image/gif slot and one audio slot, and setting one
+clears the other (`PostComposePanel.SetAttachmentURL`/`SetPendingAudio`,
+`PostDetailModel.SetReplyAttachmentURL`/`SetReplyAudioAttachment`). Nobody
+asked for "attach both an image and a song to the same post," so this stays
+simple rather than widening every command's signature to a slice for a case
+that's never been requested.
+
+## Reply attachments (`internal/ui/screens/postdetail.go`)
+
+`PostDetailModel` gains `replyAttachmentURL`/`replyAudioAttachment` (mutually
+exclusive, set via `SetReplyAttachmentURL`/`SetReplyAudioAttachment`) and
+`replyContextBase` — the compose box's context label ("replying to @user")
+before an attachment note is appended. `setReplyComposeContext` rebuilds that
+label live via `ComposeModel.SetContext` (new — the label was previously
+fixed at `Open()` time) so the user sees "replying to @user · attach
+<url>" or "· song <artist> — <title>" before submitting.
+
+`SubmitReplyMsg` gained `AttachmentURL`/`Attachment` fields, populated on
+submit and cleared on both submit and cancel so nothing leaks into the next
+reply. `App.createReplyCmd` (`internal/ui/app.go`) resolves the image URL's
+real dimensions via the existing `resolveAttachment` (same 640px client-side
+guard as posts) or passes the already-built audio attachment straight
+through — `CreateReply` itself gained an `attachment *model.Attachment`
+param (`internal/api/client.go`, `internal/api/interface.go`,
+`internal/api/mock.go`).
+
+`applyAttachURL`'s reply-compose branch (`internal/ui/app.go`) now routes to
+`SetReplyAttachmentURL` instead of warning "replies don't support image
+attachments" — that message was accurate against `docs.md`'s prose but wrong
+against the live API.
+
+## Song attach on posts/replies (`internal/ui/app.go`)
+
+`ctrl+j`'s guard broadened from `a.active == screenChatrooms` to also match
+Feed's panel (`a.feed.PanelActive()`) and Post Detail's edit panel / reply
+compose (`EditPanelActive()`/`ReplyComposeActive()`), still gated on
+supporter status either way — non-chat targets get a `notify(notifyWarn,
+...)` banner instead of chat's local system-message rejection, since neither
+Feed nor Post Detail has an equivalent inline notice area.
+
+`submitSongPrompt` branches by target instead of always building a `/song
+...` command string: Feed/edit-panel/reply-compose each get a
+`model.Attachment` handed to their own setter (`SetPanelAudioAttachment`,
+`SetEditPanelAudioAttachment`, `SetReplyAudioAttachment`); only the
+chat targets still get the `/song ...` text via `SetComposeValueMsg`.
+
+`SongPromptModel` gained `BuildAttachment() (model.Attachment, bool)` — the
+same field validation `BuildCommand` already did, now shared so both callers
+agree on what counts as valid (`internal/ui/screens/songprompt.go`).
+`BuildCommand` is now implemented in terms of it rather than duplicating the
+validation.
+
+## Panel rendering (`internal/ui/screens/compose.go`)
+
+`PostComposePanel` gained a `pendingAudio *model.Attachment` field alongside
+the existing `attachmentURL`, rendered as a `song   <artist> — <title>` row
+directly below the existing `attach <url>` row (same truncation/width
+handling), adding one row to `PanelHeight()` when set. `OpenForEdit`'s
+attachment-sorting loop now splits three ways: image/gif → `attachmentURL`,
+audio → `pendingAudio`, anything else → `otherAttachments` (unchanged
+fallback, now effectively unreachable given the API's closed `type` union,
+kept as a defensive catch-all).
+
+## ⚠ EXPERIMENTAL: image dimensions are currently faked (2026-08-27)
+
+`resolveAttachment` (`internal/ui/app.go`) no longer fetches an attached
+image to determine its real size — it always declares `640x640`
+(`maxAttachmentDim`), at the user's explicit request, to test whether the
+API's declared-dimension check is meaningfully enforced anywhere beyond the
+create/edit request itself (confirmed it's never checked against the real
+file — see `docs/00-api-backlog.md`'s "Attachments — shape & validation").
+This means:
+
+- Any image attached through cyber-tui right now is declared as 640×640
+  regardless of its real resolution — a false statement sent to the API and
+  stored on the post/reply, visible to every viewer on every client.
+- The client no longer rejects (or can detect) an oversized image before
+  posting — the honest-dimension guard and its clear error message are gone
+  along with the fetch.
+- This is explicitly temporary, tracked here so it isn't mistaken for
+  finished behavior. `resolveAttachment`'s doc comment in `app.go` has the
+  exact revert instructions (restore the `imgview.Dimensions` fetch + the
+  `maxAttachmentDim` comparison it replaced).
+
+## Scope / known gaps
+
+- **Supporter gating on posts/replies is untested.** Chat's `/song` 403s a
+  non-supporter server-side; this feature's one live test used a supporter
+  account. The client-side supporter gate is applied uniformly as a
+  precaution — revisit if a non-supporter test ever confirms posts/replies
+  don't actually require it.
+- **Reply edit** (`PATCH /v1/replies/:id`) still only supports `content` per
+  `docs.md` — no attachment editing on an existing reply, only at creation.
+  `OpenCompose`'s edit-reply path explicitly resets any pending reply
+  attachment state before opening.
+- The `attachmentTypeForURL`-assigned string `"gif"` (not in the API's
+  documented `'audio' | 'image'` union) is a pre-existing, separate gap not
+  touched by this feature — see `docs/00-api-backlog.md`.
+
+## Verification
+
+- `go test ./...`, `go vet ./...`, `staticcheck ./...` — no warnings.
+- `internal/ui/screens/songprompt_test.go`: `BuildAttachment`'s shape and
+  shared validation failure cases.
+- `internal/ui/screens/compose_test.go`: `OpenForEdit` prefilling both slots,
+  image/audio mutual exclusivity, `PanelHeight` growth.
+- `internal/ui/screens/postdetail_test.go`: reply attachment mutual
+  exclusivity, `SubmitReplyMsg` carrying/clearing the attachment across
+  submit and cancel.
+- `internal/ui/app_test.go`: `applyAttachURL` on reply compose no longer
+  warns; `ctrl+j` opens from Feed panel and reply compose; `submitSongPrompt`
+  routes to the right target instead of `SetComposeValueMsg`;
+  `createReplyCmd`/`editPostCmd` resolve/forward the right attachment.
+- Manual: run the TUI, `ctrl+g` on a reply — attach an image, post it, confirm
+  it renders. `ctrl+j` on Feed's new-post panel and a reply — paste a
+  YouTube URL, confirm the `song` row appears, post, confirm the audio
+  attachment shows up on the created post/reply via `apifetch`.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -397,9 +397,10 @@ type editReplyRequest struct {
 }
 
 type createReplyRequest struct {
-	PostID        string `json:"postId"`
-	Content       string `json:"content"`
-	ParentReplyID string `json:"parentReplyId,omitempty"`
+	PostID        string           `json:"postId"`
+	Content       string           `json:"content"`
+	ParentReplyID string           `json:"parentReplyId,omitempty"`
+	Attachments   []wireAttachment `json:"attachments,omitempty"`
 }
 
 type createReplyResponseData struct {
@@ -1435,11 +1436,16 @@ func (c *HTTPClient) GetReply(replyID string) (model.Reply, error) {
 	return wireReplyToModel(wire), nil
 }
 
-func (c *HTTPClient) CreateReply(postID, content, parentReplyID string) (model.Reply, error) {
+func (c *HTTPClient) CreateReply(postID, content, parentReplyID string, attachment *model.Attachment) (model.Reply, error) {
+	var attachments []wireAttachment
+	if attachment != nil {
+		attachments = []wireAttachment{wireAttachmentFromModel(*attachment)}
+	}
 	env, err := c.doJSON("POST", "/v1/replies", createReplyRequest{
 		PostID:        postID,
 		Content:       content,
 		ParentReplyID: parentReplyID,
+		Attachments:   attachments,
 	})
 	if err != nil {
 		return model.Reply{}, err
@@ -1448,7 +1454,11 @@ func (c *HTTPClient) CreateReply(postID, content, parentReplyID string) (model.R
 	if err := json.Unmarshal(env.Data, &data); err != nil {
 		return model.Reply{}, err
 	}
-	return model.Reply{ID: data.ReplyID, PostID: postID, Content: content, ParentReplyID: parentReplyID}, nil
+	reply := model.Reply{ID: data.ReplyID, PostID: postID, Content: content, ParentReplyID: parentReplyID}
+	if attachment != nil {
+		reply.Attachments = []model.Attachment{*attachment}
+	}
+	return reply, nil
 }
 
 func (c *HTTPClient) GetPost(postID string) (model.Post, error) {

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -41,8 +41,11 @@ type Client interface {
 	GetPostReplies(postID string) ([]model.Reply, error)
 	// GetReply fetches a single reply by ID (used when opening a reply bookmark).
 	GetReply(replyID string) (model.Reply, error)
-	// CreateReply posts a reply to postID. Pass empty parentReplyID for top-level replies.
-	CreateReply(postID, content, parentReplyID string) (model.Reply, error)
+	// CreateReply posts a reply to postID. Pass empty parentReplyID for
+	// top-level replies. attachment, if non-nil, attaches an image/gif or
+	// audio (YouTube) URL — same shape and width/height rules as CreatePost's
+	// attachment param.
+	CreateReply(postID, content, parentReplyID string, attachment *model.Attachment) (model.Reply, error)
 
 	// Profile
 	GetOwnProfile() (model.User, error)

--- a/internal/api/mock.go
+++ b/internal/api/mock.go
@@ -204,8 +204,8 @@ func (m *MockClient) GetFeed(cursor string) ([]model.Post, string, error) {
 	}, "", nil
 }
 
-func (m *MockClient) CreateReply(postID, content, parentReplyID string) (model.Reply, error) {
-	return model.Reply{
+func (m *MockClient) CreateReply(postID, content, parentReplyID string, attachment *model.Attachment) (model.Reply, error) {
+	reply := model.Reply{
 		ID:             "reply-new-1",
 		PostID:         postID,
 		AuthorID:       mockUsers[0].ID,
@@ -213,7 +213,11 @@ func (m *MockClient) CreateReply(postID, content, parentReplyID string) (model.R
 		Content:        content,
 		ParentReplyID:  parentReplyID,
 		CreatedAt:      time.Now(),
-	}, nil
+	}
+	if attachment != nil {
+		reply.Attachments = []model.Attachment{*attachment}
+	}
+	return reply, nil
 }
 
 func (m *MockClient) GetReply(replyID string) (model.Reply, error) {

--- a/internal/api/mock_test.go
+++ b/internal/api/mock_test.go
@@ -434,7 +434,7 @@ func TestMockGetPostReplies_AnyPostID(t *testing.T) {
 
 func TestMockCreateReply_ReturnsReply(t *testing.T) {
 	m := newMock()
-	r, err := m.CreateReply("p1", "great post", "")
+	r, err := m.CreateReply("p1", "great post", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -451,12 +451,24 @@ func TestMockCreateReply_ReturnsReply(t *testing.T) {
 
 func TestMockCreateReply_WithParent(t *testing.T) {
 	m := newMock()
-	r, err := m.CreateReply("p1", "nested reply", "r1")
+	r, err := m.CreateReply("p1", "nested reply", "r1", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if r.ParentReplyID != "r1" {
 		t.Errorf("expected ParentReplyID=%q, got %q", "r1", r.ParentReplyID)
+	}
+}
+
+func TestMockCreateReply_WithAttachment(t *testing.T) {
+	m := newMock()
+	att := &model.Attachment{Type: "audio", Src: "https://youtube.com/watch?v=abc", Origin: "youtube", Artist: "a", Title: "t"}
+	r, err := m.CreateReply("p1", "check this out", "", att)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.Attachments) != 1 || r.Attachments[0] != *att {
+		t.Errorf("expected attachment %+v to round-trip, got %+v", *att, r.Attachments)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1085,10 +1085,17 @@ func (a App) handleKeys(msg tea.Msg) (App, tea.Cmd, bool) {
 			return a, cmd, true
 		}
 	case "ctrl+j":
-		if a.active == screenChatrooms && a.activeScreenHasFocusedInput() {
+		songTargetActive := a.active == screenChatrooms ||
+			(a.active == screenFeed && a.feed.PanelActive()) ||
+			(a.active == screenPostDetail && (a.postDetail.EditPanelActive() || a.postDetail.ReplyComposeActive()))
+		if songTargetActive && a.activeScreenHasFocusedInput() {
 			if !a.currentUser.IsSupporter {
-				a.chatrooms = a.chatrooms.AppendSystemMessage(a.chatrooms.ActiveRoomSlug(), "*** song attachments require supporter status")
-				return a, nil, true
+				if a.active == screenChatrooms {
+					a.chatrooms = a.chatrooms.AppendSystemMessage(a.chatrooms.ActiveRoomSlug(), "*** song attachments require supporter status")
+					return a, nil, true
+				}
+				a, cmd := a.notify(notifyWarn, "song attachments require supporter status")
+				return a, cmd, true
 			}
 			a.songPromptOpen = true
 			var cmd tea.Cmd
@@ -1270,14 +1277,14 @@ func (a App) handlePostDetail(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		return a, nil, true
 	case screens.SubmitNewPostMsg:
-		return a, a.createPostCmd(msg.Content, msg.Title, msg.Slug, msg.Topics, msg.IsPublic, msg.IsNSFW, msg.AttachmentURL), true
+		return a, a.createPostCmd(msg.Content, msg.Title, msg.Slug, msg.Topics, msg.IsPublic, msg.IsNSFW, msg.AttachmentURL, msg.AudioAttachment), true
 	case postCreatedMsg:
 		return a, a.loadFeedCmd(), true
 	case postConvertedToNoteMsg:
 		a, notifyCmd := a.notify(notifyWarn, "posted too soon after your last entry — saved to your Journal instead")
 		return a, tea.Batch(notifyCmd, a.loadFeedCmd()), true
 	case screens.SubmitPostEditMsg:
-		return a, a.editPostCmd(msg.PostID, msg.Content, msg.Title, msg.Topics, msg.IsPublic, msg.IsNSFW, msg.AttachmentURL, msg.AttachmentTouched, msg.OtherAttachments), true
+		return a, a.editPostCmd(msg.PostID, msg.Content, msg.Title, msg.Topics, msg.IsPublic, msg.IsNSFW, msg.AttachmentURL, msg.AttachmentTouched, msg.AudioAttachment, msg.OtherAttachments), true
 	case postEditedMsg:
 		// Both Feed and PostDetail may hold their own local copy of this post;
 		// PostDetail's ApplyPostEdit has no postID param, so guard it here —
@@ -1289,7 +1296,7 @@ func (a App) handlePostDetail(msg tea.Msg) (App, tea.Cmd, bool) {
 		}
 		return a, nil, true
 	case screens.SubmitReplyMsg:
-		return a, a.createReplyCmd(msg.PostID, msg.Content, msg.ParentReplyID), true
+		return a, a.createReplyCmd(msg.PostID, msg.Content, msg.ParentReplyID, msg.AttachmentURL, msg.Attachment), true
 	case screens.SubmitReplyEditMsg:
 		return a, a.editReplyCmd(msg.ReplyID, msg.Content), true
 	case replyEditedMsg:
@@ -4103,12 +4110,13 @@ func (a App) handleAttachURLPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // applyAttachURL dispatches a submitted attach-URL prompt result, per what
-// was confirmed live this session: posts get a native attachment (routed
-// through the create/edit request); circ/C-Mail can only embed an animated
-// GIF, via the server's own /gif command — visually confirmed on the
-// website, whereas markdown in a message's content does not render there;
-// and replies have no attachment mechanism at all (no attachments field in
-// the reply API). Where nothing can actually render, this warns instead of
+// was confirmed live this session: posts and replies both get a native
+// attachment (routed through the create/edit request — confirmed live
+// 2026-08-27 that the reply API accepts attachments too, despite docs.md
+// never mentioning it, see docs/00-api-backlog.md); circ/C-Mail can only
+// embed an animated GIF, via the server's own /gif command — visually
+// confirmed on the website, whereas markdown in a message's content does not
+// render there. Where nothing can actually render, this warns instead of
 // silently inserting text that looks like it worked but won't show up
 // anywhere but cyber-tui's own inline-image view.
 func (a App) applyAttachURL(url string) (App, tea.Cmd) {
@@ -4119,18 +4127,18 @@ func (a App) applyAttachURL(url string) (App, tea.Cmd) {
 	case a.active == screenPostDetail && a.postDetail.EditPanelActive():
 		a.postDetail = a.postDetail.SetEditPanelAttachment(url)
 		return a, nil
+	case a.active == screenPostDetail && a.postDetail.ReplyComposeActive():
+		a.postDetail = a.postDetail.SetReplyAttachmentURL(url)
+		return a, nil
 	}
 	if url == "" {
 		return a, nil
 	}
-	switch {
-	case a.active == screenChatrooms, a.active == screenCMail:
+	if a.active == screenChatrooms || a.active == screenCMail {
 		if !urlutil.IsGIFURL(url) {
 			return a.notify(notifyWarn, "cyberspace.online can only embed a GIF in chat (via /gif) — a static image needs a file upload the API doesn't support")
 		}
 		return a, func() tea.Msg { return screens.SetComposeValueMsg{Value: "/gif " + url} }
-	case a.active == screenPostDetail && a.postDetail.ReplyComposeActive():
-		return a.notify(notifyWarn, "replies don't support image attachments — there's no attachments field in the reply API")
 	}
 	return a, func() tea.Msg { return screens.InsertIconMsg{Icon: "![](" + url + ")"} }
 }
@@ -4178,17 +4186,36 @@ func (a App) handleSongPromptKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // submitSongPrompt validates the song prompt's fields and, if valid, closes
-// the modal and hands the built "/song ..." command to the chatrooms
-// composer via SetComposeValueMsg — the same handoff applyAttachURL uses
-// for ctrl+g's "/gif <url>". The user still presses Enter in the composer
-// itself to actually send it.
+// the modal and dispatches the built attachment per target: Feed's new-post
+// panel / Post Detail's edit panel / Post Detail's reply compose each get a
+// native model.Attachment (confirmed live 2026-08-27 that posts and replies
+// both accept a "audio" attachment with no width/height — see
+// docs/00-api-backlog.md); cIRC/C-Mail instead get the "/song ..." command
+// text handed to the composer via SetComposeValueMsg — the same handoff
+// applyAttachURL uses for ctrl+g's "/gif <url>" — since the user still
+// presses Enter there to actually send it.
 func (a App) submitSongPrompt() (App, tea.Cmd) {
-	cmd, ok := a.songPrompt.BuildCommand()
+	att, ok := a.songPrompt.BuildAttachment()
 	if !ok {
 		a.songPrompt = a.songPrompt.SetWarning("enter a YouTube URL, artist, and title")
 		return a, nil
 	}
 	a.songPromptOpen = false
+	switch {
+	case a.active == screenFeed && a.feed.PanelActive():
+		a.feed = a.feed.SetPanelAudioAttachment(att)
+		return a, nil
+	case a.active == screenPostDetail && a.postDetail.EditPanelActive():
+		a.postDetail = a.postDetail.SetEditPanelAudioAttachment(att)
+		return a, nil
+	case a.active == screenPostDetail && a.postDetail.ReplyComposeActive():
+		a.postDetail = a.postDetail.SetReplyAudioAttachment(att)
+		return a, nil
+	}
+	cmd := "/song " + att.Src + " | " + att.Artist + " | " + att.Title
+	if att.Genre != "" {
+		cmd += " | " + att.Genre
+	}
 	return a, func() tea.Msg { return screens.SetComposeValueMsg{Value: cmd} }
 }
 
@@ -5109,9 +5136,22 @@ func (a *App) loadTopicThreadCmd(postID string) tea.Cmd {
 	}
 }
 
-func (a *App) createReplyCmd(postID, content, parentReplyID string) tea.Cmd {
+// createReplyCmd resolves at most one pending attachment (image/gif URL, or
+// an already-built audio one — SetReplyAttachmentURL/SetReplyAudioAttachment
+// each clear the other, so only one is ever non-empty/non-nil) and sends it
+// with the reply. Confirmed live 2026-08-27 that POST /v1/replies accepts an
+// attachments array identically to posts — see docs/00-api-backlog.md.
+func (a *App) createReplyCmd(postID, content, parentReplyID, attachmentURL string, audioAttachment *model.Attachment) tea.Cmd {
 	return func() tea.Msg {
-		reply, err := a.client.CreateReply(postID, content, parentReplyID)
+		attachment := audioAttachment
+		if attachmentURL != "" {
+			resolved, err := resolveAttachment(attachmentURL)
+			if err != nil {
+				return actionErrMsg{err}
+			}
+			attachment = resolved
+		}
+		reply, err := a.client.CreateReply(postID, content, parentReplyID, attachment)
 		if err != nil {
 			return actionErrMsg{err}
 		}
@@ -5141,35 +5181,46 @@ func attachmentTypeForURL(rawURL string) string {
 	return "image"
 }
 
-// resolveAttachment fetches attachmentURL's declared dimensions and builds
-// the model.Attachment CreatePost/EditPost send. Returns nil, nil for an
-// empty URL (no attachment). Returns an error — surfaced to the user like any
-// other actionErrMsg/editErrorMsg — when the image can't be fetched or
-// exceeds maxAttachmentDim; this app has no way to resize it (no upload
-// endpoint to host the result), so the accurate move is to fail clearly here
-// rather than let the server reject a request the user already spent an
-// interaction composing.
+// resolveAttachment builds the model.Attachment CreatePost/EditPost/
+// CreateReply send. Returns nil, nil for an empty URL (no attachment).
+//
+// EXPERIMENTAL, at user's request (2026-08-27): always declares
+// maxAttachmentDim x maxAttachmentDim instead of fetching the image to
+// determine and honestly report its real dimensions. Confirmed live
+// (docs/00-api-backlog.md, "Attachments — shape & validation") that the API
+// only validates the *declared* width/height are integers in [1, 640] —
+// it never fetches src to check them against the real file — so this
+// deliberately sends a false but always-valid declaration to test whether
+// cyberspace.online's website (or other clients) autoscale/render based on
+// the real image regardless of declared size, or actually trust the
+// declared dimensions for layout. No network fetch means this also no
+// longer rejects (or can reject) an oversized image client-side.
+//
+// To revert to honest dimension reporting (fetch the real image, reject
+// anything over maxAttachmentDim with a clear error): restore the version
+// of this function from before this comment — it called
+// imgview.Dimensions(ctx, attachmentURL) with a 20s timeout and compared the
+// real width/height against maxAttachmentDim, erroring with "attach image:
+// %dx%d exceeds the site's %dx%d limit..." when either was too large.
 func resolveAttachment(attachmentURL string) (*model.Attachment, error) {
 	if attachmentURL == "" {
 		return nil, nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
-	width, height, err := imgview.Dimensions(ctx, attachmentURL)
-	if err != nil {
-		return nil, fmt.Errorf("attach image: %w", err)
-	}
-	if width > maxAttachmentDim || height > maxAttachmentDim {
-		return nil, fmt.Errorf("attach image: %dx%d exceeds the site's %dx%d limit for post attachments — try a smaller image, or paste the link in the body text instead", width, height, maxAttachmentDim, maxAttachmentDim)
-	}
-	return &model.Attachment{Type: attachmentTypeForURL(attachmentURL), Src: attachmentURL, Width: width, Height: height}, nil
+	return &model.Attachment{Type: attachmentTypeForURL(attachmentURL), Src: attachmentURL, Width: maxAttachmentDim, Height: maxAttachmentDim}, nil
 }
 
-func (a *App) createPostCmd(content, title, slug string, topics []string, isPublic, isNSFW bool, attachmentURL string) tea.Cmd {
+// createPostCmd resolves at most one pending attachment (image/gif URL, or
+// an already-built audio one — PostComposePanel's SetAttachmentURL/
+// SetPendingAudio each clear the other, so only one is ever non-empty/nil).
+func (a *App) createPostCmd(content, title, slug string, topics []string, isPublic, isNSFW bool, attachmentURL string, audioAttachment *model.Attachment) tea.Cmd {
 	return func() tea.Msg {
-		attachment, err := resolveAttachment(attachmentURL)
-		if err != nil {
-			return actionErrMsg{err}
+		attachment := audioAttachment
+		if attachmentURL != "" {
+			resolved, err := resolveAttachment(attachmentURL)
+			if err != nil {
+				return actionErrMsg{err}
+			}
+			attachment = resolved
 		}
 		post, err := a.client.CreatePost(content, title, slug, topics, isPublic, isNSFW, attachment)
 		if err != nil {
@@ -5832,17 +5883,21 @@ func (a *App) deletePostCmd(postID string, fromFeed bool) tea.Cmd {
 // panel found on the post but doesn't manage (e.g. an audio one) — when
 // attachmentTouched, they're resent alongside the resolved attachmentURL
 // since EditPost replaces the whole attachments array wholesale.
-func (a *App) editPostCmd(postID, content, title string, topics []string, isPublic, isNSFW bool, attachmentURL string, attachmentTouched bool, otherAttachments []model.Attachment) tea.Cmd {
+func (a *App) editPostCmd(postID, content, title string, topics []string, isPublic, isNSFW bool, attachmentURL string, attachmentTouched bool, audioAttachment *model.Attachment, otherAttachments []model.Attachment) tea.Cmd {
 	return func() tea.Msg {
 		var attachments []model.Attachment
 		if attachmentTouched {
-			attachment, err := resolveAttachment(attachmentURL)
-			if err != nil {
-				return editErrorMsg(err)
-			}
 			attachments = append(attachments, otherAttachments...)
-			if attachment != nil {
-				attachments = append(attachments, *attachment)
+			if attachmentURL != "" {
+				resolved, err := resolveAttachment(attachmentURL)
+				if err != nil {
+					return editErrorMsg(err)
+				}
+				if resolved != nil {
+					attachments = append(attachments, *resolved)
+				}
+			} else if audioAttachment != nil {
+				attachments = append(attachments, *audioAttachment)
 			}
 		}
 		if err := a.client.EditPost(postID, content, title, topics, isPublic, isNSFW, attachments, attachmentTouched); err != nil {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1,15 +1,11 @@
 package ui
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"image"
 	"image/color"
-	"image/png"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -912,7 +908,7 @@ func TestShowSearchReplyMsg_NavigatesToPostDetailAndScrollsToReply(t *testing.T)
 func TestCreateReplyCmd_ReturnsReplyID(t *testing.T) {
 	a := loggedInApp()
 
-	cmd := a.createReplyCmd("p1", "nice post", "")
+	cmd := a.createReplyCmd("p1", "nice post", "", "", nil)
 	msg := cmd()
 
 	created, ok := msg.(replyCreatedMsg)
@@ -2371,7 +2367,7 @@ func (c *tooSoonPostClient) GetPost(postID string) (model.Post, error) {
 func TestCreatePostCmd_TooSoonConversion_ReturnsPostConvertedToNoteMsg(t *testing.T) {
 	a := NewApp(&tooSoonPostClient{MockClient: api.NewMockClient()})
 
-	msg := a.createPostCmd("hello", "", "", nil, true, false, "")()
+	msg := a.createPostCmd("hello", "", "", nil, true, false, "", nil)()
 	if _, ok := msg.(postConvertedToNoteMsg); !ok {
 		t.Fatalf("createPostCmd() = %T, want postConvertedToNoteMsg", msg)
 	}
@@ -2380,27 +2376,13 @@ func TestCreatePostCmd_TooSoonConversion_ReturnsPostConvertedToNoteMsg(t *testin
 func TestCreatePostCmd_NormalSuccess_ReturnsPostCreatedMsg(t *testing.T) {
 	a := NewApp(api.NewMockClient())
 
-	msg := a.createPostCmd("hello", "", "", nil, true, false, "")()
+	msg := a.createPostCmd("hello", "", "", nil, true, false, "", nil)()
 	if _, ok := msg.(postCreatedMsg); !ok {
 		t.Fatalf("createPostCmd() = %T, want postCreatedMsg", msg)
 	}
 }
 
-// --- resolveAttachment: dimension fetch + the API's 640px cap ---
-
-func testPNGServer(t *testing.T, w, h int) *httptest.Server {
-	t.Helper()
-	img := image.NewRGBA(image.Rect(0, 0, w, h))
-	var buf bytes.Buffer
-	if err := png.Encode(&buf, img); err != nil {
-		t.Fatalf("encode png: %v", err)
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		rw.Write(buf.Bytes())
-	}))
-	t.Cleanup(srv.Close)
-	return srv
-}
+// --- resolveAttachment ---
 
 func TestResolveAttachment_EmptyURL_ReturnsNil(t *testing.T) {
 	attachment, err := resolveAttachment("")
@@ -2409,14 +2391,17 @@ func TestResolveAttachment_EmptyURL_ReturnsNil(t *testing.T) {
 	}
 }
 
-func TestResolveAttachment_WithinLimit_SetsTypeAndDimensions(t *testing.T) {
-	srv := testPNGServer(t, 100, 50)
-	attachment, err := resolveAttachment(srv.URL + "/pic.png")
+// TestResolveAttachment_AlwaysReportsMaxDim guards the current EXPERIMENTAL
+// behavior (see resolveAttachment's doc comment, app.go): no network fetch,
+// always declares maxAttachmentDim x maxAttachmentDim regardless of the
+// image's real size — the URL doesn't even need to point at a real image.
+func TestResolveAttachment_AlwaysReportsMaxDim(t *testing.T) {
+	attachment, err := resolveAttachment("https://example.com/huge-4000x3000.png")
 	if err != nil {
 		t.Fatalf("resolveAttachment: %v", err)
 	}
-	if attachment.Type != "image" || attachment.Width != 100 || attachment.Height != 50 {
-		t.Errorf("attachment = %+v, want type=image width=100 height=50", attachment)
+	if attachment.Type != "image" || attachment.Width != maxAttachmentDim || attachment.Height != maxAttachmentDim {
+		t.Errorf("attachment = %+v, want type=image width=%d height=%d", attachment, maxAttachmentDim, maxAttachmentDim)
 	}
 }
 
@@ -2424,29 +2409,12 @@ func TestResolveAttachment_WithinLimit_SetsTypeAndDimensions(t *testing.T) {
 // extension-based inference, which the caller (createPostCmd/editPostCmd)
 // relies on since the API distinguishes "image" from "gif" attachments.
 func TestResolveAttachment_GIFExtension_SetsGIFType(t *testing.T) {
-	srv := testPNGServer(t, 10, 10) // content doesn't need to actually be a gif — only the URL suffix is inspected
-	attachment, err := resolveAttachment(srv.URL + "/pic.gif")
+	attachment, err := resolveAttachment("https://example.com/pic.gif")
 	if err != nil {
 		t.Fatalf("resolveAttachment: %v", err)
 	}
 	if attachment.Type != "gif" {
 		t.Errorf("attachment.Type = %q, want gif", attachment.Type)
-	}
-}
-
-// TestResolveAttachment_ExceedsLimit_ReturnsClearError guards the one thing
-// this app has no way to fix automatically: there's no upload endpoint to
-// host a resized copy, so an oversized image must fail here with a message
-// that explains why, rather than as a raw 400 from the API (confirmed live:
-// POST /v1/posts rejects width/height above 640px).
-func TestResolveAttachment_ExceedsLimit_ReturnsClearError(t *testing.T) {
-	srv := testPNGServer(t, 1200, 480)
-	attachment, err := resolveAttachment(srv.URL + "/pic.png")
-	if attachment != nil {
-		t.Errorf("attachment = %+v, want nil on an oversized image", attachment)
-	}
-	if err == nil || !strings.Contains(err.Error(), "640") {
-		t.Errorf("err = %v, want a message mentioning the 640px limit", err)
 	}
 }
 
@@ -2471,21 +2439,87 @@ func (c *editPostRecordingClient) EditPost(postID, content, title string, topics
 // here would silently delete them server-side, since EditPost replaces the
 // whole array.
 func TestEditPostCmd_MergesOtherAttachmentsWithResolvedAttachment(t *testing.T) {
-	srv := testPNGServer(t, 10, 10)
 	client := &editPostRecordingClient{MockClient: api.NewMockClient()}
 	a := NewApp(client)
 	audio := model.Attachment{Type: "audio", Src: "https://youtu.be/old"}
 
-	msg := a.editPostCmd("p1", "content", "title", nil, false, false, srv.URL+"/pic.png", true, []model.Attachment{audio})()
+	msg := a.editPostCmd("p1", "content", "title", nil, false, false, "https://example.com/pic.png", true, nil, []model.Attachment{audio})()
 	if _, ok := msg.(postEditedMsg); !ok {
 		t.Fatalf("editPostCmd() = %T, want postEditedMsg", msg)
 	}
 	if !client.gotTouched {
 		t.Fatal("expected EditPost to be called with attachmentTouched = true")
 	}
-	want := []model.Attachment{audio, {Type: "image", Src: srv.URL + "/pic.png", Width: 10, Height: 10}}
+	want := []model.Attachment{audio, {Type: "image", Src: "https://example.com/pic.png", Width: maxAttachmentDim, Height: maxAttachmentDim}}
 	if !slices.Equal(client.gotAttachments, want) {
 		t.Errorf("EditPost attachments = %+v, want %+v (other attachment first, then the resolved one)", client.gotAttachments, want)
+	}
+}
+
+// TestEditPostCmd_SendsAudioAttachmentWhenNoImageURL guards the ctrl+j path
+// for Post Detail's edit panel: when there's no pending image URL, the
+// pending audio attachment (already fully built — no dimension fetch needed)
+// must be sent instead, alongside any otherAttachments.
+func TestEditPostCmd_SendsAudioAttachmentWhenNoImageURL(t *testing.T) {
+	client := &editPostRecordingClient{MockClient: api.NewMockClient()}
+	a := NewApp(client)
+	audio := model.Attachment{Type: "audio", Src: "https://youtu.be/dQw4w9WgXcQ", Origin: "youtube", Artist: "a", Title: "t"}
+
+	msg := a.editPostCmd("p1", "content", "title", nil, false, false, "", true, &audio, nil)()
+	if _, ok := msg.(postEditedMsg); !ok {
+		t.Fatalf("editPostCmd() = %T, want postEditedMsg", msg)
+	}
+	want := []model.Attachment{audio}
+	if !slices.Equal(client.gotAttachments, want) {
+		t.Errorf("EditPost attachments = %+v, want %+v", client.gotAttachments, want)
+	}
+}
+
+// createReplyRecordingClient captures CreateReply's arguments so a test can
+// inspect exactly what was sent without a real API.
+type createReplyRecordingClient struct {
+	*api.MockClient
+	gotAttachment *model.Attachment
+}
+
+func (c *createReplyRecordingClient) CreateReply(postID, content, parentReplyID string, attachment *model.Attachment) (model.Reply, error) {
+	c.gotAttachment = attachment
+	return c.MockClient.CreateReply(postID, content, parentReplyID, attachment)
+}
+
+// TestCreateReplyCmd_ResolvesImageAttachmentURL guards the new reply
+// attachment path end to end: an AttachmentURL must be resolved (dimensions
+// fetched) the same way createPostCmd does, and sent as the reply's
+// attachment — confirmed live 2026-08-27 that POST /v1/replies accepts this
+// (docs/00-api-backlog.md).
+func TestCreateReplyCmd_ResolvesImageAttachmentURL(t *testing.T) {
+	client := &createReplyRecordingClient{MockClient: api.NewMockClient()}
+	a := NewApp(client)
+
+	msg := a.createReplyCmd("p1", "nice", "", "https://example.com/pic.png", nil)()
+	if _, ok := msg.(replyCreatedMsg); !ok {
+		t.Fatalf("createReplyCmd() = %T, want replyCreatedMsg", msg)
+	}
+	want := &model.Attachment{Type: "image", Src: "https://example.com/pic.png", Width: maxAttachmentDim, Height: maxAttachmentDim}
+	if client.gotAttachment == nil || *client.gotAttachment != *want {
+		t.Errorf("CreateReply attachment = %+v, want %+v", client.gotAttachment, want)
+	}
+}
+
+// TestCreateReplyCmd_SendsAudioAttachmentDirectly guards the ctrl+j path for
+// a reply: an already-built audio attachment needs no dimension fetch and
+// must be passed straight through to CreateReply.
+func TestCreateReplyCmd_SendsAudioAttachmentDirectly(t *testing.T) {
+	client := &createReplyRecordingClient{MockClient: api.NewMockClient()}
+	a := NewApp(client)
+	audio := &model.Attachment{Type: "audio", Src: "https://youtu.be/dQw4w9WgXcQ", Origin: "youtube", Artist: "a", Title: "t"}
+
+	msg := a.createReplyCmd("p1", "check this out", "", "", audio)()
+	if _, ok := msg.(replyCreatedMsg); !ok {
+		t.Fatalf("createReplyCmd() = %T, want replyCreatedMsg", msg)
+	}
+	if client.gotAttachment == nil || *client.gotAttachment != *audio {
+		t.Errorf("CreateReply attachment = %+v, want %+v", client.gotAttachment, audio)
 	}
 }
 
@@ -2945,10 +2979,11 @@ func TestApplyAttachURL_CMailNonGIF_WarnsInsteadOfInserting(t *testing.T) {
 	}
 }
 
-// TestApplyAttachURL_ReplyCompose_WarnsInsteadOfInserting: the reply API has
-// no attachments field at all, so ctrl+g must not silently insert markdown
-// that (per the same live evidence as the chat case) won't render anywhere.
-func TestApplyAttachURL_ReplyCompose_WarnsInsteadOfInserting(t *testing.T) {
+// TestApplyAttachURL_ReplyCompose_SetsAttachmentURL: confirmed live 2026-08-27
+// that the reply API does accept an attachments field (docs.md just never
+// mentions it) — ctrl+g sets a pending image/gif attachment for the reply
+// the same way it does for Feed's compose panel, instead of the old warning.
+func TestApplyAttachURL_ReplyCompose_SetsAttachmentURL(t *testing.T) {
 	a := loggedInApp()
 	a.active = screenPostDetail
 	a.postDetail = a.postDetail.SetPost(model.Post{ID: "p1", Content: "body"})
@@ -2959,8 +2994,8 @@ func TestApplyAttachURL_ReplyCompose_WarnsInsteadOfInserting(t *testing.T) {
 	}
 
 	a2, _ := a.applyAttachURL("https://example.com/pic.png")
-	if a2.notifyLevel != notifyWarn || a2.notifyText == "" {
-		t.Errorf("expected a warning notification for a reply attachment, got level=%v text=%q", a2.notifyLevel, a2.notifyText)
+	if a2.notifyText != "" {
+		t.Errorf("expected no warning notification, got level=%v text=%q", a2.notifyLevel, a2.notifyText)
 	}
 }
 
@@ -3028,6 +3063,102 @@ func TestHandleKeys_CtrlJ_NotConsumed_OutsideChatrooms(t *testing.T) {
 	_, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyCtrlJ})
 	if consumed {
 		t.Error("expected ctrl+j to be unconsumed (and not open the song prompt) outside cIRC")
+	}
+}
+
+// TestHandleKeys_CtrlJ_OpensSongPrompt_FromFeedPanel guards the broadened
+// scope confirmed live 2026-08-27: posts (not just cIRC) accept an audio
+// attachment, so ctrl+j must also open from Feed's new-post panel.
+func TestHandleKeys_CtrlJ_OpensSongPrompt_FromFeedPanel(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{IsSupporter: true}
+	m, _ := a.feed.Update(keyMsg("n"))
+	a.feed = m
+	if !a.feed.PanelActive() {
+		t.Fatal("setup: expected Feed's new-post panel open after 'n'")
+	}
+
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if !consumed {
+		t.Fatal("expected ctrl+j to be consumed while Feed's compose panel is open")
+	}
+	if !a2.songPromptOpen {
+		t.Error("expected songPromptOpen = true after ctrl+j from Feed's panel")
+	}
+}
+
+// TestHandleKeys_CtrlJ_OpensSongPrompt_FromReplyCompose guards the same
+// broadened scope for Post Detail's reply compose box.
+func TestHandleKeys_CtrlJ_OpensSongPrompt_FromReplyCompose(t *testing.T) {
+	a := loggedInApp()
+	a.currentUser = model.User{IsSupporter: true}
+	a.active = screenPostDetail
+	a.postDetail = a.postDetail.SetPost(model.Post{ID: "p1", Content: "body"})
+	pd, _ := a.postDetail.OpenCompose()
+	a.postDetail = pd
+	if !a.postDetail.ReplyComposeActive() {
+		t.Fatal("setup: expected the reply compose box open")
+	}
+
+	a2, _, consumed := a.handleKeys(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if !consumed {
+		t.Fatal("expected ctrl+j to be consumed while the reply compose box is open")
+	}
+	if !a2.songPromptOpen {
+		t.Error("expected songPromptOpen = true after ctrl+j from the reply compose box")
+	}
+}
+
+// TestSubmitSongPrompt_ReplyCompose_SetsAudioAttachmentNotComposeText guards
+// the dispatch that makes this feature work: submitting from a reply compose
+// target must build a native model.Attachment and hand it to PostDetail,
+// not fall through to the chat-only "/song ..." SetComposeValueMsg path.
+func TestSubmitSongPrompt_ReplyCompose_SetsAudioAttachmentNotComposeText(t *testing.T) {
+	a := loggedInApp()
+	a.active = screenPostDetail
+	a.postDetail = a.postDetail.SetPost(model.Post{ID: "p1", Content: "body"})
+	pd, _ := a.postDetail.OpenCompose()
+	a.postDetail = pd
+	a.songPromptOpen = true
+	a.songPrompt, _ = a.songPrompt.Open()
+	fillSongPrompt(&a, "https://youtu.be/dQw4w9WgXcQ", "Rick Astley", "Never Gonna Give You Up", "")
+
+	a2, cmd := a.submitSongPrompt()
+	if a2.songPromptOpen {
+		t.Error("expected songPromptOpen = false after a valid submit")
+	}
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(screens.SetComposeValueMsg); ok {
+				t.Error("expected no SetComposeValueMsg for a reply-compose target — that's the chat-only path")
+			}
+		}
+	}
+}
+
+// TestSubmitSongPrompt_FeedPanel_SetsAudioAttachmentNotComposeText mirrors
+// the reply-compose case for Feed's new-post panel.
+func TestSubmitSongPrompt_FeedPanel_SetsAudioAttachmentNotComposeText(t *testing.T) {
+	a := loggedInApp()
+	m, _ := a.feed.Update(keyMsg("n"))
+	a.feed = m
+	a.songPromptOpen = true
+	a.songPrompt, _ = a.songPrompt.Open()
+	fillSongPrompt(&a, "https://youtu.be/dQw4w9WgXcQ", "Rick Astley", "Never Gonna Give You Up", "")
+
+	a2, cmd := a.submitSongPrompt()
+	if a2.songPromptOpen {
+		t.Error("expected songPromptOpen = false after a valid submit")
+	}
+	if got := a2.feed.PanelAudioAttachment(); got == nil || got.Title != "Never Gonna Give You Up" {
+		t.Errorf("expected Feed's panel to hold the submitted audio attachment, got %v", got)
+	}
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(screens.SetComposeValueMsg); ok {
+				t.Error("expected no SetComposeValueMsg for a Feed-panel target — that's the chat-only path")
+			}
+		}
 	}
 }
 

--- a/internal/ui/screens/compose.go
+++ b/internal/ui/screens/compose.go
@@ -137,6 +137,14 @@ func (m ComposeModel) Close() ComposeModel {
 // IsActive reports whether the compose box is open and focused.
 func (m ComposeModel) IsActive() bool { return m.active }
 
+// SetContext replaces the label shown above the editor — used to append a
+// pending-attachment note (e.g. PostDetail's reply compose showing "song
+// <artist> — <title>" after ctrl+j) without reopening the box.
+func (m ComposeModel) SetContext(ctx string) ComposeModel {
+	m.context = ctx
+	return m
+}
+
 // Content returns the current textarea value.
 func (m ComposeModel) Content() string { return m.textarea.Value() }
 
@@ -316,11 +324,16 @@ type PostComposePanel struct {
 	// existing one (e.g. an audio attachment this panel knows nothing about).
 	attachmentURL     string
 	attachmentTouched bool
+	// pendingAudio is a pending audio (YouTube) attachment, set via ctrl+j
+	// (see app.go's submitSongPrompt) — the post/reply equivalent of cIRC's
+	// /song. Confirmed live that the API accepts a "audio"-type attachment
+	// on posts/replies with no width/height (docs/00-api-backlog.md).
+	pendingAudio *model.Attachment
 	// otherAttachments holds every attachment OpenForEdit found on the post
-	// besides the one it loaded into attachmentURL (e.g. a /song jukebox
-	// track) — carried through untouched so a submit that sends the
-	// attachments field (attachmentTouched) re-includes them instead of
-	// dropping them, since the API replaces the whole array wholesale.
+	// besides the ones it loaded into attachmentURL/pendingAudio — carried
+	// through untouched so a submit that sends the attachments field
+	// (attachmentTouched) re-includes them instead of dropping them, since
+	// the API replaces the whole array wholesale.
 	otherAttachments []model.Attachment
 }
 
@@ -368,6 +381,7 @@ func (m PostComposePanel) Open(defaultPublic bool) (PostComposePanel, tea.Cmd) {
 	m.textarea.SetHeight(composeMinLines)
 	m.attachmentURL = ""
 	m.attachmentTouched = false
+	m.pendingAudio = nil
 	m.otherAttachments = nil
 	m.textarea.Blur()
 	m.slugInput.Blur()
@@ -392,13 +406,18 @@ func (m PostComposePanel) OpenForEdit(post model.Post) (PostComposePanel, tea.Cm
 	m.textarea.SetValue(post.Content)
 	m.attachmentURL = ""
 	m.attachmentTouched = false
+	m.pendingAudio = nil
 	m.otherAttachments = nil
 	for _, a := range post.Attachments {
-		if m.attachmentURL == "" && (a.Type == "image" || a.Type == "gif") {
+		switch {
+		case m.attachmentURL == "" && (a.Type == "image" || a.Type == "gif"):
 			m.attachmentURL = a.Src
-			continue
+		case m.pendingAudio == nil && a.Type == "audio":
+			attCopy := a
+			m.pendingAudio = &attCopy
+		default:
+			m.otherAttachments = append(m.otherAttachments, a)
 		}
-		m.otherAttachments = append(m.otherAttachments, a)
 	}
 	m.titleInput.Blur()
 	m.slugInput.Blur()
@@ -429,23 +448,46 @@ func (m PostComposePanel) Close() PostComposePanel {
 	m.topicsInput.Blur()
 	m.attachmentURL = ""
 	m.attachmentTouched = false
+	m.pendingAudio = nil
 	m.otherAttachments = nil
 	return m
 }
 
-func (m PostComposePanel) IsActive() bool     { return m.active }
-func (m PostComposePanel) Content() string    { return m.textarea.Value() }
+func (m PostComposePanel) IsActive() bool  { return m.active }
+func (m PostComposePanel) Content() string { return m.textarea.Value() }
 
 // SetAttachmentURL sets (or, given "", clears) the pending image/gif
 // attachment and marks it touched — see the struct's attachmentTouched doc.
+// Setting a non-empty URL clears any pending audio attachment: CreatePost
+// only accepts one native attachment per post, so the two slots are
+// mutually exclusive (matching how EditPost/CreateReply's equivalent panels
+// behave too).
 func (m PostComposePanel) SetAttachmentURL(url string) PostComposePanel {
 	m.attachmentURL = url
 	m.attachmentTouched = true
+	if url != "" {
+		m.pendingAudio = nil
+	}
 	return m
 }
 
 func (m PostComposePanel) AttachmentURL() string   { return m.attachmentURL }
 func (m PostComposePanel) AttachmentTouched() bool { return m.attachmentTouched }
+
+// SetPendingAudio sets (or, given nil, clears) the pending audio (YouTube)
+// attachment built by the ctrl+j song prompt, and marks attachments touched
+// — see the struct's attachmentTouched doc. Setting one clears a pending
+// image/gif — see SetAttachmentURL's doc for why the two are exclusive.
+func (m PostComposePanel) SetPendingAudio(a *model.Attachment) PostComposePanel {
+	m.pendingAudio = a
+	m.attachmentTouched = true
+	if a != nil {
+		m.attachmentURL = ""
+	}
+	return m
+}
+
+func (m PostComposePanel) PendingAudio() *model.Attachment { return m.pendingAudio }
 
 // OtherAttachments returns every attachment OpenForEdit found on the post
 // besides the image/gif one tracked by AttachmentURL — see the struct's
@@ -481,6 +523,9 @@ func (m PostComposePanel) PanelHeight() int {
 		h = m.bodyLines + 6
 	}
 	if m.attachmentURL != "" {
+		h++
+	}
+	if m.pendingAudio != nil {
 		h++
 	}
 	return h
@@ -750,6 +795,14 @@ func (m PostComposePanel) View() string {
 			url = ansiTruncate(url, remaining)
 		}
 		rows = append(rows, theme.Subtle.Render("attach ")+theme.Base.Render(url))
+	}
+	if m.pendingAudio != nil {
+		const songLabelW = 7 // "song   " — matches attachLabelW
+		label := m.pendingAudio.Artist + " — " + m.pendingAudio.Title
+		if remaining := innerW - songLabelW; remaining > 1 {
+			label = ansiTruncate(label, remaining)
+		}
+		rows = append(rows, theme.Subtle.Render("song   ")+theme.Base.Render(label))
 	}
 	inner := lipgloss.JoinVertical(lipgloss.Left, rows...)
 	boxStyle := theme.ActiveBorder

--- a/internal/ui/screens/compose_test.go
+++ b/internal/ui/screens/compose_test.go
@@ -35,16 +35,15 @@ func TestPostComposePanel_OpenForEdit_TextareaHeightMatchesBodyLines(t *testing.
 	}
 }
 
-// TestPostComposePanel_OpenForEdit_PrefillsImageAttachment guards the
-// prefill PostDetail/Feed rely on to avoid clobbering an existing attachment
-// on save: OpenForEdit must seed attachmentURL from the post's own
-// image/gif attachment (skipping any audio one), but leave it untouched so
-// a save that never calls SetAttachmentURL omits the attachments field
-// entirely (see EditPost's attachmentTouched). The audio attachment must
-// still be preserved (via OtherAttachments) rather than discarded, since a
-// touched save resends the whole attachments array and would otherwise
-// silently drop it.
-func TestPostComposePanel_OpenForEdit_PrefillsImageAttachment(t *testing.T) {
+// TestPostComposePanel_OpenForEdit_PrefillsImageAndAudioAttachments guards
+// the prefill PostDetail/Feed rely on to avoid clobbering an existing
+// attachment on save: OpenForEdit must seed attachmentURL from the post's
+// own image/gif attachment and pendingAudio from its audio attachment, but
+// leave both untouched so a save that never calls SetAttachmentURL/
+// SetPendingAudio omits the attachments field entirely (see EditPost's
+// attachmentTouched). OtherAttachments stays empty here since both slots
+// were filled — it only catches attachment types beyond these two.
+func TestPostComposePanel_OpenForEdit_PrefillsImageAndAudioAttachments(t *testing.T) {
 	m := NewPostComposePanel(80)
 	audio := model.Attachment{Type: "audio", Src: "https://example.com/track.mp3"}
 	m, _ = m.OpenForEdit(model.Post{
@@ -54,10 +53,13 @@ func TestPostComposePanel_OpenForEdit_PrefillsImageAttachment(t *testing.T) {
 		},
 	})
 	if got := m.AttachmentURL(); got != "https://example.com/pic.png" {
-		t.Errorf("AttachmentURL() = %q, want the image attachment's src (audio skipped)", got)
+		t.Errorf("AttachmentURL() = %q, want the image attachment's src", got)
 	}
-	if got := m.OtherAttachments(); len(got) != 1 || got[0] != audio {
-		t.Errorf("OtherAttachments() = %v, want [%v] (the audio attachment, preserved)", got, audio)
+	if got := m.PendingAudio(); got == nil || *got != audio {
+		t.Errorf("PendingAudio() = %v, want %v", got, audio)
+	}
+	if got := m.OtherAttachments(); len(got) != 0 {
+		t.Errorf("OtherAttachments() = %v, want empty — both attachments have dedicated slots", got)
 	}
 	if m.AttachmentTouched() {
 		t.Error("AttachmentTouched() = true after OpenForEdit, want false — prefilling isn't a user edit")
@@ -97,5 +99,40 @@ func TestPostComposePanel_Open_ResetsAttachment(t *testing.T) {
 	}
 	if m.AttachmentTouched() {
 		t.Error("AttachmentTouched() = true after Open(), want false")
+	}
+}
+
+// TestPostComposePanel_ImageAndAudioAttachmentsAreMutuallyExclusive guards
+// CreatePost's single-attachment signature: setting an image clears a
+// pending audio one and vice versa, so a submit never has to decide which of
+// two set attachments to actually send.
+func TestPostComposePanel_ImageAndAudioAttachmentsAreMutuallyExclusive(t *testing.T) {
+	audio := &model.Attachment{Type: "audio", Src: "https://youtu.be/dQw4w9WgXcQ", Origin: "youtube", Artist: "a", Title: "t"}
+
+	m := NewPostComposePanel(80)
+	m = m.SetPendingAudio(audio)
+	m = m.SetAttachmentURL("https://example.com/pic.png")
+	if got := m.PendingAudio(); got != nil {
+		t.Errorf("PendingAudio() = %v after SetAttachmentURL, want nil", got)
+	}
+
+	m2 := NewPostComposePanel(80)
+	m2 = m2.SetAttachmentURL("https://example.com/pic.png")
+	m2 = m2.SetPendingAudio(audio)
+	if got := m2.AttachmentURL(); got != "" {
+		t.Errorf("AttachmentURL() = %q after SetPendingAudio, want empty", got)
+	}
+}
+
+// TestPostComposePanel_PanelHeight_GrowsForPendingAudio guards the layout
+// math: a pending audio attachment adds exactly one row, the same as an
+// image attachment does, so App's viewport-height recalculation stays in
+// sync with what View() actually renders.
+func TestPostComposePanel_PanelHeight_GrowsForPendingAudio(t *testing.T) {
+	m := NewPostComposePanel(80)
+	base := m.PanelHeight()
+	m = m.SetPendingAudio(&model.Attachment{Type: "audio", Src: "https://youtu.be/dQw4w9WgXcQ", Artist: "a", Title: "t"})
+	if got := m.PanelHeight(); got != base+1 {
+		t.Errorf("PanelHeight() = %d after SetPendingAudio, want %d", got, base+1)
 	}
 }

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -69,13 +69,14 @@ const feedMergeAnimDelay = 200 * time.Millisecond
 
 // SubmitNewPostMsg is emitted when the user submits a new post from the Feed.
 type SubmitNewPostMsg struct {
-	Content       string
-	Title         string // empty = no title
-	Slug          string // empty = server-generated
-	Topics        []string
-	IsPublic      bool
-	IsNSFW        bool
-	AttachmentURL string // empty = no attachment
+	Content         string
+	Title           string // empty = no title
+	Slug            string // empty = server-generated
+	Topics          []string
+	IsPublic        bool
+	IsNSFW          bool
+	AttachmentURL   string            // empty = no image/gif attachment
+	AudioAttachment *model.Attachment // nil = no audio attachment
 }
 
 // SubmitPostEditMsg is emitted when the user submits an edit to an existing
@@ -90,9 +91,13 @@ type SubmitPostEditMsg struct {
 	IsNSFW            bool
 	AttachmentURL     string // only meaningful when AttachmentTouched
 	AttachmentTouched bool   // false = leave existing attachments alone
+	// AudioAttachment is the pending audio (YouTube) attachment, set via
+	// ctrl+j — sent alongside AttachmentURL when AttachmentTouched.
+	AudioAttachment *model.Attachment
 	// OtherAttachments are attachments the edit panel found on the post but
-	// doesn't manage (e.g. an audio one) — re-sent alongside AttachmentURL
-	// when AttachmentTouched, since the API replaces the whole array.
+	// doesn't manage (any type besides the one image/gif slot and the one
+	// audio slot) — re-sent alongside AttachmentURL/AudioAttachment when
+	// AttachmentTouched, since the API replaces the whole array.
 	OtherAttachments []model.Attachment
 }
 
@@ -505,6 +510,15 @@ func (m FeedModel) SetPanelAttachment(url string) FeedModel {
 	return m
 }
 
+// SetPanelAudioAttachment sets the panel's pending audio (YouTube) attachment.
+func (m FeedModel) SetPanelAudioAttachment(a model.Attachment) FeedModel {
+	m.panel = m.panel.SetPendingAudio(&a)
+	return m
+}
+
+// PanelAudioAttachment returns the panel's pending audio attachment, if any.
+func (m FeedModel) PanelAudioAttachment() *model.Attachment { return m.panel.PendingAudio() }
+
 func (m FeedModel) Init() tea.Cmd { return nil }
 
 func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
@@ -607,18 +621,19 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		isNSFW := m.panel.IsNSFW()
 		attachmentURL := m.panel.AttachmentURL()
 		attachmentTouched := m.panel.AttachmentTouched()
+		audioAttachment := m.panel.PendingAudio()
 		otherAttachments := m.panel.OtherAttachments()
 		if m.editingPostID != "" {
 			postID := m.editingPostID
 			m = m.closeCompose()
 			return m, func() tea.Msg {
-				return SubmitPostEditMsg{PostID: postID, Content: content, Title: title, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW, AttachmentURL: attachmentURL, AttachmentTouched: attachmentTouched, OtherAttachments: otherAttachments}
+				return SubmitPostEditMsg{PostID: postID, Content: content, Title: title, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW, AttachmentURL: attachmentURL, AttachmentTouched: attachmentTouched, AudioAttachment: audioAttachment, OtherAttachments: otherAttachments}
 			}
 		}
 		slug := m.panel.SlugValue()
 		m = m.closeCompose()
 		return m, func() tea.Msg {
-			return SubmitNewPostMsg{Content: content, Title: title, Slug: slug, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW, AttachmentURL: attachmentURL}
+			return SubmitNewPostMsg{Content: content, Title: title, Slug: slug, Topics: topics, IsPublic: isPublic, IsNSFW: isNSFW, AttachmentURL: attachmentURL, AudioAttachment: audioAttachment}
 		}
 
 	case ComposeCancelMsg:

--- a/internal/ui/screens/postdetail.go
+++ b/internal/ui/screens/postdetail.go
@@ -99,6 +99,8 @@ type SubmitReplyMsg struct {
 	PostID        string
 	ParentReplyID string
 	Content       string
+	AttachmentURL string            // empty = no image/gif attachment; resolved (dimensions fetched) by App before sending
+	Attachment    *model.Attachment // pending audio (YouTube) attachment, already fully built — nil = none
 }
 
 // SubmitReplyEditMsg is emitted when the user submits an edit to their own
@@ -132,14 +134,17 @@ type PostDetailModel struct {
 	loading             bool
 	err                 error
 
-	compose           ComposeModel
-	replyPostID       string           // postID set when compose opens
-	replyParentID     string           // parentReplyID set when compose opens (empty = top-level)
-	editingReplyID    string           // non-empty while m.compose is editing this reply rather than composing a new one
-	editPanel         PostComposePanel // post-edit panel; PostDetail has no "new post" panel, only this edit-mode one
-	relaxed           bool             // true = blank lines between post, header, and replies
-	loc               *time.Location   // timezone for timestamp display; nil = UTC
-	timeDisplayFormat string           // API setting: "datetime", "relative", "unix", "swatch"
+	compose              ComposeModel
+	replyPostID          string            // postID set when compose opens
+	replyParentID        string            // parentReplyID set when compose opens (empty = top-level)
+	replyContextBase     string            // compose.context before any attachment note is appended — see setReplyComposeContext
+	replyAttachmentURL   string            // pending image/gif attachment URL for the reply compose box, set via ctrl+g; resolved (dimensions fetched) by App at submit time
+	replyAudioAttachment *model.Attachment // pending audio (YouTube) attachment for the reply compose box, set via ctrl+j
+	editingReplyID       string            // non-empty while m.compose is editing this reply rather than composing a new one
+	editPanel            PostComposePanel  // post-edit panel; PostDetail has no "new post" panel, only this edit-mode one
+	relaxed              bool              // true = blank lines between post, header, and replies
+	loc                  *time.Location    // timezone for timestamp display; nil = UTC
+	timeDisplayFormat    string            // API setting: "datetime", "relative", "unix", "swatch"
 
 	currentUsername        string        // set after login; guards the delete key to own content
 	currentUserIsSupporter bool          // set after login/profile load; edit requires supporter status
@@ -239,6 +244,8 @@ func (m PostDetailModel) Close() PostDetailModel {
 	m.loading = false
 	m.err = nil
 	m.compose = m.compose.Close()
+	m.replyAttachmentURL = ""
+	m.replyAudioAttachment = nil
 	m.confirming = pdConfirmNone
 	m.flagPrompt = NewFlagPrompt()
 	m.flagTargetPostID, m.flagTargetReplyID = "", ""
@@ -318,13 +325,55 @@ func (m PostDetailModel) ComposeActive() bool {
 func (m PostDetailModel) EditPanelActive() bool { return m.editPanel.IsActive() }
 
 // ReplyComposeActive reports whether the reply compose box specifically
-// (not the edit panel) is open — see app.go's applyAttachURL, which warns
-// instead of inserting here: the reply API has no attachments field at all.
+// (not the edit panel) is open — see app.go's applyAttachURL, which routes
+// ctrl+g here to SetReplyAttachmentURL (confirmed live 2026-08-27 that the
+// API's attachments field works on replies too, despite docs.md never
+// mentioning it — see docs/00-api-backlog.md).
 func (m PostDetailModel) ReplyComposeActive() bool { return m.compose.IsActive() }
+
+// setReplyComposeContext rebuilds the compose box's context label from
+// replyContextBase plus a short note about whichever attachment (image/gif
+// URL or audio) is currently pending, so the user sees it's attached before
+// submitting. Only one of the two is ever shown — SetReplyAttachmentURL and
+// SetReplyAudioAttachment each clear the other, matching PostComposePanel's
+// one-slot-per-kind behavior.
+func (m PostDetailModel) setReplyComposeContext() PostDetailModel {
+	ctx := m.replyContextBase
+	switch {
+	case m.replyAttachmentURL != "":
+		ctx += " · attach " + m.replyAttachmentURL
+	case m.replyAudioAttachment != nil:
+		ctx += " · song " + m.replyAudioAttachment.Artist + " — " + m.replyAudioAttachment.Title
+	}
+	m.compose = m.compose.SetContext(ctx)
+	return m
+}
+
+// SetReplyAttachmentURL sets (or, given "", clears) the reply compose box's
+// pending image/gif attachment URL — see app.go's applyAttachURL (ctrl+g).
+func (m PostDetailModel) SetReplyAttachmentURL(url string) PostDetailModel {
+	m.replyAttachmentURL = url
+	m.replyAudioAttachment = nil
+	return m.setReplyComposeContext()
+}
+
+// SetReplyAudioAttachment sets the reply compose box's pending audio
+// (YouTube) attachment — see app.go's submitSongPrompt (ctrl+j).
+func (m PostDetailModel) SetReplyAudioAttachment(a model.Attachment) PostDetailModel {
+	m.replyAudioAttachment = &a
+	m.replyAttachmentURL = ""
+	return m.setReplyComposeContext()
+}
 
 // SetEditPanelAttachment sets the edit panel's pending image/gif attachment URL.
 func (m PostDetailModel) SetEditPanelAttachment(url string) PostDetailModel {
 	m.editPanel = m.editPanel.SetAttachmentURL(url)
+	return m
+}
+
+// SetEditPanelAudioAttachment sets the edit panel's pending audio (YouTube) attachment.
+func (m PostDetailModel) SetEditPanelAudioAttachment(a model.Attachment) PostDetailModel {
+	m.editPanel = m.editPanel.SetPendingAudio(&a)
 	return m
 }
 
@@ -458,6 +507,8 @@ func (m PostDetailModel) SetLocation(loc *time.Location) PostDetailModel {
 // Returns (model, cmd) where cmd starts the cursor blink animation.
 func (m PostDetailModel) OpenCompose() (PostDetailModel, tea.Cmd) {
 	m.replyPostID = m.post.ID
+	m.replyAttachmentURL = ""
+	m.replyAudioAttachment = nil
 	var ctx string
 	if m.selectedReply >= 0 && m.selectedReply < len(m.flatTree) {
 		m.replyParentID = m.flatTree[m.selectedReply].Reply.ID
@@ -466,6 +517,7 @@ func (m PostDetailModel) OpenCompose() (PostDetailModel, tea.Cmd) {
 		m.replyParentID = ""
 		ctx = "replying to @" + m.post.AuthorUsername
 	}
+	m.replyContextBase = ctx
 	var cmd tea.Cmd
 	m.compose, cmd = m.compose.Open(ctx, "write your reply…")
 	if m.ready {
@@ -631,7 +683,11 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 			}
 		}
 		parentID := m.replyParentID
+		attachmentURL := m.replyAttachmentURL
+		attachment := m.replyAudioAttachment
 		m.compose = m.compose.Close()
+		m.replyAttachmentURL = ""
+		m.replyAudioAttachment = nil
 		if m.ready {
 			m.viewport.Height = m.viewportHeight()
 		}
@@ -640,6 +696,8 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 				PostID:        postID,
 				ParentReplyID: parentID,
 				Content:       content,
+				AttachmentURL: attachmentURL,
+				Attachment:    attachment,
 			}
 		}
 
@@ -647,6 +705,8 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 		m.compose = m.compose.Close()
 		m.editPanel = m.editPanel.Close()
 		m.editingReplyID = ""
+		m.replyAttachmentURL = ""
+		m.replyAudioAttachment = nil
 		if m.ready {
 			m.viewport.Height = m.viewportHeight()
 		}
@@ -759,6 +819,10 @@ func (m PostDetailModel) Update(msg tea.Msg) (PostDetailModel, tea.Cmd) {
 			reply := m.flatTree[m.selectedReply].Reply
 			m.editingReplyID = reply.ID
 			m.replyPostID = m.post.ID
+			// Reply edit only supports content (docs.md, confirmed) — no
+			// attachment state carries into an edit-in-progress.
+			m.replyAttachmentURL = ""
+			m.replyAudioAttachment = nil
 			var cmd tea.Cmd
 			m.compose, cmd = m.compose.OpenWithContent("editing reply", "write your reply…", reply.Content)
 			m.viewport.Height = m.viewportHeight()

--- a/internal/ui/screens/postdetail_test.go
+++ b/internal/ui/screens/postdetail_test.go
@@ -732,3 +732,84 @@ func TestPostDetail_T_EmitsPreviewPostThemeMsg_WhenSelectedReplyHasThemeBlock(t 
 		t.Errorf("Palette.Foreground = %q, want #d000ff", msg.Palette.Foreground)
 	}
 }
+
+// TestPostDetail_ReplyAttachment_ImageAndAudioAreMutuallyExclusive guards
+// CreateReply's single-attachment signature the same way PostComposePanel's
+// two setters do: setting one clears the other.
+func TestPostDetail_ReplyAttachment_ImageAndAudioAreMutuallyExclusive(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetPost(pdPost("p1"))
+	m, _ = m.OpenCompose()
+
+	audio := model.Attachment{Type: "audio", Src: "https://youtu.be/dQw4w9WgXcQ", Origin: "youtube", Artist: "a", Title: "t"}
+	m = m.SetReplyAudioAttachment(audio)
+	m = m.SetReplyAttachmentURL("https://example.com/pic.png")
+
+	_, cmd := m.Update(screens.ComposeSubmitMsg{Content: "check this out"})
+	if cmd == nil {
+		t.Fatal("expected a cmd from ComposeSubmitMsg")
+	}
+	msg, ok := cmd().(screens.SubmitReplyMsg)
+	if !ok {
+		t.Fatalf("expected SubmitReplyMsg, got %T", cmd())
+	}
+	if msg.AttachmentURL != "https://example.com/pic.png" {
+		t.Errorf("AttachmentURL = %q, want the image URL", msg.AttachmentURL)
+	}
+	if msg.Attachment != nil {
+		t.Errorf("Attachment = %v, want nil — setting the image URL should have cleared the pending audio one", msg.Attachment)
+	}
+}
+
+// TestPostDetail_ComposeSubmit_CarriesReplyAudioAttachment guards the
+// opposite direction: an audio attachment set via SetReplyAudioAttachment
+// must reach SubmitReplyMsg, and clear afterward so it can't leak into the
+// next reply.
+func TestPostDetail_ComposeSubmit_CarriesReplyAudioAttachment(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetPost(pdPost("p1"))
+	m, _ = m.OpenCompose()
+
+	audio := model.Attachment{Type: "audio", Src: "https://youtu.be/dQw4w9WgXcQ", Origin: "youtube", Artist: "a", Title: "t"}
+	m = m.SetReplyAudioAttachment(audio)
+
+	m, cmd := m.Update(screens.ComposeSubmitMsg{Content: "check this out"})
+	msg, ok := cmd().(screens.SubmitReplyMsg)
+	if !ok {
+		t.Fatalf("expected SubmitReplyMsg, got %T", cmd())
+	}
+	if msg.Attachment == nil || *msg.Attachment != audio {
+		t.Errorf("Attachment = %v, want %v", msg.Attachment, audio)
+	}
+
+	// Reopening for a new reply must not carry the previous one's attachment.
+	m, _ = m.OpenCompose()
+	_, cmd2 := m.Update(screens.ComposeSubmitMsg{Content: "another reply"})
+	msg2, ok := cmd2().(screens.SubmitReplyMsg)
+	if !ok {
+		t.Fatalf("expected SubmitReplyMsg, got %T", cmd2())
+	}
+	if msg2.Attachment != nil || msg2.AttachmentURL != "" {
+		t.Errorf("expected the next reply to start with no attachment, got Attachment=%v AttachmentURL=%q", msg2.Attachment, msg2.AttachmentURL)
+	}
+}
+
+// TestPostDetail_ComposeCancel_ClearsReplyAttachment guards Esc: a pending
+// attachment must not survive a cancelled compose and leak into the next one.
+func TestPostDetail_ComposeCancel_ClearsReplyAttachment(t *testing.T) {
+	m := initPostDetail()
+	m = m.SetPost(pdPost("p1"))
+	m, _ = m.OpenCompose()
+	m = m.SetReplyAttachmentURL("https://example.com/pic.png")
+
+	m, _ = m.Update(screens.ComposeCancelMsg{})
+	m, _ = m.OpenCompose()
+	_, cmd := m.Update(screens.ComposeSubmitMsg{Content: "fresh reply"})
+	msg, ok := cmd().(screens.SubmitReplyMsg)
+	if !ok {
+		t.Fatalf("expected SubmitReplyMsg, got %T", cmd())
+	}
+	if msg.AttachmentURL != "" {
+		t.Errorf("AttachmentURL = %q after cancel+reopen, want empty", msg.AttachmentURL)
+	}
+}

--- a/internal/ui/screens/songprompt.go
+++ b/internal/ui/screens/songprompt.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/ragnar/cyber-tui/internal/model"
 	"github.com/ragnar/cyber-tui/internal/ui/theme"
 	"github.com/ragnar/cyber-tui/internal/youtube"
 )
@@ -117,23 +118,36 @@ func (m SongPromptModel) FetchFailed() SongPromptModel {
 	return m
 }
 
-// BuildCommand validates the current field values and, if valid, returns the
-// "/song <url> | <artist> | <title> [| <genre>]" string ready to hand to the
-// composer. Genre is the only optional field, matching the server's own
-// /song syntax (see docs/00-latest-api-reference.md).
-func (m SongPromptModel) BuildCommand() (string, bool) {
+// BuildAttachment validates the current field values and, if valid, returns
+// a model.Attachment ready to send as a post/reply's native audio attachment
+// — the same shape the API's chat audioAttachment field uses (type "audio",
+// origin "youtube"). Genre is the only optional field, matching the server's
+// own /song syntax (see docs/00-latest-api-reference.md). Shared validation
+// for both this and BuildCommand.
+func (m SongPromptModel) BuildAttachment() (model.Attachment, bool) {
 	url := m.URLValue()
 	artist := m.ArtistValue()
 	title := m.TitleValue()
 	if _, ok := youtube.ExtractVideoID(url); !ok {
-		return "", false
+		return model.Attachment{}, false
 	}
 	if artist == "" || title == "" {
+		return model.Attachment{}, false
+	}
+	return model.Attachment{Type: "audio", Src: url, Origin: "youtube", Artist: artist, Title: title, Genre: m.GenreValue()}, true
+}
+
+// BuildCommand validates the current field values and, if valid, returns the
+// "/song <url> | <artist> | <title> [| <genre>]" string ready to hand to the
+// chat composer.
+func (m SongPromptModel) BuildCommand() (string, bool) {
+	att, ok := m.BuildAttachment()
+	if !ok {
 		return "", false
 	}
-	cmd := "/song " + url + " | " + artist + " | " + title
-	if genre := m.GenreValue(); genre != "" {
-		cmd += " | " + genre
+	cmd := "/song " + att.Src + " | " + att.Artist + " | " + att.Title
+	if att.Genre != "" {
+		cmd += " | " + att.Genre
 	}
 	return cmd, true
 }

--- a/internal/ui/screens/songprompt_test.go
+++ b/internal/ui/screens/songprompt_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/ragnar/cyber-tui/internal/model"
 )
 
 func typeInto(m SongPromptModel, s string) SongPromptModel {
@@ -116,6 +117,50 @@ func TestSongPromptModel_BuildCommand(t *testing.T) {
 				t.Errorf("BuildCommand() = %q, want %q", cmd, tt.wantCmd)
 			}
 		})
+	}
+}
+
+// TestSongPromptModel_BuildAttachment_ShapeMatchesLiveAPIConfirmation guards
+// the model.Attachment shape BuildAttachment builds for posts/replies against
+// what was live-confirmed 2026-08-27 (docs/00-api-backlog.md): a "audio"-type
+// attachment needs exactly {src, origin: "youtube", artist, title, genre} —
+// no width/height required or sent, unlike an image attachment.
+func TestSongPromptModel_BuildAttachment_ShapeMatchesLiveAPIConfirmation(t *testing.T) {
+	m, _ := NewSongPromptModel().Open()
+	m = typeInto(m, "https://youtu.be/dQw4w9WgXcQ")
+	m, _ = m.NextField()
+	m = typeInto(m, "Rick Astley")
+	m, _ = m.NextField()
+	m = typeInto(m, "Never Gonna Give You Up")
+	m, _ = m.NextField()
+	m = typeInto(m, "pop")
+
+	att, ok := m.BuildAttachment()
+	if !ok {
+		t.Fatal("BuildAttachment() ok = false, want true")
+	}
+	want := model.Attachment{
+		Type: "audio", Src: "https://youtu.be/dQw4w9WgXcQ", Origin: "youtube",
+		Artist: "Rick Astley", Title: "Never Gonna Give You Up", Genre: "pop",
+	}
+	if att != want {
+		t.Errorf("BuildAttachment() = %+v, want %+v", att, want)
+	}
+}
+
+// TestSongPromptModel_BuildAttachment_InvalidFieldsFail mirrors
+// TestSongPromptModel_BuildCommand's failure cases for the shared
+// validation BuildAttachment now performs.
+func TestSongPromptModel_BuildAttachment_InvalidFieldsFail(t *testing.T) {
+	m, _ := NewSongPromptModel().Open()
+	m = typeInto(m, "https://vimeo.com/12345")
+	m, _ = m.NextField()
+	m = typeInto(m, "Artist")
+	m, _ = m.NextField()
+	m = typeInto(m, "Title")
+
+	if _, ok := m.BuildAttachment(); ok {
+		t.Error("BuildAttachment() ok = true for a non-YouTube URL, want false")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Live-tested via `apifetch` that `POST`/`PATCH /v1/replies` accepts an `attachments` array identically to posts, despite `docs.md` never mentioning it for replies. `CreateReply` gains an `attachment` param; `ctrl+g` on the reply compose box now sets a real attachment instead of warning it's unsupported.
- The `ctrl+j` song-attach modal (previously cIRC-only) now also opens from Feed's new-post panel and Post Detail's edit/reply panels, building a native audio attachment (`type: "audio"`, no width/height required — confirmed live) instead of a `/song ...` command string when targeting a post or reply.
- `PostComposePanel` and `PostDetailModel` each gain a pending-audio slot alongside the existing image/gif one, mutually exclusive with it since `CreatePost`/`CreateReply` accept at most one native attachment.
- **⚠ Experimental, at the user's explicit request:** `resolveAttachment` no longer fetches the real image to report honest dimensions — it always declares `640x640` (`maxAttachmentDim`), to test whether the site's declared-dimension check is meaningfully enforced beyond the create request itself (confirmed live it never verifies declared width/height against the real file). Flagged in `resolveAttachment`'s doc comment (with exact revert instructions) and in `docs/50-post-reply-attachments.md`.
- Also confirmed live and logged in `docs/00-api-backlog.md`: `hasImageAttachment`/`hasAudioAttachment` are computed for posts but never for replies — likely why an image attached to a reply didn't render on the website despite being stored correctly. A reply permalink observed with an `undefined` username segment looks like a website-side bug, unrelated to the API or this client.

## Docs

- New: `docs/50-post-reply-attachments.md`
- Updated: `docs/00-api-backlog.md`, `docs/00-project-reference.md`

## Test plan

- `go test ./...`, `go vet ./...`, `staticcheck ./...` all clean.
- Unit tests added across `internal/api`, `internal/ui`, `internal/ui/screens` for the new attachment plumbing and the mutual-exclusivity/clear-on-cancel behavior.
