### PR TITLE
feat: blocked topics

### DIFF
--- a/docs/00-api-backlog.md
+++ b/docs/00-api-backlog.md
@@ -327,7 +327,7 @@ Notes:
 | --------------- | ------------------------------------- | -------------------------------------------------------------------- |
 | Notes (Journal) | List, create, edit, delete, revision history | — |
 | Profile         | View and edit all fields              | —                                                                    |
-| Settings        | All TUI-relevant fields editable; `mutedUsersByRoom` read and enforced (feature 37) | `keyboardBindings`, `keyboardPreset` — web UI concepts with no TUI equivalent; intentionally omitted |
+| Settings        | All TUI-relevant fields editable; `mutedUsersByRoom` read and enforced (feature 37); `mutedTopics` (blocked topics) managed from the Topics tab and filtered everywhere (feature 54) | `keyboardBindings`, `keyboardPreset` — web UI concepts with no TUI equivalent; intentionally omitted; `followedTopics`, `iconTheme`, `imagePixelSize` still deferred |
 | Follows         | Follow, unfollow, list following and followers | — |
 | Notifications   | All v0.4 types received and displayed with dedicated text and icons; unread-only toggle (`u`); category filter panel (`f`) | — |
 

--- a/docs/00-project-reference.md
+++ b/docs/00-project-reference.md
@@ -564,9 +564,10 @@ Browse all topics (tags) and drill into posts for a selected topic.
 - Two-mode screen: topic list → topic feed
 - Topic list sorted by post count, cursor-paginated; `enter` opens the topic feed
 - Topic feed is a standard paginated post list; `esc` returns to the topic list
+- `b` (topic list only) blocks/unblocks the highlighted topic — emits `SetBlockedTopicsMsg`, App persists `Settings.MutedTopics` via a debounced `PATCH /v1/settings`; blocked rows show a `blocked` marker. See `docs/54-blocked-topics.md`
 - Same inline-image support as `guilds.go`'s thread feed — see that section
 
-Key types: `TopicsModel`, `LoadMoreTopicsMsg`, `LoadTopicPostsMsg`, `LoadMoreTopicPostsMsg`  
+Key types: `TopicsModel`, `LoadMoreTopicsMsg`, `LoadTopicPostsMsg`, `LoadMoreTopicPostsMsg`, `SetBlockedTopicsMsg`  
 Key methods: `SetTopics(topics, cursor)`, `AppendTopics(topics, cursor)`, `SetTopicPosts(posts, cursor)`, `AppendTopicPosts(posts, cursor)`
 
 #### `journal.go`

--- a/docs/17-settings.md
+++ b/docs/17-settings.md
@@ -21,7 +21,7 @@ This feature aligns the codebase with API v0.3.2, which supports 13 preference f
 | `IconTheme` | string | Icon set (not yet modelled) | Device-roaming |
 | `TimeDisplayFormat` | string | Time display: `"datetime"`, `"relative"`, `"unix"`, `"swatch"` | Device-roaming |
 | `FollowedTopics` | []string | Topics subscribed to | Device-roaming |
-| `MutedTopics` | []string | Topics to hide | Device-roaming |
+| `MutedTopics` | []string | Blocked topics — posts tagged with any are hidden. Managed from the Topics tab (`b`), not this screen. See `docs/54-blocked-topics.md`. | Device-roaming |
 | `ImagePixelSize` | string | Pixel multiplier or preset (e.g., "sharp", "2") | Device-roaming |
 | `DefaultPublicPost` | bool | Posts default to public | Device-roaming |
 
@@ -162,8 +162,10 @@ Changes are accumulated in memory until `ctrl+s` is pressed. This respects the A
 The following settings require complex pickers and are deferred to a future feature branch:
 - `IconTheme` — icon set selection
 - `FollowedTopics` — topic subscription management
-- `MutedTopics` — topic muting
 - `ImagePixelSize` — image scaling or presets
+
+`MutedTopics` (blocked topics) shipped in Feature 54 — managed from the Topics
+tab, not this screen; included in `PATCH /v1/settings`. See `docs/54-blocked-topics.md`.
 
 ---
 

--- a/docs/19-topics.md
+++ b/docs/19-topics.md
@@ -60,6 +60,7 @@ Rate limits: GET /v1/topics 20/min · GET posts 30/min.
 | `j` / `↓` | Move cursor down |
 | `k` / `↑` | Move up; at top → refresh topic list |
 | `enter` | Open topic → switch to post list view |
+| `b` | Block / unblock the highlighted topic (hides its posts everywhere; see `docs/54-blocked-topics.md`) |
 
 ### Topic posts view
 

--- a/docs/54-blocked-topics.md
+++ b/docs/54-blocked-topics.md
@@ -1,0 +1,102 @@
+# 54 — Blocked Topics
+
+## Overview
+
+Users can block topics they don't want to see. A post tagged with any blocked
+topic is hidden from every post list, the same way `FilterNSFW` hides NSFW
+posts. Blocking is managed from the **Topics** tab: press `b` on a topic row to
+block or unblock it.
+
+Blocked topics are stored server-side in the settings object's `mutedTopics`
+array (the cyberspace.online website labels this "blocked topics"). The field
+was already decoded into `model.Settings.MutedTopics` and broadcast to every
+screen; this feature wires it into filtering, into a management UI, and into
+`PATCH /v1/settings`.
+
+> Naming: the UI says **"blocked"**; Go identifiers keep the existing
+> `MutedTopics` name. Unrelated to the cIRC per-room user **mute** feature
+> (`docs/37-circ-mute.md`).
+
+---
+
+## Managing the list
+
+Topics tab, topic-list view only (there is no single "current topic" to act on
+while browsing a topic's posts):
+
+| Key | Action |
+|-----|--------|
+| `b` | Block the highlighted topic, or unblock it if already blocked |
+
+A blocked row shows `BLOCKED` (in the error colour) in place of its post count.
+
+Pressing `b` updates the marker immediately (optimistic) and emits
+`SetBlockedTopicsMsg{Topics []string}` carrying the full new list. `App`:
+
+1. sets `a.settings.MutedTopics` and calls `broadcastConfig()` so every post
+   list re-filters at once;
+2. bumps `a.blockedTopicsSaveSeq` and schedules a `blockedTopicsFlushMsg` tick
+   (`blockedTopicsSaveDebounce`, 2 s).
+
+Only the tick whose `seq` still matches persists, via `client.UpdateSettings`,
+producing a `blockedTopicsSaveResultMsg`. A burst of toggles therefore
+coalesces into a single `PATCH /v1/settings` (rate-limited 2/min, 15/day).
+
+**On save failure the optimistic change is rolled back.** `App` keeps
+`blockedTopicsSaved` — the `MutedTopics` list the server last accepted (set at
+login and after each successful save). A failed `blockedTopicsSaveResultMsg`
+restores `a.settings.MutedTopics` from it, bumps the save seq (cancelling any
+still-pending tick), re-broadcasts so every screen and the marker revert, and
+shows a `notifyError` banner. `blockedTopicsSaveFailText(err)` names the cause:
+the 2/min–15/day rate limit, an expired session, or a 5xx — falling back to
+`friendlyErr(err)`, always suffixed "— reverted".
+
+---
+
+## Filtering
+
+Each post-list screen keeps a `blockedTopics map[string]struct{}`, refreshed
+from `SharedConfigMsg.Settings.MutedTopics` in its existing `SharedConfigMsg`
+handler (right where it already mirrors `FilterNSFW`), resetting the selection
+index when the set changes. Its `visible*()` helper drops any post where
+`topicBlocked(p.Topics, m.blockedTopics)` is true.
+
+| Screen | Helper | Filtered |
+|--------|--------|----------|
+| Feed (`feed.go`) | `visiblePosts()` | yes |
+| Topics (`topics.go`) | `visiblePosts()` | yes (a topic's own post list too) |
+| Guilds (`guilds.go`) | `visiblePosts()` | yes |
+| Profile (`profile.go`) | `visibleProfilePosts()` | yes (Posts sub-tab) |
+| Bookmarks (`bookmarks.go`) | `visibleItems()` | yes (bookmarked posts; replies carry no topics) |
+| Post detail (`postdetail.go`) | — | **no** — an explicit open / deep link is honoured |
+| Search (`search.go`) | — | **no** — consistent with `FilterNSFW`, which Search also doesn't apply |
+
+Shared helpers live in `internal/ui/screens/shared.go`: `topicBlocked`,
+`blockedSet`, `sameBlockedSet`, `toggleBlocked`.
+
+Card render caches are unaffected — they already key on the joined topic list,
+and filtering happens before rendering.
+
+---
+
+## API
+
+`GET /v1/settings` → `mutedTopics` (already parsed). `PATCH /v1/settings` now
+includes `mutedTopics` (`wirePatchSettings`, `HTTPClient.UpdateSettings`) — sent
+as a full array, never `null`, so unblocking the last topic clears it
+server-side. The Settings screen doesn't edit the field but re-syncs it from
+every `SharedConfigMsg` so a `ctrl+s` there can't PATCH a stale list back.
+
+---
+
+## Tests
+
+| File | Tests |
+|------|-------|
+| `internal/ui/screens/feed_test.go` | `TestFeed_BlockedTopics_HidesMatchingPost`, `_Off_ShowsAll` |
+| `internal/ui/screens/topics_test.go` | `TestTopics_BlockedTopics_HidesMatchingPost`, `TestTopics_BlockKey_TogglesBlockedList` |
+| `internal/ui/screens/guilds_test.go` | `TestGuildsModel_BlockedTopics_HidesMatchingPost` |
+| `internal/ui/screens/profile_test.go` | `TestProfile_BlockedTopics_HidesMatchingPost` |
+| `internal/ui/screens/bookmarks_test.go` | `TestBookmarks_BlockedTopics_HidesMatchingPost` |
+| `internal/api/client_test.go` | `TestHTTPUpdateSettings_SendsMutedTopics` (incl. clearing to `[]`) |
+| `internal/ui/app_test.go` | `TestHandleTopics_SetBlockedTopics_AppliesAndDebouncesSave`, `…_RollsBackOnSaveFailure` |

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -468,8 +468,11 @@ type wireSettings struct {
 
 // wirePatchSettings is the PATCH /v1/settings payload — only the fields the
 // UI manages. Deferred fields (iconTheme, imagePixelSize, followedTopics,
-// mutedTopics, mutedUsersByRoom) are intentionally excluded so the API never
-// receives them — mutedUsersByRoom is server-managed via /mute commands, not PATCH.
+// mutedUsersByRoom) are intentionally excluded so the API never receives
+// them — mutedUsersByRoom is server-managed via /mute commands, not PATCH.
+// mutedTopics IS sent: the Topics tab's block/unblock (docs/54-blocked-topics.md)
+// is the only writer, and it always sends the full current list (no omitempty,
+// so unblocking the last topic reaches the server as []).
 type wirePatchSettings struct {
 	Notifications        wireNotificationPrefs `json:"notifications"`
 	FilterNSFW           bool                  `json:"filterNSFW"`
@@ -478,6 +481,7 @@ type wirePatchSettings struct {
 	ShowGuildPostsInFeed bool                  `json:"showGuildPostsInFeed"`
 	TimeDisplayFormat    string                `json:"timeDisplayFormat"`
 	DefaultPublicPost    bool                  `json:"defaultPublicPost"`
+	MutedTopics          []string              `json:"mutedTopics"`
 }
 
 // --- CIRC wire types ---
@@ -1540,6 +1544,12 @@ func (c *HTTPClient) GetSettings() (model.Settings, error) {
 }
 
 func (c *HTTPClient) UpdateSettings(update model.Settings) error {
+	// Always send an array, never JSON null, so unblocking the last topic
+	// actually clears the list server-side.
+	mutedTopics := update.MutedTopics
+	if mutedTopics == nil {
+		mutedTopics = []string{}
+	}
 	_, err := c.doJSON("PATCH", "/v1/settings", wirePatchSettings{
 		Notifications: wireNotificationPrefs{
 			Bookmark: update.Notifications.Bookmark,
@@ -1552,6 +1562,7 @@ func (c *HTTPClient) UpdateSettings(update model.Settings) error {
 		ShowGuildPostsInFeed: update.ShowGuildPostsInFeed,
 		TimeDisplayFormat:    update.TimeDisplayFormat,
 		DefaultPublicPost:    update.DefaultPublicPost,
+		MutedTopics:          mutedTopics,
 	})
 	return err
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -3008,6 +3008,52 @@ func TestHTTPSettings_ShowGuildPostsInFeed_RoundTrips(t *testing.T) {
 	}
 }
 
+func TestHTTPUpdateSettings_SendsMutedTopics(t *testing.T) {
+	var gotBody map[string]any
+	c := newClient(t, loginHandler(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/settings" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method == "PATCH" {
+			json.NewDecoder(r.Body).Decode(&gotBody)
+			writeOK(t, w, map[string]any{})
+			return
+		}
+		writeOK(t, w, map[string]any{"mutedTopics": []string{"crypto"}})
+	})))
+	c.Login("u@example.com", "pass")
+
+	settings, err := c.GetSettings()
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	if len(settings.MutedTopics) != 1 || settings.MutedTopics[0] != "crypto" {
+		t.Fatalf("MutedTopics parsed as %v, want [crypto]", settings.MutedTopics)
+	}
+
+	settings.MutedTopics = []string{"crypto", "sports"}
+	if err := c.UpdateSettings(settings); err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+	got, _ := gotBody["mutedTopics"].([]any)
+	if len(got) != 2 || got[0] != "crypto" || got[1] != "sports" {
+		t.Errorf("PATCH body mutedTopics = %v, want [crypto sports]", gotBody["mutedTopics"])
+	}
+
+	// Unblocking the last topic must still reach the server as [] (no omitempty).
+	settings.MutedTopics = nil
+	if err := c.UpdateSettings(settings); err != nil {
+		t.Fatalf("UpdateSettings (clear): %v", err)
+	}
+	if _, present := gotBody["mutedTopics"]; !present {
+		t.Errorf("PATCH body omitted mutedTopics when clearing; want an empty array")
+	}
+	if got, _ := gotBody["mutedTopics"].([]any); len(got) != 0 {
+		t.Errorf("PATCH body mutedTopics = %v, want []", gotBody["mutedTopics"])
+	}
+}
+
 // --- Notes ---
 
 func TestHTTPGetNotes_ParsesList(t *testing.T) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -599,6 +599,17 @@ type App struct {
 	// its own stale snapshot.
 	settingsSaveSeq int
 
+	// blockedTopicsSaveSeq is bumped on every SetBlockedTopicsMsg. Only the
+	// matching blockedTopicsFlushMsg tick persists; earlier ticks are dropped,
+	// so a burst of block/unblock presses coalesces into a single
+	// PATCH /v1/settings (rate-limited 2/min) — see docs/54-blocked-topics.md.
+	blockedTopicsSaveSeq int
+
+	// blockedTopicsSaved is the MutedTopics list the server last accepted (set
+	// on login and after each successful save). A failed save rolls the
+	// optimistic in-memory list back to this.
+	blockedTopicsSaved []string
+
 	// sessionGen is bumped in handleUnauthorized on session expiry, so the
 	// self-rescheduling poll/wander/logo-idle tea.Tick chains started by
 	// afterLoginCmd (each stamped with the gen they were scheduled under)
@@ -1722,6 +1733,7 @@ func (a App) handleSettings(msg tea.Msg) (App, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case settingsLoadedMsg:
 		a.settings = msg.settings
+		a.blockedTopicsSaved = msg.settings.MutedTopics // rollback baseline for Topics-tab block/unblock
 		a.settingsScreen = a.settingsScreen.SetSettings(msg.settings)
 		a.broadcastConfig()
 		return a, nil, true
@@ -2466,6 +2478,49 @@ func (a App) handleTopics(msg tea.Msg) (App, tea.Cmd, bool) {
 	case screens.RefreshTopicsMsg:
 		return a, a.loadTopicsCmd(), true
 
+	case screens.SetBlockedTopicsMsg:
+		// Block / unblock a topic from the Topics tab. Apply + broadcast now so
+		// every post list re-filters immediately (optimistic); persist on a
+		// debounce tick so a rapid series of toggles becomes one PATCH. If that
+		// PATCH fails, blockedTopicsSaveResultMsg rolls the list back to
+		// blockedTopicsSaved (the last version the server accepted).
+		a.settings.MutedTopics = msg.Topics
+		// broadcastConfig re-seeds the settings screen's MutedTopics baseline too
+		// (see its SharedConfigMsg handler), so a later ctrl+s there can't PATCH
+		// a stale list back.
+		a.broadcastConfig()
+		a.blockedTopicsSaveSeq++
+		seq := a.blockedTopicsSaveSeq
+		return a, tea.Tick(blockedTopicsSaveDebounce, func(time.Time) tea.Msg {
+			return blockedTopicsFlushMsg{seq: seq}
+		}), true
+
+	case blockedTopicsFlushMsg:
+		if msg.seq != a.blockedTopicsSaveSeq {
+			return a, nil, true // superseded by a newer toggle
+		}
+		s := a.settings
+		attempted := append([]string(nil), s.MutedTopics...)
+		return a, func() tea.Msg {
+			if err := a.client.UpdateSettings(s); err != nil {
+				return blockedTopicsSaveResultMsg{err: err}
+			}
+			return blockedTopicsSaveResultMsg{topics: attempted}
+		}, true
+
+	case blockedTopicsSaveResultMsg:
+		if msg.err != nil {
+			// Roll back to the last list the server accepted and cancel any
+			// still-pending debounce tick so it can't re-PATCH the reverted state.
+			a.settings.MutedTopics = append([]string(nil), a.blockedTopicsSaved...)
+			a.blockedTopicsSaveSeq++
+			a.broadcastConfig()
+			a, cmd := a.notify(notifyError, blockedTopicsSaveFailText(msg.err))
+			return a, cmd, true
+		}
+		a.blockedTopicsSaved = msg.topics
+		return a, nil, true
+
 	case topicsLoadedMsg:
 		a.topics = a.topics.SetTopics(msg.topics, msg.cursor)
 		return a, nil, true
@@ -2802,6 +2857,22 @@ func friendlyErr(err error) string {
 		}
 	}
 	return err.Error()
+}
+
+// blockedTopicsSaveFailText explains why a block/unblock couldn't be saved, so
+// the revert banner names a cause instead of just "can't block".
+func blockedTopicsSaveFailText(err error) string {
+	reason := friendlyErr(err)
+	var apiErr *api.APIError
+	switch {
+	case errors.Is(err, api.ErrRateLimited):
+		reason = "too many settings changes just now (limit 2/min, 15/day) — wait a bit and try again"
+	case errors.Is(err, api.ErrUnauthorized):
+		reason = "your session expired — sign in again"
+	case errors.As(err, &apiErr) && apiErr.Status >= 500:
+		reason = "the server had a problem (" + strconv.Itoa(apiErr.Status) + ") — try again shortly"
+	}
+	return "couldn't save blocked topics: " + reason + " — reverted"
 }
 
 // composeFailText is friendlyErr plus a rate-limit case: a 429 on CreatePost
@@ -4817,6 +4888,23 @@ type topicPostsPageMsg struct {
 	posts  []model.Post
 	cursor string
 }
+
+// blockedTopicsFlushMsg is the debounce tick that persists a block/unblock made
+// from the Topics tab. Only the tick whose seq still matches
+// blockedTopicsSaveSeq calls UpdateSettings — see docs/54-blocked-topics.md.
+type blockedTopicsFlushMsg struct{ seq int }
+
+// blockedTopicsSaveResultMsg reports the outcome of that PATCH. On success
+// (err == nil) topics is the list now stored server-side; on failure the
+// optimistic in-memory list is rolled back to blockedTopicsSaved.
+type blockedTopicsSaveResultMsg struct {
+	topics []string
+	err    error
+}
+
+// blockedTopicsSaveDebounce coalesces a burst of block/unblock presses into one
+// PATCH /v1/settings (rate-limited 2/min, 15/day).
+const blockedTopicsSaveDebounce = 2 * time.Second
 
 type searchPreviewLoadedMsg struct {
 	preview model.SearchPreview

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2009,6 +2009,106 @@ func TestHandleSettings_ManualToAutoRestartsFeedPoll(t *testing.T) {
 	}
 }
 
+// TestHandleTopics_SetBlockedTopics_AppliesAndDebouncesSave verifies the
+// Topics-tab block/unblock path: SetBlockedTopicsMsg applies to a.settings
+// immediately (and bumps the save seq), a stale blockedTopicsFlushMsg is a
+// no-op, and the current one persists via UpdateSettings. See
+// docs/54-blocked-topics.md.
+func TestHandleTopics_SetBlockedTopics_AppliesAndDebouncesSave(t *testing.T) {
+	a := loggedInApp()
+
+	a, cmd, ok := a.handleTopics(screens.SetBlockedTopicsMsg{Topics: []string{"crypto"}})
+	if !ok {
+		t.Fatal("expected handleTopics to handle SetBlockedTopicsMsg")
+	}
+	if len(a.settings.MutedTopics) != 1 || a.settings.MutedTopics[0] != "crypto" {
+		t.Fatalf("a.settings.MutedTopics = %v, want [crypto]", a.settings.MutedTopics)
+	}
+	if a.blockedTopicsSaveSeq != 1 {
+		t.Fatalf("blockedTopicsSaveSeq = %d, want 1", a.blockedTopicsSaveSeq)
+	}
+	if cmd == nil {
+		t.Fatal("expected a debounce tick cmd")
+	}
+
+	// A superseded tick does nothing.
+	if _, c, ok := a.handleTopics(blockedTopicsFlushMsg{seq: 99}); !ok || c != nil {
+		t.Fatalf("stale blockedTopicsFlushMsg: ok=%v cmd=%v, want ok=true cmd=nil", ok, c)
+	}
+
+	// The current tick persists and reports success.
+	_, c, ok := a.handleTopics(blockedTopicsFlushMsg{seq: a.blockedTopicsSaveSeq})
+	if !ok || c == nil {
+		t.Fatalf("current blockedTopicsFlushMsg: ok=%v cmd=%v, want ok=true cmd!=nil", ok, c)
+	}
+	res, ok := c().(blockedTopicsSaveResultMsg)
+	if !ok || res.err != nil {
+		t.Fatalf("expected a successful blockedTopicsSaveResultMsg, got %#v", c())
+	}
+	a, _, _ = a.handleTopics(res)
+	if len(a.blockedTopicsSaved) != 1 || a.blockedTopicsSaved[0] != "crypto" {
+		t.Errorf("blockedTopicsSaved = %v, want [crypto]", a.blockedTopicsSaved)
+	}
+	got, err := a.client.GetSettings()
+	if err != nil {
+		t.Fatalf("GetSettings: %v", err)
+	}
+	if len(got.MutedTopics) != 1 || got.MutedTopics[0] != "crypto" {
+		t.Errorf("persisted MutedTopics = %v, want [crypto]", got.MutedTopics)
+	}
+}
+
+// updateSettingsFailClient makes every UpdateSettings call fail with a 429, to
+// exercise the blocked-topics rollback path and its cause-specific banner.
+type updateSettingsFailClient struct {
+	*api.MockClient
+}
+
+func (c updateSettingsFailClient) UpdateSettings(model.Settings) error {
+	return api.ErrRateLimited
+}
+
+// A failed save rolls the optimistic MutedTopics list back to the last version
+// the server accepted (blockedTopicsSaved) and shows an error banner.
+func TestHandleTopics_SetBlockedTopics_RollsBackOnSaveFailure(t *testing.T) {
+	a := NewApp(updateSettingsFailClient{api.NewMockClient()})
+	a.active = screenFeed
+	a.focus = focusMenu
+	// Login baseline: "news" is already blocked and persisted.
+	a, _, _ = a.handleSettings(settingsLoadedMsg{settings: model.Settings{MutedTopics: []string{"news"}}})
+
+	// User blocks "crypto" too — optimistic.
+	a, _, _ = a.handleTopics(screens.SetBlockedTopicsMsg{Topics: []string{"news", "crypto"}})
+	if len(a.settings.MutedTopics) != 2 {
+		t.Fatalf("optimistic MutedTopics = %v, want [news crypto]", a.settings.MutedTopics)
+	}
+
+	// The debounced save fires and fails.
+	_, c, _ := a.handleTopics(blockedTopicsFlushMsg{seq: a.blockedTopicsSaveSeq})
+	res, ok := c().(blockedTopicsSaveResultMsg)
+	if !ok || res.err == nil {
+		t.Fatalf("expected a failed blockedTopicsSaveResultMsg, got %#v", c())
+	}
+
+	seqBefore := a.blockedTopicsSaveSeq
+	a, cmd, ok := a.handleTopics(res)
+	if !ok {
+		t.Fatal("expected handleTopics to handle the failed result")
+	}
+	if len(a.settings.MutedTopics) != 1 || a.settings.MutedTopics[0] != "news" {
+		t.Errorf("after rollback MutedTopics = %v, want [news]", a.settings.MutedTopics)
+	}
+	if a.blockedTopicsSaveSeq == seqBefore {
+		t.Error("expected blockedTopicsSaveSeq to be bumped so a pending tick is cancelled")
+	}
+	if !strings.Contains(a.notifyText, "2/min") {
+		t.Errorf("banner %q should explain the rate-limit cause", a.notifyText)
+	}
+	if cmd == nil {
+		t.Error("expected the banner's expire cmd")
+	}
+}
+
 // subscribeCancelSpyClient wraps MockClient's SubscribeDMs/SubscribeRoom
 // cancel funcs to record whether they were actually invoked — used below to
 // verify handleUnauthorized tears down a live per-conversation/per-room

--- a/internal/ui/layout_tabs.go
+++ b/internal/ui/layout_tabs.go
@@ -407,7 +407,7 @@ func (l TabsLayout) screenHints(a App) []hint {
 		if a.topics.IsBrowsingTopic() {
 			return []hint{{"↑↓", "navigate"}, {"enter", "open"}, {"esc", "back"}, more}
 		}
-		return []hint{{"↑↓", "navigate"}, {"enter", "browse"}, {"esc", "back"}, more}
+		return []hint{{"↑↓", "navigate"}, {"enter", "browse"}, {"b", "block"}, {"esc", "back"}, more}
 	case screenSearch:
 		if a.search.InputFocused() {
 			return []hint{{"enter", "search"}}

--- a/internal/ui/screens/bookmarks.go
+++ b/internal/ui/screens/bookmarks.go
@@ -55,21 +55,26 @@ type BookmarksModel struct {
 	loc           *time.Location
 	relaxed       bool
 	filterNSFW    bool
+	blockedTopics map[string]struct{} // Settings.MutedTopics; bookmarked posts tagged with any are hidden
 }
 
 func NewBookmarksModel() BookmarksModel {
 	return BookmarksModel{}
 }
 
-// visibleItems returns the bookmarks shown given the FilterNSFW setting. Only
-// posts carry an NSFW flag; bookmarked replies have none and are always shown.
+// visibleItems returns the bookmarks shown given the FilterNSFW and blocked-topics
+// settings. Only bookmarked posts carry an NSFW flag and topics; bookmarked
+// replies have neither and are always shown.
 func (m BookmarksModel) visibleItems() []model.Bookmark {
-	if !m.filterNSFW {
+	if !m.filterNSFW && len(m.blockedTopics) == 0 {
 		return m.items
 	}
 	out := m.items[:0:0]
 	for _, b := range m.items {
-		if b.Post != nil && b.Post.IsNSFW {
+		if b.Post != nil && m.filterNSFW && b.Post.IsNSFW {
+			continue
+		}
+		if b.Post != nil && topicBlocked(b.Post.Topics, m.blockedTopics) {
 			continue
 		}
 		out = append(out, b)
@@ -156,6 +161,10 @@ func (m BookmarksModel) Update(msg tea.Msg) (BookmarksModel, tea.Cmd) {
 		}
 		if msg.Settings.FilterNSFW != m.filterNSFW {
 			m.filterNSFW = msg.Settings.FilterNSFW
+			m.selectedIndex = 0
+		}
+		if !sameBlockedSet(m.blockedTopics, msg.Settings.MutedTopics) {
+			m.blockedTopics = blockedSet(msg.Settings.MutedTopics)
 			m.selectedIndex = 0
 		}
 		if m.ready {

--- a/internal/ui/screens/bookmarks_test.go
+++ b/internal/ui/screens/bookmarks_test.go
@@ -36,6 +36,27 @@ func TestBookmarks_FilterNSFW_HidesNSFWPostKeepsReply(t *testing.T) {
 	}
 }
 
+// A blocked topic hides matching bookmarked posts; replies (no topics) stay.
+func TestBookmarks_BlockedTopics_HidesMatchingPost(t *testing.T) {
+	m := screens.NewBookmarksModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m.SetBookmarks([]model.Bookmark{
+		{ID: "b1", Type: "post", PostID: "p1", Post: &model.Post{ID: "p1", Content: "keep https://example.com/a", Topics: []string{"linux"}}},
+		{ID: "b2", Type: "post", PostID: "p2", Post: &model.Post{ID: "p2", Content: "drop https://example.com/x", Topics: []string{"crypto"}}},
+		{ID: "b3", Type: "reply", ReplyID: "r1", Reply: &model.Reply{ID: "r1", Content: "reply https://example.com/b"}},
+	}, "")
+	m, _ = m.Update(blockedTopicsMsg("crypto"))
+
+	// Visible list is [b1(post), b3(reply)]; the crypto post b2 is hidden.
+	if got := m.GetFocusedURLs(); len(got) != 1 || got[0] != "https://example.com/a" {
+		t.Fatalf("focused URLs at top = %v, want [https://example.com/a]", got)
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if got := m.GetFocusedURLs(); len(got) != 1 || got[0] != "https://example.com/b" {
+		t.Fatalf("focused URLs after down = %v, want [https://example.com/b]", got)
+	}
+}
+
 func TestBookmarks_FilterNSFW_Off_ShowsNSFW(t *testing.T) {
 	m := screens.NewBookmarksModel()
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})

--- a/internal/ui/screens/feed.go
+++ b/internal/ui/screens/feed.go
@@ -139,6 +139,7 @@ type FeedModel struct {
 	bookmarkedPostIDs map[string]struct{}
 	watchedPostIDs    map[string]struct{}
 	filterNSFW        bool
+	blockedTopics     map[string]struct{} // Settings.MutedTopics; posts tagged with any are hidden
 
 	// bodyCache memoizes renderPostBody per post ID, keyed additionally by
 	// whatever else affects its output — see renderPost. Selection state
@@ -405,14 +406,18 @@ func (m FeedModel) RemovePost(postID string) FeedModel {
 }
 
 func (m FeedModel) visiblePosts() []model.Post {
-	if !m.filterNSFW {
+	if !m.filterNSFW && len(m.blockedTopics) == 0 {
 		return m.posts
 	}
 	out := m.posts[:0:0]
 	for _, p := range m.posts {
-		if !p.IsNSFW {
-			out = append(out, p)
+		if m.filterNSFW && p.IsNSFW {
+			continue
 		}
+		if topicBlocked(p.Topics, m.blockedTopics) {
+			continue
+		}
+		out = append(out, p)
 	}
 	return out
 }
@@ -528,7 +533,11 @@ func (m FeedModel) Update(msg tea.Msg) (FeedModel, tea.Cmd) {
 		m.inlineImagesEnabled = msg.InlineImagesEnabled
 		m = m.SetRelaxed(msg.Relaxed)
 		m = m.SetLocation(msg.Loc)
-		if msg.Settings.FilterNSFW != m.filterNSFW {
+		blockedChanged := !sameBlockedSet(m.blockedTopics, msg.Settings.MutedTopics)
+		if blockedChanged {
+			m.blockedTopics = blockedSet(msg.Settings.MutedTopics)
+		}
+		if msg.Settings.FilterNSFW != m.filterNSFW || blockedChanged {
 			m.filterNSFW = msg.Settings.FilterNSFW
 			m.selectedIndex = 0
 			if m.ready {

--- a/internal/ui/screens/feed_test.go
+++ b/internal/ui/screens/feed_test.go
@@ -77,6 +77,61 @@ func TestFeed_FilterNSFW_RefreshKeepsVisibleSelection(t *testing.T) {
 	}
 }
 
+// --- Blocked topics ---
+
+func blockedTopicsMsg(topics ...string) screens.SharedConfigMsg {
+	return screens.SharedConfigMsg{
+		Settings: model.Settings{MutedTopics: topics},
+	}
+}
+
+func TestFeed_BlockedTopics_HidesMatchingPost(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "keep", Topics: []string{"linux"}},
+		{ID: "p2", AuthorUsername: "bob", Content: "drop", Topics: []string{"crypto", "news"}},
+		{ID: "p3", AuthorUsername: "carol", Content: "keep too"},
+	}, "")
+	m, _ = m.Update(blockedTopicsMsg("crypto"))
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected a cmd on enter")
+	}
+	sp, ok := cmd().(screens.ShowPostMsg)
+	if !ok {
+		t.Fatalf("expected ShowPostMsg, got %T", cmd())
+	}
+	if sp.Post.ID != "p3" {
+		t.Errorf("expected p3 (crypto post filtered out), got %s", sp.Post.ID)
+	}
+}
+
+func TestFeed_BlockedTopics_Off_ShowsAll(t *testing.T) {
+	m := screens.NewFeedModel()
+	m = m.SetPosts([]model.Post{
+		{ID: "p1", AuthorUsername: "alice", Content: "a", Topics: []string{"linux"}},
+		{ID: "p2", AuthorUsername: "bob", Content: "b", Topics: []string{"crypto"}},
+	}, "")
+	m, _ = m.Update(blockedTopicsMsg()) // no blocked topics
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected a cmd on enter")
+	}
+	sp, ok := cmd().(screens.ShowPostMsg)
+	if !ok {
+		t.Fatalf("expected ShowPostMsg, got %T", cmd())
+	}
+	if sp.Post.ID != "p2" {
+		t.Errorf("expected p2, got %s", sp.Post.ID)
+	}
+}
+
 func TestFeed_FilterNSFW_Off_ShowsAll(t *testing.T) {
 	m := screens.NewFeedModel()
 	m = m.SetPosts([]model.Post{

--- a/internal/ui/screens/guilds.go
+++ b/internal/ui/screens/guilds.go
@@ -159,6 +159,7 @@ type GuildsModel struct {
 	relaxed           bool
 	timeDisplayFormat string
 	filterNSFW        bool
+	blockedTopics     map[string]struct{} // Settings.MutedTopics; threads tagged with any are hidden
 
 	// postImages is parallel to itemOffsets when view == viewGuildPosts —
 	// see TopicsModel's field of the same name for the convention.
@@ -184,14 +185,18 @@ func NewGuildsModel() GuildsModel {
 }
 
 func (m GuildsModel) visiblePosts() []model.Post {
-	if !m.filterNSFW {
+	if !m.filterNSFW && len(m.blockedTopics) == 0 {
 		return m.posts
 	}
 	out := m.posts[:0:0]
 	for _, p := range m.posts {
-		if !p.IsNSFW {
-			out = append(out, p)
+		if m.filterNSFW && p.IsNSFW {
+			continue
 		}
+		if topicBlocked(p.Topics, m.blockedTopics) {
+			continue
+		}
+		out = append(out, p)
 	}
 	return out
 }
@@ -505,6 +510,10 @@ func (m GuildsModel) Update(msg tea.Msg) (GuildsModel, tea.Cmd) {
 		m.timeDisplayFormat = msg.Settings.TimeDisplayFormat
 		if msg.Settings.FilterNSFW != m.filterNSFW {
 			m.filterNSFW = msg.Settings.FilterNSFW
+			m.postIndex = 0
+		}
+		if !sameBlockedSet(m.blockedTopics, msg.Settings.MutedTopics) {
+			m.blockedTopics = blockedSet(msg.Settings.MutedTopics)
 			m.postIndex = 0
 		}
 		m.ownGuildSlug = msg.OwnGuildSlug

--- a/internal/ui/screens/guilds_test.go
+++ b/internal/ui/screens/guilds_test.go
@@ -496,6 +496,35 @@ func TestGuildsModel_UpAtTop_GuildListEmitsNoCmd(t *testing.T) {
 	}
 }
 
+// --- Blocked topics ---
+
+func TestGuildsModel_BlockedTopics_HidesMatchingPost(t *testing.T) {
+	m := screens.NewGuildsModel()
+	m = m.SetGuilds(sampleGuilds(), "")
+	m, _ = m.Update(specialKey(tea.KeyEnter))
+	m = m.SetGuildPosts([]model.Post{
+		{ID: "g1", AuthorUsername: "alice", Content: "keep", Topics: []string{"linux"}},
+		{ID: "g2", AuthorUsername: "bob", Content: "drop", Topics: []string{"crypto"}},
+		{ID: "g3", AuthorUsername: "carol", Content: "keep too"},
+	}, "")
+	m, _ = m.Update(blockedTopicsMsg("crypto"))
+
+	m, _ = m.Update(keyMsg_g("j"))
+	m, _ = m.Update(keyMsg_g("j"))
+
+	_, cmd := m.Update(specialKey(tea.KeyEnter))
+	if cmd == nil {
+		t.Fatal("expected a cmd on enter")
+	}
+	sp, ok := cmd().(screens.ShowGuildPostMsg)
+	if !ok {
+		t.Fatalf("expected ShowGuildPostMsg, got %T", cmd())
+	}
+	if sp.Post.ID != "g3" {
+		t.Errorf("expected g3 (crypto post filtered), got %s", sp.Post.ID)
+	}
+}
+
 // --- FilterNSFW ---
 
 func TestGuildsModel_FilterNSFW_HidesNSFWPost(t *testing.T) {

--- a/internal/ui/screens/messages.go
+++ b/internal/ui/screens/messages.go
@@ -167,6 +167,13 @@ type SaveSettingsMsg struct {
 // so it can show transient feedback.
 type BookmarkedMsg struct{ PostID string }
 
+// SetBlockedTopicsMsg is emitted by TopicsModel when the user presses 'b' on a
+// topic row to block or unblock it. It carries the full new blocked list. App
+// updates Settings.MutedTopics, re-broadcasts SharedConfigMsg so every screen
+// re-filters, and persists via a debounced UpdateSettings — see
+// docs/54-blocked-topics.md.
+type SetBlockedTopicsMsg struct{ Topics []string }
+
 // FollowUserMsg is emitted by ProfileModel when the user presses 'f' to follow another user.
 type FollowUserMsg struct{ UserID string }
 

--- a/internal/ui/screens/profile.go
+++ b/internal/ui/screens/profile.go
@@ -103,6 +103,7 @@ type ProfileModel struct {
 	timeDisplayFormat   string
 	loc                 *time.Location
 	filterNSFW          bool
+	blockedTopics       map[string]struct{} // Settings.MutedTopics; Posts-tab entries tagged with any are hidden
 	showFollowerCount   bool
 	inlineImagesEnabled bool
 
@@ -130,14 +131,18 @@ type SaveProfileMsg struct {
 }
 
 func (m ProfileModel) visibleProfilePosts() []model.Post {
-	if !m.filterNSFW {
+	if !m.filterNSFW && len(m.blockedTopics) == 0 {
 		return m.posts
 	}
 	out := m.posts[:0:0]
 	for _, p := range m.posts {
-		if !p.IsNSFW {
-			out = append(out, p)
+		if m.filterNSFW && p.IsNSFW {
+			continue
 		}
+		if topicBlocked(p.Topics, m.blockedTopics) {
+			continue
+		}
+		out = append(out, p)
 	}
 	return out
 }
@@ -593,6 +598,12 @@ func (m ProfileModel) Update(msg tea.Msg) (ProfileModel, tea.Cmd) {
 		}
 		if msg.Settings.FilterNSFW != m.filterNSFW {
 			m.filterNSFW = msg.Settings.FilterNSFW
+			if m.activeTab == tabPosts {
+				m.tabSelected = 0
+			}
+		}
+		if !sameBlockedSet(m.blockedTopics, msg.Settings.MutedTopics) {
+			m.blockedTopics = blockedSet(msg.Settings.MutedTopics)
 			if m.activeTab == tabPosts {
 				m.tabSelected = 0
 			}

--- a/internal/ui/screens/profile_test.go
+++ b/internal/ui/screens/profile_test.go
@@ -403,6 +403,31 @@ func TestProfile_FilterNSFW_HidesNSFWPost(t *testing.T) {
 	}
 }
 
+func TestProfile_BlockedTopics_HidesMatchingPost(t *testing.T) {
+	posts := []model.Post{
+		{ID: "pp1", AuthorUsername: "ragnar", Content: "keep", Topics: []string{"linux"}},
+		{ID: "pp2", AuthorUsername: "ragnar", Content: "drop", Topics: []string{"crypto"}},
+		{ID: "pp3", AuthorUsername: "ragnar", Content: "keep too"},
+	}
+	m := profileWithPosts(posts)
+	m, _ = m.Update(blockedTopicsMsg("crypto"))
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected a cmd on enter")
+	}
+	sp, ok := cmd().(screens.ShowProfilePostMsg)
+	if !ok {
+		t.Fatalf("expected ShowProfilePostMsg, got %T", cmd())
+	}
+	if sp.Post.ID != "pp3" {
+		t.Errorf("expected pp3 (crypto post filtered), got %s", sp.Post.ID)
+	}
+}
+
 func TestProfile_FilterNSFW_Off_ShowsAll(t *testing.T) {
 	posts := []model.Post{
 		{ID: "pp1", AuthorUsername: "ragnar", Content: "safe"},

--- a/internal/ui/screens/settings.go
+++ b/internal/ui/screens/settings.go
@@ -474,6 +474,13 @@ func (m SettingsModel) Update(msg tea.Msg) (SettingsModel, tea.Cmd) {
 		if m.original.TimeDisplayFormat == "" && (m.original.Notifications == model.NotificationPrefs{}) {
 			m = m.SetSettings(msg.Settings)
 		}
+		// MutedTopics isn't editable here (it's managed on the Topics tab), so
+		// track the latest value on both the working copy and the baseline even
+		// after first load — otherwise a ctrl+s on this screen would PATCH a
+		// stale list back. settingsEqual ignores it, so dirty state is unaffected.
+		// See docs/54-blocked-topics.md.
+		m.settings.MutedTopics = msg.Settings.MutedTopics
+		m.original.MutedTopics = msg.Settings.MutedTopics
 		// prefsSeeded gates the preference fields below independently of the
 		// m.original guard above — SetSettings can run before this handler
 		// ever sees a SharedConfigMsg (see settingsLoadedMsg in app.go), which

--- a/internal/ui/screens/shared.go
+++ b/internal/ui/screens/shared.go
@@ -187,6 +187,66 @@ func updateTopicsInput(input textinput.Model, msg tea.Msg) (textinput.Model, tea
 	return input.Update(filtered)
 }
 
+// topicBlocked reports whether any of a post's topics is in the blocked set —
+// the blocked-topics analogue of the FilterNSFW check each post-list screen
+// applies in its visible*() helper. See docs/54-blocked-topics.md.
+func topicBlocked(topics []string, blocked map[string]struct{}) bool {
+	for _, t := range topics {
+		if _, ok := blocked[t]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// blockedSet builds the lookup set from Settings.MutedTopics; returns nil for an
+// empty list so callers can cheaply short-circuit with len() == 0.
+func blockedSet(topics []string) map[string]struct{} {
+	if len(topics) == 0 {
+		return nil
+	}
+	m := make(map[string]struct{}, len(topics))
+	for _, t := range topics {
+		m[t] = struct{}{}
+	}
+	return m
+}
+
+// sameBlockedSet reports whether set already holds exactly the slugs in list
+// (order-independent) — used by SharedConfigMsg handlers to skip a needless
+// selection reset + re-render when the blocked list hasn't changed.
+func sameBlockedSet(set map[string]struct{}, list []string) bool {
+	if len(set) != len(list) {
+		return false
+	}
+	for _, t := range list {
+		if _, ok := set[t]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// toggleBlocked returns a new slice with slug removed from the current blocked
+// set if present, or appended if not. Order of the retained entries is not
+// guaranteed (the API doesn't care).
+func toggleBlocked(set map[string]struct{}, slug string) []string {
+	if _, blocked := set[slug]; blocked {
+		out := make([]string, 0, len(set)-1)
+		for t := range set {
+			if t != slug {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+	out := make([]string, 0, len(set)+1)
+	for t := range set {
+		out = append(out, t)
+	}
+	return append(out, slug)
+}
+
 // extractURLs is a package-internal helper used by URLProvider implementations.
 // It normalizes each extracted URL so relative paths get the cyberspace.online prefix.
 func extractURLs(content string) []string {

--- a/internal/ui/screens/topics.go
+++ b/internal/ui/screens/topics.go
@@ -106,6 +106,7 @@ type TopicsModel struct {
 	relaxed           bool
 	timeDisplayFormat string
 	filterNSFW        bool
+	blockedTopics     map[string]struct{} // Settings.MutedTopics; posts tagged with any are hidden, rows show a marker
 
 	// postBodyCache/replyBodyCache memoize the Miller detail pane's post
 	// card and thread replies (cachedPostCard/cachedReplyCard, render.go) so
@@ -124,14 +125,18 @@ func NewTopicsModel() TopicsModel {
 }
 
 func (m TopicsModel) visiblePosts() []model.Post {
-	if !m.filterNSFW {
+	if !m.filterNSFW && len(m.blockedTopics) == 0 {
 		return m.posts
 	}
 	out := m.posts[:0:0]
 	for _, p := range m.posts {
-		if !p.IsNSFW {
-			out = append(out, p)
+		if m.filterNSFW && p.IsNSFW {
+			continue
 		}
+		if topicBlocked(p.Topics, m.blockedTopics) {
+			continue
+		}
+		out = append(out, p)
 	}
 	return out
 }
@@ -262,6 +267,10 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 		m.timeDisplayFormat = msg.Settings.TimeDisplayFormat
 		if msg.Settings.FilterNSFW != m.filterNSFW {
 			m.filterNSFW = msg.Settings.FilterNSFW
+			m.postIndex = 0
+		}
+		if !sameBlockedSet(m.blockedTopics, msg.Settings.MutedTopics) {
+			m.blockedTopics = blockedSet(msg.Settings.MutedTopics)
 			m.postIndex = 0
 		}
 		m.inlineImagesEnabled = msg.InlineImagesEnabled
@@ -460,6 +469,18 @@ func (m TopicsModel) Update(msg tea.Msg) (TopicsModel, tea.Cmd) {
 			}
 			return m, nil
 
+		case "b":
+			// Block / unblock the highlighted topic. Only in the topic list —
+			// the post list has no single "current topic" to act on.
+			if m.view == viewTopicList && len(m.topics) > 0 && m.topicIndex < len(m.topics) {
+				slug := m.topics[m.topicIndex].Slug
+				next := toggleBlocked(m.blockedTopics, slug)
+				m.blockedTopics = blockedSet(next) // optimistic: marker updates now
+				m = m.refreshContent()
+				return m, func() tea.Msg { return SetBlockedTopicsMsg{Topics: next} }
+			}
+			return m, nil
+
 		case "esc":
 			if m.view == viewTopicPosts {
 				m.view = viewTopicList
@@ -578,6 +599,9 @@ func (m TopicsModel) renderTopicItem(index int) string {
 	}
 	slugStr := slugStyle.Render(topic.Slug)
 	countStr := theme.Subtle.Render(fmt.Sprintf("%d posts", topic.PostCount))
+	if _, blocked := m.blockedTopics[topic.Slug]; blocked {
+		countStr = theme.Error.Render("BLOCKED")
+	}
 
 	var line string
 	if innerWidth > 0 {

--- a/internal/ui/screens/topics_test.go
+++ b/internal/ui/screens/topics_test.go
@@ -101,6 +101,69 @@ func TestTopics_FilterNSFW_Off_ShowsAll(t *testing.T) {
 	}
 }
 
+// --- Blocked topics ---
+
+func TestTopics_BlockedTopics_HidesMatchingPost(t *testing.T) {
+	m := screens.NewTopicsModel()
+	m = m.SetTopics(sampleTopics(), "")
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m.SetTopicPosts([]model.Post{
+		{ID: "tp1", AuthorUsername: "alice", Content: "keep", Topics: []string{"art"}},
+		{ID: "tp2", AuthorUsername: "bob", Content: "drop", Topics: []string{"crypto"}},
+		{ID: "tp3", AuthorUsername: "carol", Content: "keep too"},
+	}, "")
+	m, _ = m.Update(blockedTopicsMsg("crypto"))
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected a cmd on enter")
+	}
+	sp, ok := cmd().(screens.ShowTopicPostMsg)
+	if !ok {
+		t.Fatalf("expected ShowTopicPostMsg, got %T", cmd())
+	}
+	if sp.Post.ID != "tp3" {
+		t.Errorf("expected tp3 (crypto post filtered), got %s", sp.Post.ID)
+	}
+}
+
+// Pressing 'b' on a topic row toggles it in/out of the blocked list carried by
+// the emitted SetBlockedTopicsMsg.
+func TestTopics_BlockKey_TogglesBlockedList(t *testing.T) {
+	m := screens.NewTopicsModel()
+	m = m.SetTopics(sampleTopics(), "") // topicIndex 0 == "tech"
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b")})
+	if cmd == nil {
+		t.Fatal("expected a SetBlockedTopicsMsg cmd on first 'b'")
+	}
+	msg, ok := cmd().(screens.SetBlockedTopicsMsg)
+	if !ok {
+		t.Fatalf("expected SetBlockedTopicsMsg, got %T", cmd())
+	}
+	if len(msg.Topics) != 1 || msg.Topics[0] != "tech" {
+		t.Fatalf("first 'b' Topics = %v, want [tech]", msg.Topics)
+	}
+
+	// Feed that new list back in (as App would via broadcastConfig) and press 'b'
+	// again — "tech" should now be removed.
+	m, _ = m.Update(blockedTopicsMsg(msg.Topics...))
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b")})
+	if cmd == nil {
+		t.Fatal("expected a SetBlockedTopicsMsg cmd on second 'b'")
+	}
+	msg2, ok := cmd().(screens.SetBlockedTopicsMsg)
+	if !ok {
+		t.Fatalf("expected SetBlockedTopicsMsg, got %T", cmd())
+	}
+	if len(msg2.Topics) != 0 {
+		t.Errorf("second 'b' Topics = %v, want []", msg2.Topics)
+	}
+}
+
 // --- VisibleInlineImages ---
 
 func TestTopics_VisibleInlineImages_DisabledByDefault(t *testing.T) {


### PR DESCRIPTION
## Feature 54 — Blocked Topics

Hide posts tagged with a blocked topic, and manage the blocked list from the Topics tab.

### Filtering
Mirrors the existing `FilterNSFW` mechanism. Each post-list screen keeps a `blockedTopics` set built from `SharedConfigMsg.Settings.MutedTopics` and drops matching posts in its `visible*()` helper. Shared helpers (`topicBlocked`, `blockedSet`, `sameBlockedSet`, `toggleBlocked`) live in `internal/ui/screens/shared.go`.

- **Filtered:** Feed, Topics, Guilds, Profile (Posts tab), Bookmarks
- **Not filtered:** PostDetail (explicit open / deep link), Search — consistent with `FilterNSFW` today

### Management
`b` on a row in the Topics list blocks/unblocks it; blocked rows show a `BLOCKED` marker. `TopicsModel` emits `SetBlockedTopicsMsg` with the full new list. `App`:

1. applies it optimistically to `a.settings.MutedTopics` and re-broadcasts so every screen re-filters immediately;
2. persists on a 2s seq-guarded debounce tick, so a burst of toggles coalesces into one `PATCH /v1/settings` (rate limit 2/min, 15/day).

On save failure the optimistic change is **rolled back** to `blockedTopicsSaved` (the list the server last accepted, tracked from login and each success), the save seq is bumped to cancel any pending tick, and a `notifyError` banner names the cause (rate limit / expired session / 5xx) via `blockedTopicsSaveFailText`.

### API
`mutedTopics` added to `wirePatchSettings` + `HTTPClient.UpdateSettings`, always sent as an array (never `null`) so unblocking the last topic clears it server-side. The Settings screen re-syncs `MutedTopics` from every `SharedConfigMsg` so a `ctrl+s` there can't PATCH a stale list.

### Docs
New `docs/54-blocked-topics.md`; updated `17-settings.md`, `19-topics.md`, `00-project-reference.md`, `00-api-backlog.md`.

### Tests

| Group | Tests | Result |
|---|---|---|
| API | `TestHTTPUpdateSettings_SendsMutedTopics` (incl. clear-to-`[]`) | PASS |
| screens/feed | `TestFeed_BlockedTopics_HidesMatchingPost`, `_Off_ShowsAll` | PASS |
| screens/topics | `TestTopics_BlockedTopics_HidesMatchingPost`, `TestTopics_BlockKey_TogglesBlockedList` | PASS |
| screens/guilds | `TestGuildsModel_BlockedTopics_HidesMatchingPost` | PASS |
| screens/profile | `TestProfile_BlockedTopics_HidesMatchingPost` | PASS |
| screens/bookmarks | `TestBookmarks_BlockedTopics_HidesMatchingPost` | PASS |
| ui/app | `TestHandleTopics_SetBlockedTopics_AppliesAndDebouncesSave`, `_RollsBackOnSaveFailure` | PASS |
| Full suite | `go test ./...` | PASS |
| Lint | `go vet ./...`, `staticcheck ./...` | Clean |

Interactive TUI drive not run (Windows, no tmux). Real-API check skipped (would mutate the account's `mutedTopics`).
